### PR TITLE
feat: RDS: bootstrap DB in EU for dragonfly

### DIFF
--- a/aws_dragonfly-prod_eu-central-1_rds_dragonfly-rds-prod-eu1_aurora-postgres.tf
+++ b/aws_dragonfly-prod_eu-central-1_rds_dragonfly-rds-prod-eu1_aurora-postgres.tf
@@ -1,0 +1,12 @@
+module "rds" {
+  source            = "git::https://wwwin-github.cisco.com/eti/sre-tf-module-aws-aurora-postgres?ref=1.1.0"
+  vpc_name          = "dragonfly-prod-data-euc1-1"
+  database_name     = "dragonfly"
+  db_instance_type  = "db.r5.xlarge"
+  cluster_name      = "dragonfly-rds-prod-eu1"
+  db_engine_version = "13.11"
+  secret_path       = "secret/eticcprod/infra/aurora-pg/eu-central-1/dragonfly-rds-prod-eu-1"
+  db_allowed_cidrs  = [
+    data.aws_vpc.eks_vpc.cidr_block,
+  ]
+}

--- a/aws_dragonfly-prod_eu-central-1_rds_dragonfly-rds-prod-eu1_aurora-postgres.tf
+++ b/aws_dragonfly-prod_eu-central-1_rds_dragonfly-rds-prod-eu1_aurora-postgres.tf
@@ -1,5 +1,5 @@
 module "rds" {
-  source            = "git::https://wwwin-github.cisco.com/eti/sre-tf-module-aws-aurora-postgres?ref=1.1.0"
+  source            = "git::https://github.com/cisco-eti/sre-tf-module-aws-aurora-postgres?ref=1.1.0"
   vpc_name          = "dragonfly-prod-data-euc1-1"
   database_name     = "dragonfly"
   db_instance_type  = "db.r5.xlarge"

--- a/aws_dragonfly-prod_eu-central-1_rds_dragonfly-rds-prod-eu1_backend.tf
+++ b/aws_dragonfly-prod_eu-central-1_rds_dragonfly-rds-prod-eu1_backend.tf
@@ -1,7 +1,7 @@
 terraform {
   backend "s3" {
     bucket = "eticloud-tf-state-prod"
-    key    = "terraform-state/aws-dragonfly-production/aurora-postgres/us-east-2/dragonfly-rds-prod-1.tfstate"
+    key    = "terraform-state/aws/dragonfly-prod/eu-central-1/rds/dragonfly-rds-prod-1.tfstate"
     region = "us-east-2"
   }
 }

--- a/aws_dragonfly-prod_eu-central-1_rds_dragonfly-rds-prod-eu1_backend.tf
+++ b/aws_dragonfly-prod_eu-central-1_rds_dragonfly-rds-prod-eu1_backend.tf
@@ -1,0 +1,7 @@
+terraform {
+  backend "s3" {
+    bucket = "eticloud-tf-state-prod"
+    key    = "terraform-state/aws-dragonfly-production/aurora-postgres/us-east-2/dragonfly-rds-prod-1.tfstate"
+    region = "us-east-2"
+  }
+}

--- a/aws_dragonfly-prod_eu-central-1_rds_dragonfly-rds-prod-eu1_backend.tf
+++ b/aws_dragonfly-prod_eu-central-1_rds_dragonfly-rds-prod-eu1_backend.tf
@@ -1,7 +1,7 @@
 terraform {
   backend "s3" {
     bucket = "eticloud-tf-state-prod"
-    key    = "terraform-state/aws/dragonfly-prod/eu-central-1/rds/dragonfly-rds-prod-1.tfstate"
+    key    = "terraform-state/aws/dragonfly-prod/eu-central-1/rds/dragonfly-rds-prod-eu1.tfstate"
     region = "us-east-2"
   }
 }

--- a/aws_dragonfly-prod_eu-central-1_rds_dragonfly-rds-prod-eu1_dependencies.tf
+++ b/aws_dragonfly-prod_eu-central-1_rds_dragonfly-rds-prod-eu1_dependencies.tf
@@ -1,0 +1,11 @@
+data "vault_generic_secret" "aws_infra_credential" {
+  path     = "secret/eticcprod/infra/dragonfly-production/aws"
+  provider = vault.eticloud_eticcprod
+}
+
+data "aws_vpc" "eks_vpc" {
+  filter {
+    name   = "tag:Name"
+    values = ["dragonfly-prod-euc1-1"]
+  }
+}

--- a/aws_dragonfly-prod_eu-central-1_rds_dragonfly-rds-prod-eu1_dependencies.tf
+++ b/aws_dragonfly-prod_eu-central-1_rds_dragonfly-rds-prod-eu1_dependencies.tf
@@ -1,6 +1,6 @@
 data "vault_generic_secret" "aws_infra_credential" {
-  path     = "secret/eticcprod/infra/dragonfly-production/aws"
-  provider = vault.eticloud_eticcprod
+  path     = "secret/infra/aws/dragonfly-prod/terraform_admin"
+  provider = vault.eticcprod
 }
 
 data "aws_vpc" "eks_vpc" {

--- a/aws_dragonfly-prod_eu-central-1_rds_dragonfly-rds-prod-eu1_providers.tf
+++ b/aws_dragonfly-prod_eu-central-1_rds_dragonfly-rds-prod-eu1_providers.tf
@@ -1,8 +1,8 @@
 provider "vault" {
-  alias     = "eticloud_eticcprod"
+  alias     = "eticcprod"
   address   = "https://keeper.cisco.com"
-  namespace = "eticloud/eticcprod"
-}
+  namespace = "eticloud"
+} 
 
 provider "aws" {
   access_key  = data.vault_generic_secret.aws_infra_credential.data["AWS_ACCESS_KEY_ID"]

--- a/aws_dragonfly-prod_eu-central-1_rds_dragonfly-rds-prod-eu1_providers.tf
+++ b/aws_dragonfly-prod_eu-central-1_rds_dragonfly-rds-prod-eu1_providers.tf
@@ -1,0 +1,22 @@
+provider "vault" {
+  alias     = "eticloud_eticcprod"
+  address   = "https://keeper.cisco.com"
+  namespace = "eticloud/eticcprod"
+}
+
+provider "aws" {
+  access_key  = data.vault_generic_secret.aws_infra_credential.data["AWS_ACCESS_KEY_ID"]
+  secret_key  = data.vault_generic_secret.aws_infra_credential.data["AWS_SECRET_ACCESS_KEY"]
+  region      = "eu-central-1"
+  max_retries = 3
+  default_tags {
+    tags = {
+      ApplicationName    = "dragonfly-rds-1"
+      CiscoMailAlias     = "eti-sre-admins@cisco.com"
+      DataClassification = "Cisco Confidential"
+      DataTaxonomy       = "Cisco Operations Data"
+      EnvironmentName    = "Prod"
+      ResourceOwner      = "ETI SRE"
+    }
+  }
+}

--- a/aws_dragonfly-prod_eu-central-1_rds_dragonfly-rds-prod-eu1_versions.tf
+++ b/aws_dragonfly-prod_eu-central-1_rds_dragonfly-rds-prod-eu1_versions.tf
@@ -1,0 +1,14 @@
+terraform {
+  required_version = ">= 1.5.5"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+    vault = {
+      source  = "hashicorp/vault"
+      version = "~> 3.0"
+    }
+  }
+}

--- a/aws_dragonfly-prod_eu-central-1_rds_eu-central-1_aurora-postgres.tf
+++ b/aws_dragonfly-prod_eu-central-1_rds_eu-central-1_aurora-postgres.tf
@@ -1,0 +1,12 @@
+module "rds" {
+  source            = "git::https://wwwin-github.cisco.com/eti/sre-tf-module-aws-aurora-postgres?ref=1.1.0"
+  vpc_name          = "dragonfly-prod-data-euc1-1"
+  database_name     = "dragonfly"
+  db_instance_type  = "db.r5.xlarge"
+  cluster_name      = "dragonfly-rds-prod-eu1"
+  db_engine_version = "13.11"
+  secret_path       = "secret/eticcprod/infra/aurora-pg/eu-central-1/dragonfly-rds-prod-eu-1"
+  db_allowed_cidrs  = [
+    data.aws_vpc.eks_vpc.cidr_block,
+  ]
+}

--- a/aws_dragonfly-prod_eu-central-1_rds_eu-central-1_backend.tf
+++ b/aws_dragonfly-prod_eu-central-1_rds_eu-central-1_backend.tf
@@ -1,0 +1,7 @@
+terraform {
+  backend "s3" {
+    bucket = "eticloud-tf-state-prod"
+    key    = "terraform-state/aws-dragonfly-production/aurora-postgres/us-east-2/dragonfly-rds-prod-1.tfstate"
+    region = "us-east-2"
+  }
+}

--- a/aws_dragonfly-prod_eu-central-1_rds_eu-central-1_dependencies.tf
+++ b/aws_dragonfly-prod_eu-central-1_rds_eu-central-1_dependencies.tf
@@ -1,0 +1,11 @@
+data "vault_generic_secret" "aws_infra_credential" {
+  path     = "secret/eticcprod/infra/dragonfly-production/aws"
+  provider = vault.eticloud_eticcprod
+}
+
+data "aws_vpc" "eks_vpc" {
+  filter {
+    name   = "tag:Name"
+    values = ["dragonfly-prod-data-euc1-1"]
+  }
+}

--- a/aws_dragonfly-prod_eu-central-1_rds_eu-central-1_dependencies.tf
+++ b/aws_dragonfly-prod_eu-central-1_rds_eu-central-1_dependencies.tf
@@ -6,6 +6,6 @@ data "vault_generic_secret" "aws_infra_credential" {
 data "aws_vpc" "eks_vpc" {
   filter {
     name   = "tag:Name"
-    values = ["dragonfly-prod-data-euc1-1"]
+    values = ["dragonfly-prod-euc1-1"]
   }
 }

--- a/aws_dragonfly-prod_eu-central-1_rds_eu-central-1_providers.tf
+++ b/aws_dragonfly-prod_eu-central-1_rds_eu-central-1_providers.tf
@@ -4,12 +4,6 @@ provider "vault" {
   namespace = "eticloud/eticcprod"
 }
 
-data "vault_generic_secret" "aws_infra_credential" {
-  path     = "secret/eticcprod/infra/eticloud-preprod/aws"
-  provider = vault.eticloud_eticcprod
-}
-
-
 provider "aws" {
   access_key  = data.vault_generic_secret.aws_infra_credential.data["AWS_ACCESS_KEY_ID"]
   secret_key  = data.vault_generic_secret.aws_infra_credential.data["AWS_SECRET_ACCESS_KEY"]

--- a/aws_dragonfly-prod_eu-central-1_rds_eu-central-1_providers.tf
+++ b/aws_dragonfly-prod_eu-central-1_rds_eu-central-1_providers.tf
@@ -1,0 +1,28 @@
+provider "vault" {
+  alias     = "eticloud_eticcprod"
+  address   = "https://keeper.cisco.com"
+  namespace = "eticloud/eticcprod"
+}
+
+data "vault_generic_secret" "aws_infra_credential" {
+  path     = "secret/eticcprod/infra/eticloud-preprod/aws"
+  provider = vault.eticloud_eticcprod
+}
+
+
+provider "aws" {
+  access_key  = data.vault_generic_secret.aws_infra_credential.data["AWS_ACCESS_KEY_ID"]
+  secret_key  = data.vault_generic_secret.aws_infra_credential.data["AWS_SECRET_ACCESS_KEY"]
+  region      = "eu-central-1"
+  max_retries = 3
+  default_tags {
+    tags = {
+      ApplicationName    = "dragonfly-rds-1"
+      CiscoMailAlias     = "eti-sre-admins@cisco.com"
+      DataClassification = "Cisco Confidential"
+      DataTaxonomy       = "Cisco Operations Data"
+      EnvironmentName    = "Prod"
+      ResourceOwner      = "ETI SRE"
+    }
+  }
+}

--- a/aws_dragonfly-prod_eu-central-1_rds_eu-central-1_versions.tf
+++ b/aws_dragonfly-prod_eu-central-1_rds_eu-central-1_versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.3.6"
+  required_version = ">= 1.5.5"
 
   required_providers {
     aws = {

--- a/aws_dragonfly-prod_eu-central-1_rds_eu-central-1_versions.tf
+++ b/aws_dragonfly-prod_eu-central-1_rds_eu-central-1_versions.tf
@@ -1,0 +1,14 @@
+terraform {
+  required_version = ">= 1.3.6"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+    vault = {
+      source  = "hashicorp/vault"
+      version = "~> 3.0"
+    }
+  }
+}

--- a/aws_dragonfly-prod_eu-central-1_vpc-peering_compute-to-data_main.tf
+++ b/aws_dragonfly-prod_eu-central-1_vpc-peering_compute-to-data_main.tf
@@ -1,0 +1,128 @@
+terraform {
+  backend "s3" {
+    bucket = "eticloud-tf-state-prod"
+    key    = "terraform-state/aws/dragonfly-prod/eu-central-1/vpc-peering/compute-to-data/vpc-peering.tfstate"
+    region = "us-east-2"
+  }
+}
+
+provider "vault" {
+  alias     = "eticloud_eticcprod"
+  address   = "https://keeper.cisco.com"
+  namespace = "eticloud/eticcprod"
+}
+
+data "vault_generic_secret" "aws_infra_credential" {
+  path     = "secret/eticcprod/infra/dragonfly-production/aws"
+  provider = vault.eticloud_eticcprod
+}
+
+# Get the VPC IDs based on the names of the VPCs
+data "aws_vpc" "requestor_vpc" {
+  filter {
+    name   = "tag:ApplicationName"
+    values = ["dragonfly-prod-euc1-1"]
+  }
+}
+
+# VPC created from sre-tf-infra, not migrated to this repo
+# https://wwwin-github.cisco.com/eti/sre-tf-infra/tree/main/aws-dragonfly-production/vpc/eu-central-1/dragonfly-prod-data-euc1-1
+data "aws_vpc" "acceptor_vpc" {
+  filter {
+    name   = "tag:ApplicationName"
+    values = ["dragonfly-prod-data-euc1-1"]
+  }
+}
+
+data "aws_route_tables" "requestor_vpc_rt" {
+  vpc_id = data.aws_vpc.requestor_vpc.id
+}
+
+data "aws_route_tables" "acceptor_vpc_rt" {
+  vpc_id = data.aws_vpc.acceptor_vpc.id
+}
+
+# Use this to get the account ID
+data "aws_caller_identity" "current" {}
+
+
+# By setting the AWS provider credentials via the data source above, we control in which account and region the resources get created.
+provider "aws" {
+  access_key  = data.vault_generic_secret.aws_infra_credential.data["AWS_ACCESS_KEY_ID"]
+  secret_key  = data.vault_generic_secret.aws_infra_credential.data["AWS_SECRET_ACCESS_KEY"]
+  region      = "eu-central-1"
+  max_retries = 3
+}
+
+# VPC peering resources
+resource "aws_vpc_peering_connection" "data_to_compute" {
+  peer_owner_id = data.aws_caller_identity.current.account_id
+  peer_vpc_id   = data.aws_vpc.acceptor_vpc.id
+  vpc_id        = data.aws_vpc.requestor_vpc.id
+  auto_accept   = true
+
+  accepter {
+    allow_remote_vpc_dns_resolution = true
+  }
+
+  requester {
+    allow_remote_vpc_dns_resolution = true
+  }
+
+  tags = {
+    Name                  = "VPC Peering between dragonfly-prod-euc1-1 and dragonfly-prod-data-euc1-1"
+    CSBApplicationName    = "prod-dragonfly-compute-data-peering"
+    CSBCiscoMailAlias     = "eti-sre@cisco.com"
+    CSBDataClassification = "Cisco Confidential"
+    CSBDataTaxonomy       = "Cisco Operations Data"
+    CSBEnvironment        = "Prod"
+    CSBResourceOwner      = "Outshift SRE"
+  }
+}
+
+# VPC routing resources
+resource "aws_route" "compute_to_data" {
+  count                     = length(data.aws_route_tables.requestor_vpc_rt.ids)
+  route_table_id            = data.aws_route_tables.requestor_vpc_rt.ids[count.index]
+  destination_cidr_block    = data.aws_vpc.acceptor_vpc.cidr_block
+  vpc_peering_connection_id = aws_vpc_peering_connection.data_to_compute.id
+}
+
+resource "aws_route" "data_to_compute" {
+  count                     = length(data.aws_route_tables.acceptor_vpc_rt.ids)
+  route_table_id            = data.aws_route_tables.acceptor_vpc_rt.ids[count.index]
+  destination_cidr_block    = data.aws_vpc.requestor_vpc.cidr_block
+  vpc_peering_connection_id = aws_vpc_peering_connection.data_to_compute.id
+}
+
+# Security groups
+resource "aws_security_group" "compute_to_data" {
+  name        = "compute-vpc-to-data-pvc"
+  description = "Allows all communication into data-pvc from the compute-pvc"
+  vpc_id      = data.aws_vpc.acceptor_vpc.id
+}
+
+resource "aws_security_group" "data_to_compute" {
+  name        = "data-vpc-to-compute-pvc"
+  description = "Allows all communication into compute-pvc from the data-pvc"
+  vpc_id      = data.aws_vpc.requestor_vpc.id
+}
+
+# security group rules because the rules are going to reference the groups
+resource "aws_security_group_rule" "compute_to_data" {
+  type                     = "ingress"
+  from_port                = 0
+  to_port                  = 65535
+  protocol                 = "-1"
+  security_group_id        = aws_security_group.compute_to_data.id
+  source_security_group_id = aws_security_group.data_to_compute.id
+}
+
+resource "aws_security_group_rule" "data_to_compute" {
+  type                     = "ingress"
+  from_port                = 0
+  to_port                  = 65535
+  protocol                 = "-1"
+  security_group_id        = aws_security_group.data_to_compute.id
+  source_security_group_id = aws_security_group.compute_to_data.id
+}


### PR DESCRIPTION
Supersedes https://wwwin-github.cisco.com/eti/sre-tf-infra/pull/1049, replicates what was done in `us-east-2` from that same repo.

feat: bootstrap an RDS instance for dragonfly in EU

Will also need to look into [securing the access](https://platform-docs.eticloud.io/services/data-services/postgres/rds/operator-guide/how-to-create-a-new-rds-instance/#creating-the-cluster)