### PR TITLE
fix: k8s auth method was missing for dragonfly-prod-euc1-1

### DIFF
--- a/aws_dragonfly-prod_eu-central-1_eks_dragonfly-prod-euc1-1_eso.tf
+++ b/aws_dragonfly-prod_eu-central-1_eks_dragonfly-prod-euc1-1_eso.tf
@@ -37,3 +37,13 @@ module "eso_eticloud" {
   kubernetes_ca   = base64decode(data.vault_generic_secret.cluster_certificate.data["b64certificate"])
   policies        = ["external-secrets-prod-dragonfly"]
 }
+
+module "eso_dragonfly" {
+  source = "git::https://github.com/cisco-eti/sre-tf-module-eso-access.git?ref=0.0.2"
+
+  cluster_name    = local.name
+  vault_namespace = "eticloud/apps/dragonfly"
+  kubernetes_host = data.aws_eks_cluster.cluster.endpoint
+  kubernetes_ca   = base64decode(data.vault_generic_secret.cluster_certificate.data["b64certificate"])
+  policies        = ["external-secrets-prod"]
+}


### PR DESCRIPTION
external-secrets baseapps currently failing for the `vault-eticloud-apps-dragonfly` ClusterSecretStore in the related venture Vault namespace.
missing auth method, ESO module wasn't called to create it, unlike for the eticloud namespace.
