### PR TITLE
feat: OpenSearch: bootstrap cluster in EU for dragonfly 

### DIFF
--- a/aws_dragonfly-demo_eu-west-1_eks_dragonfly-demo-euw1-1_eso.tf
+++ b/aws_dragonfly-demo_eu-west-1_eks_dragonfly-demo-euw1-1_eso.tf
@@ -1,0 +1,49 @@
+provider "vault" {
+  alias     = "eticloud"
+  address   = "https://keeper.cisco.com"
+  namespace = "eticloud"
+}
+
+data "vault_generic_secret" "aws_infra_credential" {
+  provider = vault.eticloud
+  path     = "secret/infra/aws/${local.aws_account_name}/terraform_admin"
+}
+
+provider "aws" {
+  alias      = "target"
+  access_key = data.vault_generic_secret.aws_infra_credential.data["AWS_ACCESS_KEY_ID"]
+  secret_key = data.vault_generic_secret.aws_infra_credential.data["AWS_SECRET_ACCESS_KEY"]
+  region     = local.region
+}
+
+data "aws_eks_cluster" "cluster" {
+  depends_on = [module.eks_all_in_one]
+  provider   = aws.target
+  name       = local.name
+}
+
+data "vault_generic_secret" "cluster_certificate" {
+  depends_on = [module.eks_all_in_one]
+  provider   = vault.eticloud
+  path       = "secret/infra/eks/${local.name}/certificate"
+}
+
+module "eso_eticloud" {
+  source = "git::https://github.com/cisco-eti/sre-tf-module-eso-access.git?ref=0.0.2"
+
+  cluster_name    = local.name
+  vault_namespace = "eticloud"
+  kubernetes_host = data.aws_eks_cluster.cluster.endpoint
+  kubernetes_ca   = base64decode(data.vault_generic_secret.cluster_certificate.data["b64certificate"])
+  policies        = ["external-secrets-demo-dragonfly"]
+}
+
+module "eso_dragonfly" {
+  source = "git::https://github.com/cisco-eti/sre-tf-module-eso-access.git?ref=0.0.2"
+
+  cluster_name    = local.name
+  vault_namespace = "eticloud/apps/dragonfly"
+  kubernetes_host = data.aws_eks_cluster.cluster.endpoint
+  kubernetes_ca   = base64decode(data.vault_generic_secret.cluster_certificate.data["b64certificate"])
+  policies        = ["external-secrets-demo"]
+}

--- a/aws_dragonfly-demo_eu-west-1_eks_dragonfly-demo-euw1-1_main.tf
+++ b/aws_dragonfly-demo_eu-west-1_eks_dragonfly-demo-euw1-1_main.tf
@@ -1,0 +1,36 @@
+terraform {
+  backend "s3" {
+    # This is the name of the backend S3 bucket.
+    bucket = "eticloud-tf-state-prod"
+    # This is the path to the Terraform state file in the backend S3 bucket.
+    key = "terraform-state/aws/dragonfly-demo/eu-west-1/eks/dragonfly-demo-1-euw1-1.tfstate"
+    # This is the region where the backend S3 bucket is located.
+    region = "us-east-2" # DO NOT CHANGE.
+  }
+}
+
+locals {
+  name             = "dragonfly-demo-euw1-1"
+  region           = "eu-west-1"
+  aws_account_name = "dragonfly-demo"
+}
+
+module "eks_all_in_one" {
+  # EKS cluster partially created as of Jan 15 2024
+  source = "git::https://github.com/cisco-eti/sre-tf-module-eks-allinone.git?ref=extend_ami" # Based on v0.0.10
+
+  name             = local.name             # EKS cluster name
+  region           = local.region           # AWS provider region
+  aws_account_name = local.aws_account_name # AWS account name
+  cidr             = "10.3.0.0/16"          # VPC CIDR
+  cluster_version  = "1.28"                 # EKS cluster version
+
+  # EKS Managed Private Node Group
+  hardened_image             = false           # Use or not cisco hardened images
+  ami_type                   = "AL2_x86_64"    # EKS AMI type, required in case non hardened images  
+  enable_bootstrap_user_data = false           # Disable user data bootrap for non hardened images
+  instance_types             = ["m5a.2xlarge"] # EKS instance types, prod US uses m5a.2xlarge
+  min_size                   = 5               # EKS node group min size
+  max_size                   = 10              # EKS node group max size
+  desired_size               = 6               # EKS node group desired size
+}

--- a/aws_dragonfly-demo_eu-west-1_eks_dragonfly-target-euw1-1_eso.tf
+++ b/aws_dragonfly-demo_eu-west-1_eks_dragonfly-target-euw1-1_eso.tf
@@ -1,0 +1,49 @@
+provider "vault" {
+  alias     = "eticloud"
+  address   = "https://keeper.cisco.com"
+  namespace = "eticloud"
+}
+
+data "vault_generic_secret" "aws_infra_credential" {
+  provider = vault.eticloud
+  path     = "secret/infra/aws/${local.aws_account_name}/terraform_admin"
+}
+
+provider "aws" {
+  alias      = "target"
+  access_key = data.vault_generic_secret.aws_infra_credential.data["AWS_ACCESS_KEY_ID"]
+  secret_key = data.vault_generic_secret.aws_infra_credential.data["AWS_SECRET_ACCESS_KEY"]
+  region     = local.region
+}
+
+data "aws_eks_cluster" "cluster" {
+  depends_on = [module.eks_all_in_one]
+  provider   = aws.target
+  name       = local.name
+}
+
+data "vault_generic_secret" "cluster_certificate" {
+  depends_on = [module.eks_all_in_one]
+  provider   = vault.eticloud
+  path       = "secret/infra/eks/${local.name}/certificate"
+}
+
+module "eso_eticloud" {
+  source = "git::https://github.com/cisco-eti/sre-tf-module-eso-access.git?ref=0.0.2"
+
+  cluster_name    = local.name
+  vault_namespace = "eticloud"
+  kubernetes_host = data.aws_eks_cluster.cluster.endpoint
+  kubernetes_ca   = base64decode(data.vault_generic_secret.cluster_certificate.data["b64certificate"])
+  policies        = ["external-secrets-tgt-dragonfly"]
+}
+
+module "eso_dragonfly" {
+  source = "git::https://github.com/cisco-eti/sre-tf-module-eso-access.git?ref=0.0.2"
+
+  cluster_name    = local.name
+  vault_namespace = "eticloud/apps/dragonfly"
+  kubernetes_host = data.aws_eks_cluster.cluster.endpoint
+  kubernetes_ca   = base64decode(data.vault_generic_secret.cluster_certificate.data["b64certificate"])
+  policies        = ["external-secrets-tgt"]
+}

--- a/aws_dragonfly-demo_eu-west-1_eks_dragonfly-target-euw1-1_main.tf
+++ b/aws_dragonfly-demo_eu-west-1_eks_dragonfly-target-euw1-1_main.tf
@@ -1,0 +1,36 @@
+terraform {
+  backend "s3" {
+    # This is the name of the backend S3 bucket.
+    bucket = "eticloud-tf-state-prod"
+    # This is the path to the Terraform state file in the backend S3 bucket.
+    key = "terraform-state/aws/dragonfly-demo/eu-west-1/eks/dragonfly-tgt-euw1-1.tfstate"
+    # This is the region where the backend S3 bucket is located.
+    region = "us-east-2" # DO NOT CHANGE.
+  }
+}
+
+locals {
+  name             = "dragonfly-tgt-euw1-1"
+  region           = "eu-west-1"
+  aws_account_name = "dragonfly-demo"
+}
+
+module "eks_all_in_one" {
+  # EKS cluster partially created as of Jan 15 2024
+  source = "git::https://github.com/cisco-eti/sre-tf-module-eks-allinone.git?ref=extend_ami" # Based on v0.0.10
+
+  name             = local.name             # EKS cluster name
+  region           = local.region           # AWS provider region
+  aws_account_name = local.aws_account_name # AWS account name
+  cidr             = "10.4.0.0/16"          # VPC CIDR
+  cluster_version  = "1.28"                 # EKS cluster version
+
+  # EKS Managed Private Node Group
+  hardened_image               = false           # Use or not cisco hardened images
+  ami_type                     = "AL2_x86_64"    # EKS AMI type, required in case non hardened images
+    enable_bootstrap_user_data = false           # Disable user data bootrap for non hardened images
+  instance_types               = ["m5a.2xlarge"] # EKS instance types, prod US uses m5a.2xlarge
+  min_size                     = 2               # EKS node group min size
+  max_size                     = 5               # EKS node group max size
+  desired_size                 = 2               # EKS node group desired size
+}

--- a/aws_dragonfly-prod_eu-central-1_msk_dragonfly-msk-prod-eu1_backend.tf
+++ b/aws_dragonfly-prod_eu-central-1_msk_dragonfly-msk-prod-eu1_backend.tf
@@ -1,0 +1,7 @@
+terraform {
+  backend "s3" {
+    bucket = "eticloud-tf-state-prod"
+    key    = "terraform-state/aws-dragonfly-production/msk/eu-central-1/dragonfly-msk-prod-eu1.tfstate"
+    region = "us-east-2"
+  }
+}

--- a/aws_dragonfly-prod_eu-central-1_msk_dragonfly-msk-prod-eu1_cloudwatch.tf
+++ b/aws_dragonfly-prod_eu-central-1_msk_dragonfly-msk-prod-eu1_cloudwatch.tf
@@ -1,0 +1,3 @@
+resource "aws_cloudwatch_log_group" "broker_logs" {
+  name = "dragonfly-msk-prod-eu1-broker-logs"
+}

--- a/aws_dragonfly-prod_eu-central-1_msk_dragonfly-msk-prod-eu1_dependencies.tf
+++ b/aws_dragonfly-prod_eu-central-1_msk_dragonfly-msk-prod-eu1_dependencies.tf
@@ -1,0 +1,57 @@
+data "vault_generic_secret" "aws_infra_credential" {
+  path     = "secret/infra/aws/dragonfly-prod/terraform_admin"
+  provider = vault.eticcprod
+}
+
+data "aws_caller_identity" "current" {}
+
+data "aws_iam_policy_document" "msk_secret_policy" {
+  for_each = var.kafka_clients
+
+  statement {
+    sid    = "AWSKafkaResourcePolicy"
+    effect = "Allow"
+
+    principals {
+      type        = "Service"
+      identifiers = ["kafka.amazonaws.com"]
+    }
+
+    actions   = ["secretsmanager:getSecretValue"]
+    resources = [aws_secretsmanager_secret.msk_auth_credentials[each.key].arn]
+  }
+}
+
+data "aws_vpc" "eks_vpc" {
+  filter {
+    name   = "tag:Name"
+    values = ["dragonfly-prod-euc1-1"]
+  }
+}
+
+data "aws_vpc" "msk_vpc" {
+  filter {
+    name   = "tag:Name"
+    values = ["dragonfly-prod-data-euc1-1"]
+  }
+}
+
+data "aws_subnets" "eks_subnets" {
+  filter {
+    name   = "vpc-id"
+    values = [data.aws_vpc.eks_vpc.id]
+  }
+  tags = {
+    Tier = "Private"
+  }
+}
+
+data "aws_subnets" "msk_subnets" {
+  filter {
+    name   = "vpc-id"
+    values = [data.aws_vpc.msk_vpc.id]
+  }
+  tags = {
+    Tier = "Private"
+  }
+}

--- a/aws_dragonfly-prod_eu-central-1_msk_dragonfly-msk-prod-eu1_kms.tf
+++ b/aws_dragonfly-prod_eu-central-1_msk_dragonfly-msk-prod-eu1_kms.tf
@@ -1,0 +1,29 @@
+resource "aws_kms_key" "encryption_key" {
+  description = "dragonfly-msk-prod-eu1 MSK cluster encryption key"
+
+  policy = jsonencode({
+    "Version" : "2012-10-17",
+    "Statement" : [
+      {
+        "Sid" : "Internal",
+        "Effect" : "Allow",
+        "Principal" : { "AWS" : data.aws_caller_identity.current.arn },
+        "Action" : "kms:*",
+        "Resource" : "*"
+      },
+      {
+        "Sid" : "External",
+        "Effect" : "Allow",
+        "Principal" : { "AWS" : "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/admin" },
+        "Action" : [
+          "kms:Decrypt",
+          "kms:Describe*",
+          "kms:Encrypt",
+          "kms:ReEncrypt*",
+          "kms:GenerateDataKey*"
+        ],
+        Resource : "*"
+      }
+    ]
+  })
+}

--- a/aws_dragonfly-prod_eu-central-1_msk_dragonfly-msk-prod-eu1_msk.tf
+++ b/aws_dragonfly-prod_eu-central-1_msk_dragonfly-msk-prod-eu1_msk.tf
@@ -1,0 +1,142 @@
+resource "aws_msk_configuration" "configuration" {
+  kafka_versions = [var.kafka_version]
+  name           = "dragonfly-msk-prod-eu1"
+
+  server_properties = <<PROPERTIES
+auto.create.topics.enable = true
+PROPERTIES
+}
+
+resource "aws_msk_scram_secret_association" "msk_auth_credentials" {
+  cluster_arn = aws_msk_cluster.dragonfly_msk_eu1.arn
+  secret_arn_list = [
+    for s in aws_secretsmanager_secret.msk_auth_credentials : s.arn
+  ]
+
+  depends_on = [aws_secretsmanager_secret_version.msk_auth_credentials_1]
+}
+
+resource "aws_msk_cluster" "dragonfly_msk_eu1" {
+  cluster_name           = "dragonfly-msk-prod-eu1"
+  kafka_version          = var.kafka_version
+  number_of_broker_nodes = var.number_of_broker_nodes
+
+  // Broker configuration
+  broker_node_group_info {
+    instance_type = var.instance_type
+
+    client_subnets = data.aws_subnets.msk_subnets.ids
+
+    storage_info {
+      ebs_storage_info {
+        volume_size = 1000
+      }
+    }
+
+    // Turn on multi-vpc connectivity
+    connectivity_info {
+      vpc_connectivity {
+        client_authentication {
+          sasl {
+            scram = false
+            iam   = true
+          }
+        }
+      }
+    }
+
+    security_groups = [aws_security_group.dragonfly_msk_eu1.id]
+  }
+
+  // Encryption
+  encryption_info {
+    encryption_at_rest_kms_key_arn = aws_kms_key.encryption_key.arn
+
+    encryption_in_transit {
+      client_broker = "TLS"
+      in_cluster    = true
+    }
+  }
+
+  // Authentication
+  client_authentication {
+    sasl {
+      scram = true
+      iam   = true
+    }
+  }
+
+  // Cluster config
+  configuration_info {
+    arn      = aws_msk_configuration.configuration.arn
+    revision = aws_msk_configuration.configuration.latest_revision
+  }
+
+  // Monitoring && logging
+  open_monitoring {
+    prometheus {
+      jmx_exporter {
+        enabled_in_broker = true
+      }
+      node_exporter {
+        enabled_in_broker = true
+      }
+    }
+  }
+
+  enhanced_monitoring = "PER_TOPIC_PER_PARTITION"
+
+  logging_info {
+    broker_logs {
+      cloudwatch_logs {
+        enabled   = true
+        log_group = aws_cloudwatch_log_group.broker_logs.name
+      }
+    }
+  }
+}
+
+// Save brokers in vault
+resource "vault_generic_secret" "msk_brokers_sasl_scram" {
+  path = "secret/prod/msk/eu-central-1/dragonfly-msk-1/kafka-brokers"
+
+  data_json = jsonencode({
+    brokers = aws_msk_cluster.dragonfly_msk_eu1.bootstrap_brokers_sasl_scram
+  })
+
+  provider = vault.dragonfly
+}
+
+resource "aws_msk_cluster_policy" "opensearch_ingestion_policy" {
+  cluster_arn = aws_msk_cluster.dragonfly_msk_eu1.arn
+
+  policy = jsonencode({
+    "Version" : "2012-10-17",
+    "Statement" : [
+      {
+        "Effect" : "Allow",
+        "Principal" : {
+          "Service" : "osis.amazonaws.com"
+        },
+        "Action" : [
+          "kafka:CreateVpcConnection",
+          "kafka:DescribeCluster",
+          "kafka:DescribeClusterV2"
+        ],
+        "Resource" : aws_msk_cluster.dragonfly_msk_eu1.arn
+      },
+      {
+        "Effect" : "Allow",
+        "Principal" : {
+          "Service" : "osis-pipelines.amazonaws.com"
+        },
+        "Action" : [
+          "kafka:CreateVpcConnection",
+          "kafka:GetBootstrapBrokers",
+          "kafka:DescribeCluster",
+          "kafka:DescribeClusterV2"
+        ],
+        "Resource" : aws_msk_cluster.dragonfly_msk_eu1.arn
+    }]
+  })
+}

--- a/aws_dragonfly-prod_eu-central-1_msk_dragonfly-msk-prod-eu1_outputs.tf
+++ b/aws_dragonfly-prod_eu-central-1_msk_dragonfly-msk-prod-eu1_outputs.tf
@@ -1,0 +1,19 @@
+output "zookeeper_connect_string" {
+  value = aws_msk_cluster.dragonfly_msk_eu1.zookeeper_connect_string
+}
+
+output "bootstrap_brokers" {
+  value = aws_msk_cluster.dragonfly_msk_eu1.bootstrap_brokers
+}
+
+output "bootstrap_brokers_tls" {
+  value = aws_msk_cluster.dragonfly_msk_eu1.bootstrap_brokers_tls
+}
+
+output "bootstrap_brokers_sasl_iam" {
+  value = aws_msk_cluster.dragonfly_msk_eu1.bootstrap_brokers_sasl_iam
+}
+
+output "bootstrap_brokers_sasl_scram" {
+  value = aws_msk_cluster.dragonfly_msk_eu1.bootstrap_brokers_sasl_scram
+}

--- a/aws_dragonfly-prod_eu-central-1_msk_dragonfly-msk-prod-eu1_providers.tf
+++ b/aws_dragonfly-prod_eu-central-1_msk_dragonfly-msk-prod-eu1_providers.tf
@@ -1,0 +1,29 @@
+provider "aws" {
+  access_key  = data.vault_generic_secret.aws_infra_credential.data["AWS_ACCESS_KEY_ID"]
+  secret_key  = data.vault_generic_secret.aws_infra_credential.data["AWS_SECRET_ACCESS_KEY"]
+  region      = "eu-central-1"
+  max_retries = 3
+
+  default_tags {
+    tags = {
+      ApplicationName    = "dragonfly-msk-prod-eu1"
+      CiscoMailAlias     = "eti-sre-admins@cisco.com"
+      DataClassification = "Cisco Confidential"
+      DataTaxonomy       = "Cisco Operations Data"
+      Environment        = "Prod"
+      ResourceOwner      = "ETI SRE"
+    }
+  }
+}
+
+provider "vault" {
+  alias     = "eticcprod"
+  address   = "https://keeper.cisco.com"
+  namespace = "eticloud"
+}
+
+provider "vault" {
+  alias     = "dragonfly"
+  address   = "https://keeper.cisco.com"
+  namespace = "eticloud/apps/dragonfly"
+}

--- a/aws_dragonfly-prod_eu-central-1_msk_dragonfly-msk-prod-eu1_secretsmanager.tf
+++ b/aws_dragonfly-prod_eu-central-1_msk_dragonfly-msk-prod-eu1_secretsmanager.tf
@@ -1,0 +1,47 @@
+// Generate random passwords
+resource "random_password" "password" {
+  for_each = var.kafka_clients
+
+  length  = 64
+  special = false
+}
+
+// Save secrets in Vault
+resource "vault_generic_secret" "msk_auth_credentials" {
+  for_each = var.kafka_clients
+
+  path = each.value.vault_path
+
+  data_json = jsonencode({
+    username = each.key
+    password = random_password.password[each.key].result
+  })
+
+  provider = vault.dragonfly
+}
+
+// Secrets for SASL/SCRAM authentication
+resource "aws_secretsmanager_secret" "msk_auth_credentials" {
+  for_each = var.kafka_clients
+
+  name        = "AmazonMSK_dragonfly-msk-eu1-${each.key}-auth"
+  description = each.value.description
+
+  kms_key_id = aws_kms_key.encryption_key.key_id
+}
+
+// Secret versions
+resource "aws_secretsmanager_secret_version" "msk_auth_credentials_1" {
+  for_each = var.kafka_clients
+
+  secret_id     = aws_secretsmanager_secret.msk_auth_credentials[each.key].id
+  secret_string = vault_generic_secret.msk_auth_credentials[each.key].data_json
+}
+
+// Secret policy
+resource "aws_secretsmanager_secret_policy" "msk_secret_policy" {
+  for_each = var.kafka_clients
+
+  secret_arn = aws_secretsmanager_secret.msk_auth_credentials[each.key].arn
+  policy     = data.aws_iam_policy_document.msk_secret_policy[each.key].json
+}

--- a/aws_dragonfly-prod_eu-central-1_msk_dragonfly-msk-prod-eu1_securitygroup.tf
+++ b/aws_dragonfly-prod_eu-central-1_msk_dragonfly-msk-prod-eu1_securitygroup.tf
@@ -1,0 +1,80 @@
+locals {
+  msk_ingress_rules = [
+    {
+      from_port : 9094,
+      to_port : 9094,
+      protocol : "tcp",
+      cidr_blocks : [
+        data.aws_vpc.msk_vpc.cidr_block,
+        data.aws_vpc.eks_vpc.cidr_block,
+      ],
+    },
+    {
+      from_port : 9096,
+      to_port : 9096,
+      protocol : "tcp",
+      cidr_blocks : [
+        data.aws_vpc.msk_vpc.cidr_block,
+        data.aws_vpc.eks_vpc.cidr_block,
+      ],
+    },
+    {
+      from_port : 9098,
+      to_port : 9098,
+      protocol : "tcp",
+      cidr_blocks : [
+        data.aws_vpc.msk_vpc.cidr_block,
+        data.aws_vpc.eks_vpc.cidr_block,
+      ],
+    },
+    {
+      from_port : 2181,
+      to_port : 2181,
+      protocol : "tcp",
+      cidr_blocks : [
+        data.aws_vpc.msk_vpc.cidr_block,
+      ],
+    },
+  ]
+
+  msk_egress_rules = [
+    {
+      from_port : 0,
+      to_port : 65535,
+      protocol : "tcp",
+      cidr_blocks : [
+        data.aws_vpc.msk_vpc.cidr_block,
+        data.aws_vpc.eks_vpc.cidr_block,
+      ],
+    },
+  ]
+}
+
+
+resource "aws_security_group" "dragonfly_msk_eu1" {
+  name        = "dragonfly-msk-prod-eu1-msk-default"
+  description = "dragonfly-msk-prod-eu1 MSK cluster default security group"
+  vpc_id      = data.aws_vpc.msk_vpc.id
+
+  dynamic "ingress" {
+    for_each = toset(local.msk_ingress_rules)
+
+    content {
+      from_port   = ingress.value.from_port
+      to_port     = ingress.value.to_port
+      protocol    = ingress.value.protocol
+      cidr_blocks = ingress.value.cidr_blocks
+    }
+  }
+
+  dynamic "egress" {
+    for_each = toset(local.msk_egress_rules)
+
+    content {
+      from_port   = egress.value.from_port
+      to_port     = egress.value.to_port
+      protocol    = egress.value.protocol
+      cidr_blocks = egress.value.cidr_blocks
+    }
+  }
+}

--- a/aws_dragonfly-prod_eu-central-1_msk_dragonfly-msk-prod-eu1_variables.tf
+++ b/aws_dragonfly-prod_eu-central-1_msk_dragonfly-msk-prod-eu1_variables.tf
@@ -1,0 +1,39 @@
+variable "kafka_version" {
+  description = "Kafka version to deploy"
+  type        = string
+  default     = "3.6.0"
+}
+
+variable "instance_type" {
+  description = "Instance type to use for Kafka brokers"
+  type        = string
+  default     = "kafka.m5.xlarge"
+}
+
+variable "number_of_broker_nodes" {
+  description = "Number of Kafka broker nodes to deploy"
+  type        = number
+  default     = 3
+}
+
+variable "kafka_clients" {
+  description = "Kafka clients to create"
+  type = map(object({
+    description = string
+    vault_path  = string
+  }))
+  default = {
+    "otel-collector" = {
+      description = "Auth credentials of otel-collector for dragonfly-msk-prod-1"
+      vault_path  = "secret/prod/msk/eu-central-1/dragonfly-msk-1/kafka-clients/otel-collector"
+    },
+    "notification-service" = {
+      description = "Auth credentials of notification-service for dragonfly-msk-prod-1"
+      vault_path  = "secret/prod/msk/eu-central-1/dragonfly-msk-1/kafka-clients/notification-service"
+    },
+    "opensearch-ingestion-service" = {
+      description = "Auth credentials of ingestion-service for dragonfly-msk-prod-1"
+      vault_path  = "secret/prod/msk/eu-central-1/dragonfly-msk-1/kafka-clients/opensearch-ingestion-service"
+    },
+  }
+}

--- a/aws_dragonfly-prod_eu-central-1_msk_dragonfly-msk-prod-eu1_versions.tf
+++ b/aws_dragonfly-prod_eu-central-1_msk_dragonfly-msk-prod-eu1_versions.tf
@@ -1,0 +1,18 @@
+terraform {
+  required_version = ">= 1.3.6"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+    vault = {
+      source  = "hashicorp/vault"
+      version = "~> 3.0"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = "~> 3.0"
+    }
+  }
+}

--- a/aws_dragonfly-prod_eu-central-1_os_dragonfly-prod-eu-1-os_backend.tf
+++ b/aws_dragonfly-prod_eu-central-1_os_dragonfly-prod-eu-1-os_backend.tf
@@ -1,7 +1,7 @@
 terraform {
   backend "s3" {
     bucket = "eticloud-tf-state-prod"
-    key    = "terraform-state/aws/dragonfly-prod/eu-central-1/os/dragonfly-prod-1-os.tfstate"
+    key    = "terraform-state/aws/dragonfly-prod/eu-central-1/os/dragonfly-prod-eu1-os.tfstate"
     region = "us-east-2"
   }
 }

--- a/aws_dragonfly-prod_eu-central-1_os_dragonfly-prod-eu-1-os_backend.tf
+++ b/aws_dragonfly-prod_eu-central-1_os_dragonfly-prod-eu-1-os_backend.tf
@@ -1,0 +1,7 @@
+terraform {
+  backend "s3" {
+    bucket = "eticloud-tf-state-prod"
+    key    = "terraform-state/aws/dragonfly-prod/eu-central-1/os/dragonfly-prod-1-os.tfstate"
+    region = "us-east-2"
+  }
+}

--- a/aws_dragonfly-prod_eu-central-1_os_dragonfly-prod-eu-1-os_cloudwatch.tf
+++ b/aws_dragonfly-prod_eu-central-1_os_dragonfly-prod-eu-1-os_cloudwatch.tf
@@ -1,0 +1,8 @@
+resource "aws_cloudwatch_log_group" "dragonfly_prod_eu_1_os_logs" {
+  name = "dragonfly-prod-eu-1-os-logs"
+}
+
+resource "aws_cloudwatch_log_resource_policy" "opensearch_log_publishing_policy" {
+  policy_document = data.aws_iam_policy_document.opensearch_log_publishing_policy.json
+  policy_name     = "opensearch-log-publishing-policy"
+}

--- a/aws_dragonfly-prod_eu-central-1_os_dragonfly-prod-eu-1-os_dependencies.tf
+++ b/aws_dragonfly-prod_eu-central-1_os_dragonfly-prod-eu-1-os_dependencies.tf
@@ -19,13 +19,6 @@ data "aws_subnets" "db_subnets" {
     name   = "vpc-id"
     values = [data.aws_vpc.database_vpc.id]
   }
-  filter {
-    name = "tag:Name"
-    values = [
-      # TODO: check this value
-      "dragonfly-prod-data-euc1-1-db-${data.aws_region.current.name}*"
-    ]
-  }
 }
 
 data "aws_vpc" "compute_vpc" {

--- a/aws_dragonfly-prod_eu-central-1_os_dragonfly-prod-eu-1-os_dependencies.tf
+++ b/aws_dragonfly-prod_eu-central-1_os_dragonfly-prod-eu-1-os_dependencies.tf
@@ -1,5 +1,5 @@
 data "vault_generic_secret" "aws_infra_credential" {
-  path     = "secret/eticcprod/infra/dragonfly-production/aws"
+  path     = "secret/infra/aws/dragonfly-prod/terraform_admin"
   provider = vault.eticcprod
 }
 

--- a/aws_dragonfly-prod_eu-central-1_os_dragonfly-prod-eu-1-os_dependencies.tf
+++ b/aws_dragonfly-prod_eu-central-1_os_dragonfly-prod-eu-1-os_dependencies.tf
@@ -1,6 +1,6 @@
 data "vault_generic_secret" "aws_infra_credential" {
   path     = "secret/infra/aws/dragonfly-prod/terraform_admin"
-  provider = vault.eticcprod
+  provider = vault.eticloud
 }
 
 # OS account and region

--- a/aws_dragonfly-prod_eu-central-1_os_dragonfly-prod-eu-1-os_dependencies.tf
+++ b/aws_dragonfly-prod_eu-central-1_os_dragonfly-prod-eu-1-os_dependencies.tf
@@ -14,11 +14,9 @@ data "aws_vpc" "database_vpc" {
   }
 }
 
-data "aws_subnets" "db_subnets" {
-  filter {
-    name   = "vpc-id"
-    values = [data.aws_vpc.database_vpc.id]
-  }
+data "aws_db_subnet_group" "db_subnet_group" {
+  # this returns 3 subnets where the RDS DB lives, required to create the aws_opensearch_domain
+  name = "dragonfly-prod-data-euc1-1-db-subnet-group"
 }
 
 data "aws_vpc" "compute_vpc" {

--- a/aws_dragonfly-prod_eu-central-1_os_dragonfly-prod-eu-1-os_dependencies.tf
+++ b/aws_dragonfly-prod_eu-central-1_os_dragonfly-prod-eu-1-os_dependencies.tf
@@ -1,0 +1,46 @@
+data "vault_generic_secret" "aws_infra_credential" {
+  path     = "secret/eticcprod/infra/dragonfly-production/aws"
+  provider = vault.eticcprod
+}
+
+# OS account and region
+data "aws_caller_identity" "current" {}
+data "aws_region" "current" {}
+
+data "aws_vpc" "database_vpc" {
+  filter {
+    name   = "tag:Name"
+    values = ["dragonfly-prod-data-euc1-1"]
+  }
+}
+
+data "aws_subnets" "db_subnets" {
+  filter {
+    name   = "vpc-id"
+    values = [data.aws_vpc.database_vpc.id]
+  }
+  filter {
+    name = "tag:Name"
+    values = [
+      # TODO: check this value
+      "dragonfly-prod-data-euc1-1-db-${data.aws_region.current.name}*"
+    ]
+  }
+}
+
+data "aws_vpc" "compute_vpc" {
+  filter {
+    name   = "tag:Name"
+    values = ["dragonfly-prod-euc1-1"]
+  }
+}
+
+data "aws_subnets" "compute_subnets" {
+  filter {
+    name   = "vpc-id"
+    values = [data.aws_vpc.compute_vpc.id]
+  }
+  tags = {
+    Tier = "Private"
+  }
+}

--- a/aws_dragonfly-prod_eu-central-1_os_dragonfly-prod-eu-1-os_iam.tf
+++ b/aws_dragonfly-prod_eu-central-1_os_dragonfly-prod-eu-1-os_iam.tf
@@ -1,0 +1,37 @@
+# resource "aws_iam_service_linked_role" "dragonfly_linked_role" {
+#   aws_service_name = "opensearchservice.amazonaws.com"
+# }
+
+data "aws_iam_policy_document" "dragonfly_admin_access_policy" {
+  statement {
+    sid = "admin"
+
+    effect = "Allow"
+
+    principals {
+      type        = "AWS"
+      identifiers = ["*"]
+    }
+
+    actions = ["es:*"]
+
+    resources = ["arn:aws:es:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:domain/${var.domain_name}/*"]
+  }
+}
+
+data "aws_iam_policy_document" "opensearch_log_publishing_policy" {
+  statement {
+    actions = [
+      "logs:CreateLogStream",
+      "logs:PutLogEvents",
+      "logs:PutLogEventsBatch",
+    ]
+
+    resources = ["arn:aws:logs:*"]
+
+    principals {
+      identifiers = ["opensearchservice.amazonaws.com"]
+      type        = "Service"
+    }
+  }
+}

--- a/aws_dragonfly-prod_eu-central-1_os_dragonfly-prod-eu-1-os_kms.tf
+++ b/aws_dragonfly-prod_eu-central-1_os_dragonfly-prod-eu-1-os_kms.tf
@@ -1,0 +1,3 @@
+resource "aws_kms_key" "encryption_key" {
+  description = "${var.domain_name} encryption key"
+}

--- a/aws_dragonfly-prod_eu-central-1_os_dragonfly-prod-eu-1-os_main.tf
+++ b/aws_dragonfly-prod_eu-central-1_os_dragonfly-prod-eu-1-os_main.tf
@@ -30,7 +30,7 @@ resource "aws_opensearch_domain" "dragonfly_prod_eu_1_os" {
   }
 
   vpc_options {
-    subnet_ids = data.aws_subnets.db_subnets.ids
+    subnet_ids = data.aws_db_subnet_group.db_subnet_group.subnet_ids
     security_group_ids = [
       aws_security_group.dragonfly_prod_eu_1_os.id
     ]

--- a/aws_dragonfly-prod_eu-central-1_os_dragonfly-prod-eu-1-os_main.tf
+++ b/aws_dragonfly-prod_eu-central-1_os_dragonfly-prod-eu-1-os_main.tf
@@ -1,0 +1,99 @@
+resource "aws_opensearch_domain" "dragonfly_prod_eu_1_os" {
+  depends_on = [
+    # aws_iam_service_linked_role.dragonfly_linked_role,
+    aws_cloudwatch_log_group.dragonfly_prod_eu_1_os_logs,
+  ]
+
+  domain_name     = var.domain_name
+  engine_version  = var.engine_version
+  access_policies = null
+
+  cluster_config {
+    dedicated_master_enabled = true
+    dedicated_master_count   = 3
+    dedicated_master_type    = var.instance_type
+
+    instance_count = 3
+    instance_type  = var.instance_type
+
+    warm_enabled = false
+
+    zone_awareness_enabled = true
+
+    zone_awareness_config {
+      availability_zone_count = 3
+    }
+
+    cold_storage_options {
+      enabled = false
+    }
+  }
+
+  vpc_options {
+    subnet_ids = data.aws_subnets.db_subnets.ids
+    security_group_ids = [
+      aws_security_group.dragonfly_prod_eu_1_os.id
+    ]
+  }
+
+  advanced_security_options {
+    enabled                        = true
+    anonymous_auth_enabled         = false
+    internal_user_database_enabled = true
+
+    master_user_options {
+      master_user_name     = vault_generic_secret.os_auth_credentials.data["username"]
+      master_user_password = vault_generic_secret.os_auth_credentials.data["password"]
+    }
+  }
+
+  domain_endpoint_options {
+    enforce_https       = true
+    tls_security_policy = "Policy-Min-TLS-1-2-2019-07"
+
+    custom_endpoint_enabled = false
+  }
+
+  node_to_node_encryption {
+    enabled = true
+  }
+
+  encrypt_at_rest {
+    enabled    = true
+    kms_key_id = aws_kms_key.encryption_key.arn
+  }
+
+  ebs_options {
+    ebs_enabled = true
+    volume_type = "gp3"
+    volume_size = 1000
+    iops        = 3000
+    throughput  = 250
+  }
+
+  log_publishing_options {
+    log_type                 = "AUDIT_LOGS"
+    enabled                  = true
+    cloudwatch_log_group_arn = aws_cloudwatch_log_group.dragonfly_prod_eu_1_os_logs.arn
+  }
+
+  auto_tune_options {
+    desired_state       = "ENABLED"
+    rollback_on_disable = "NO_ROLLBACK"
+  }
+
+
+  tags = {
+    DataClassification = "Cisco Restricted"
+    Environment        = "Prod"
+    ApplicationName    = var.domain_name
+    ResourceOwner      = "eti sre"
+    CiscoMailAlias     = "eti-sre-admins@cisco.com"
+    DataTaxonomy       = "Cisco Operations Data"
+  }
+}
+
+resource "aws_opensearch_domain_policy" "this" {
+  domain_name     = aws_opensearch_domain.dragonfly_prod_eu_1_os.domain_name
+  access_policies = data.aws_iam_policy_document.dragonfly_admin_access_policy.json
+}

--- a/aws_dragonfly-prod_eu-central-1_os_dragonfly-prod-eu-1-os_master-user.tf
+++ b/aws_dragonfly-prod_eu-central-1_os_dragonfly-prod-eu-1-os_master-user.tf
@@ -1,0 +1,15 @@
+resource "random_password" "password" {
+  length  = 64
+  special = true
+}
+
+resource "vault_generic_secret" "os_auth_credentials" {
+  path = "secret/prod/os/eu-central-1/os-dragonfly-prod-1/master-user"
+
+  data_json = jsonencode({
+    username = var.os_master_user
+    password = random_password.password.result
+  })
+
+  provider = vault.dragonfly
+}

--- a/aws_dragonfly-prod_eu-central-1_os_dragonfly-prod-eu-1-os_outputs.tf
+++ b/aws_dragonfly-prod_eu-central-1_os_dragonfly-prod-eu-1-os_outputs.tf
@@ -1,0 +1,9 @@
+# OS endpoint
+output "opensearch_endpoint" {
+  value = aws_opensearch_domain.dragonfly_prod_eu_1_os.endpoint
+}
+
+# OS dashboard endpoint
+output "opensearch_dashboard_endpoint" {
+  value = aws_opensearch_domain.dragonfly_prod_eu_1_os.dashboard_endpoint
+}

--- a/aws_dragonfly-prod_eu-central-1_os_dragonfly-prod-eu-1-os_providers.tf
+++ b/aws_dragonfly-prod_eu-central-1_os_dragonfly-prod-eu-1-os_providers.tf
@@ -16,7 +16,7 @@ provider "aws" {
 }
 
 provider "vault" {
-  alias     = "eticcprod"
+  alias     = "eticloud"
   address   = "https://keeper.cisco.com"
   namespace = "eticloud"
 }

--- a/aws_dragonfly-prod_eu-central-1_os_dragonfly-prod-eu-1-os_providers.tf
+++ b/aws_dragonfly-prod_eu-central-1_os_dragonfly-prod-eu-1-os_providers.tf
@@ -18,7 +18,7 @@ provider "aws" {
 provider "vault" {
   alias     = "eticcprod"
   address   = "https://keeper.cisco.com"
-  namespace = "eticloud/eticcprod"
+  namespace = "eticloud"
 }
 
 provider "vault" {

--- a/aws_dragonfly-prod_eu-central-1_os_dragonfly-prod-eu-1-os_providers.tf
+++ b/aws_dragonfly-prod_eu-central-1_os_dragonfly-prod-eu-1-os_providers.tf
@@ -1,0 +1,28 @@
+provider "aws" {
+  access_key = data.vault_generic_secret.aws_infra_credential.data["AWS_ACCESS_KEY_ID"]
+  secret_key = data.vault_generic_secret.aws_infra_credential.data["AWS_SECRET_ACCESS_KEY"]
+  region     = "us-east-2"
+
+  default_tags {
+    tags = {
+      ApplicationName    = var.domain_name
+      CiscoMailAlias     = "eti-sre-admins@cisco.com"
+      DataClassification = "Cisco Confidential"
+      DataTaxonomy       = "Cisco Operations Data"
+      EnvironmentName    = "Prod"
+      ResourceOwner      = "ETI SRE"
+    }
+  }
+}
+
+provider "vault" {
+  alias     = "eticcprod"
+  address   = "https://keeper.cisco.com"
+  namespace = "eticloud/eticcprod"
+}
+
+provider "vault" {
+  alias     = "dragonfly"
+  address   = "https://keeper.cisco.com"
+  namespace = "eticloud/apps/dragonfly"
+}

--- a/aws_dragonfly-prod_eu-central-1_os_dragonfly-prod-eu-1-os_providers.tf
+++ b/aws_dragonfly-prod_eu-central-1_os_dragonfly-prod-eu-1-os_providers.tf
@@ -1,7 +1,7 @@
 provider "aws" {
   access_key = data.vault_generic_secret.aws_infra_credential.data["AWS_ACCESS_KEY_ID"]
   secret_key = data.vault_generic_secret.aws_infra_credential.data["AWS_SECRET_ACCESS_KEY"]
-  region     = "us-east-2"
+  region     = "eu-central-1"
 
   default_tags {
     tags = {

--- a/aws_dragonfly-prod_eu-central-1_os_dragonfly-prod-eu-1-os_securitygroups.tf
+++ b/aws_dragonfly-prod_eu-central-1_os_dragonfly-prod-eu-1-os_securitygroups.tf
@@ -1,0 +1,43 @@
+locals {
+  msk_ingress_rules = [
+    {
+      from_port : 443,
+      to_port : 443,
+      protocol : "tcp",
+      cidr_blocks : [
+        data.aws_vpc.compute_vpc.cidr_block,
+      ],
+    },
+  ]
+
+  msk_egress_rules = []
+}
+
+
+resource "aws_security_group" "dragonfly_prod_eu_1_os" {
+  name        = "${var.domain_name}-default"
+  description = "${var.domain_name} opensearch cluster default security group"
+  vpc_id      = data.aws_vpc.database_vpc.id
+
+  dynamic "ingress" {
+    for_each = toset(local.msk_ingress_rules)
+
+    content {
+      from_port   = ingress.value.from_port
+      to_port     = ingress.value.to_port
+      protocol    = ingress.value.protocol
+      cidr_blocks = ingress.value.cidr_blocks
+    }
+  }
+
+  dynamic "egress" {
+    for_each = toset(local.msk_egress_rules)
+
+    content {
+      from_port   = egress.value.from_port
+      to_port     = egress.value.to_port
+      protocol    = egress.value.protocol
+      cidr_blocks = egress.value.cidr_blocks
+    }
+  }
+}

--- a/aws_dragonfly-prod_eu-central-1_os_dragonfly-prod-eu-1-os_variables.tf
+++ b/aws_dragonfly-prod_eu-central-1_os_dragonfly-prod-eu-1-os_variables.tf
@@ -1,0 +1,63 @@
+variable "cisco_cidrs" {
+  description = "Cisco network CIDRs"
+  default = [
+    "52.177.206.0/24",
+    "216.151.141.0/24",
+    "171.68.0.0/14",
+    "66.163.32.0/20",
+    "40.79.24.0/24",
+    "13.68.72.0/24",
+    "40.79.68.0/24",
+    "64.103.0.0/16",
+    "128.107.0.0/16",
+    "20.186.6.0/24",
+    "104.208.221.0/24",
+    "52.254.19.0/24",
+    "13.68.74.0/24",
+    "52.254.51.0/24",
+    "192.168.24.0/24",
+    "171.38.209.0/24",
+    "207.182.160.0/19",
+    "64.102.0.0/16",
+    "66.114.160.0/20",
+    "20.186.37.0/24",
+    "40.79.62.0/24",
+    "52.251.62.0/24",
+    "52.232.186.0/24",
+    "161.44.0.0/16",
+    "52.254.17.0/24",
+    "104.209.145.0/24",
+    "209.197.192.0/21",
+    "40.84.4.0/24",
+    "172.27.27.128/26",
+    "52.179.217.112/28",
+    "40.79.70.0/24",
+    "52.254.77.0/24",
+    "192.168.5.0/24",
+    "3.21.137.64/26",
+    "192.168.110.0/23",
+    "173.36.0.0/14",
+    "72.163.220.0/22",
+    "172.18.136.0/21"
+  ]
+}
+
+variable "domain_name" {
+  description = "Domain name for the Amazon OpenSearch Service domain"
+  default     = "os-dragonfly-prod-eu1"
+}
+
+variable "engine_version" {
+  description = "Engine version for the Amazon OpenSearch Service domain"
+  default     = "OpenSearch_2.11"
+}
+
+variable "instance_type" {
+  description = "Instance type to use for the Amazon OpenSearch Service domain"
+  default     = "r6g.large.search"
+}
+
+variable "os_master_user" {
+  description = "Username for the master user of the Amazon OpenSearch Service domain"
+  default     = "dragonfly-admin"
+}

--- a/aws_dragonfly-prod_eu-central-1_os_dragonfly-prod-eu-1-os_versions.tf
+++ b/aws_dragonfly-prod_eu-central-1_os_dragonfly-prod-eu-1-os_versions.tf
@@ -1,0 +1,18 @@
+terraform {
+  required_version = ">= 1.5.5"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+    vault = {
+      source  = "hashicorp/vault"
+      version = "~> 3.0"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = "~> 3.0"
+    }
+  }
+}

--- a/aws_dragonfly-prod_eu-central-1_os_dragonfly-prod-eu-1-osis_backend.tf
+++ b/aws_dragonfly-prod_eu-central-1_os_dragonfly-prod-eu-1-osis_backend.tf
@@ -1,0 +1,7 @@
+terraform {
+  backend "s3" {
+    bucket = "eticloud-tf-state-prod"
+    key    = "terraform-state/aws/dragonfly-prod/eu-central-1/os/dragonfly-prod-1-osis.tfstate"
+    region = "us-east-2"
+  }
+}

--- a/aws_dragonfly-prod_eu-central-1_os_dragonfly-prod-eu-1-osis_backend.tf
+++ b/aws_dragonfly-prod_eu-central-1_os_dragonfly-prod-eu-1-osis_backend.tf
@@ -1,7 +1,7 @@
 terraform {
   backend "s3" {
     bucket = "eticloud-tf-state-prod"
-    key    = "terraform-state/aws/dragonfly-prod/eu-central-1/os/dragonfly-prod-1-osis.tfstate"
+    key    = "terraform-state/aws/dragonfly-prod/eu-central-1/os/dragonfly-prod-eu1-osis.tfstate"
     region = "us-east-2"
   }
 }

--- a/aws_dragonfly-prod_eu-central-1_os_dragonfly-prod-eu-1-osis_cloudwatch.tf
+++ b/aws_dragonfly-prod_eu-central-1_os_dragonfly-prod-eu-1-osis_cloudwatch.tf
@@ -1,0 +1,3 @@
+resource "aws_cloudwatch_log_group" "dragonfly_prod_eu_1_osis_logs" {
+  name = "/aws/vendedlogs/OpenSearchIngestion/${var.pipeline_name}/audit-logs"
+}

--- a/aws_dragonfly-prod_eu-central-1_os_dragonfly-prod-eu-1-osis_dependencies.tf
+++ b/aws_dragonfly-prod_eu-central-1_os_dragonfly-prod-eu-1-osis_dependencies.tf
@@ -1,0 +1,85 @@
+# AWS credentials
+data "vault_generic_secret" "aws_infra_credential" {
+  path     = "secret/eticcprod/infra/dragonfly-production/aws"
+  provider = vault.eticcprod
+}
+
+# OS account and region
+data "aws_caller_identity" "current" {}
+data "aws_region" "current" {}
+
+# OS domain
+data "aws_opensearch_domain" "dragonfly_prod_eu_1_os" {
+  domain_name = var.domain_name
+}
+
+# MSK cluster
+data "aws_msk_cluster" "dragonfly_msk_eu1" {
+  cluster_name = var.msk_cluster_name
+}
+
+data "aws_iam_policy_document" "pipeline_opensearch" {
+  statement {
+    effect  = "Allow"
+    actions = ["es:DescribeDomain"]
+    resources = [
+      data.aws_opensearch_domain.dragonfly_prod_eu_1_os.arn,
+    ]
+  }
+
+  statement {
+    effect = "Allow"
+    actions = [
+      "es:ESHttp*",
+    ]
+    resources = [
+      "${data.aws_opensearch_domain.dragonfly_prod_eu_1_os.arn}/*",
+    ]
+  }
+}
+
+data "aws_iam_policy_document" "pipeline_kafka" {
+  statement {
+    effect  = "Allow"
+    actions = ["es:DescribeDomain"]
+    resources = [
+      data.aws_opensearch_domain.dragonfly_prod_eu_1_os.arn,
+    ]
+  }
+
+  statement {
+    effect = "Allow"
+    actions = [
+      "kafka-cluster:Connect",
+      "kafka-cluster:AlterCluster",
+      "kafka-cluster:DescribeCluster",
+      "kafka:DescribeClusterV2",
+      "kafka:GetBootstrapBrokers",
+    ]
+    resources = [
+      data.aws_msk_cluster.dragonfly_msk_eu1.arn,
+    ]
+  }
+
+  statement {
+    effect = "Allow"
+    actions = [
+      "kafka-cluster:*Topic*",
+      "kafka-cluster:ReadData",
+    ]
+    resources = [
+      "arn:aws:kafka:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:topic/${var.msk_cluster_name}/*",
+    ]
+  }
+
+  statement {
+    effect = "Allow"
+    actions = [
+      "kafka-cluster:AlterGroup",
+      "kafka-cluster:DescribeGroup"
+    ]
+    resources = [
+      "arn:aws:kafka:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:group/${var.msk_cluster_name}/*",
+    ]
+  }
+}

--- a/aws_dragonfly-prod_eu-central-1_os_dragonfly-prod-eu-1-osis_dependencies.tf
+++ b/aws_dragonfly-prod_eu-central-1_os_dragonfly-prod-eu-1-osis_dependencies.tf
@@ -1,7 +1,7 @@
 # AWS credentials
 data "vault_generic_secret" "aws_infra_credential" {
   path     = "secret/infra/aws/dragonfly-prod/terraform_admin"
-  provider = vault.eticcprod
+  provider = vault.eticloud
 }
 
 # OS account and region

--- a/aws_dragonfly-prod_eu-central-1_os_dragonfly-prod-eu-1-osis_dependencies.tf
+++ b/aws_dragonfly-prod_eu-central-1_os_dragonfly-prod-eu-1-osis_dependencies.tf
@@ -1,6 +1,6 @@
 # AWS credentials
 data "vault_generic_secret" "aws_infra_credential" {
-  path     = "secret/eticcprod/infra/dragonfly-production/aws"
+  path     = "secret/infra/aws/dragonfly-prod/terraform_admin"
   provider = vault.eticcprod
 }
 

--- a/aws_dragonfly-prod_eu-central-1_os_dragonfly-prod-eu-1-osis_iam.tf
+++ b/aws_dragonfly-prod_eu-central-1_os_dragonfly-prod-eu-1-osis_iam.tf
@@ -1,0 +1,49 @@
+module "pipeline_role" {
+  source  = "terraform-aws-modules/iam/aws/modules/iam-assumable-role"
+  version = "~> 5.0"
+
+  create_role = true
+
+  role_name        = "${var.domain_name}-pipeline-role"
+  role_description = "IAM Role to be assumed by Opensearch ingestion pipeline"
+
+  trusted_role_services = [
+    "osis-pipelines.amazonaws.com",
+  ]
+
+  role_requires_mfa       = false
+  custom_role_policy_arns = [
+    module.pipeline_opensearch_policy.arn,
+    module.pipeline_kafka_policy.arn,
+  ]
+
+  tags = var.tags
+}
+
+module "pipeline_opensearch_policy" {
+  source  = "terraform-aws-modules/iam/aws//modules/iam-policy"
+  version = "~> 5.0"
+
+  create_policy = true
+
+  name        = "${var.domain_name}-ingestion-policy"
+  path        = "/"
+  description = "IAM Policy for Opensearch ingestion"
+  policy      = data.aws_iam_policy_document.pipeline_opensearch.json
+
+  tags = var.tags
+}
+
+module "pipeline_kafka_policy" {
+  source  = "terraform-aws-modules/iam/aws//modules/iam-policy"
+  version = "~> 5.0"
+
+  create_policy = true
+
+  name        = "${var.domain_name}-kafka-consumer-policy"
+  path        = "/"
+  description = "IAM Policy for Kafka consumer"
+  policy      = data.aws_iam_policy_document.pipeline_kafka.json
+
+  tags = var.tags
+}

--- a/aws_dragonfly-prod_eu-central-1_os_dragonfly-prod-eu-1-osis_iam.tf
+++ b/aws_dragonfly-prod_eu-central-1_os_dragonfly-prod-eu-1-osis_iam.tf
@@ -1,5 +1,5 @@
 module "pipeline_role" {
-  source  = "terraform-aws-modules/iam/aws/modules/iam-assumable-role"
+  source  = "terraform-aws-modules/iam/aws//modules/iam-assumable-role"
   version = "~> 5.0"
 
   create_role = true

--- a/aws_dragonfly-prod_eu-central-1_os_dragonfly-prod-eu-1-osis_main.tf
+++ b/aws_dragonfly-prod_eu-central-1_os_dragonfly-prod-eu-1-osis_main.tf
@@ -1,0 +1,23 @@
+resource "awscc_osis_pipeline" "ingestion_pipeline" {
+  pipeline_name = var.pipeline_name
+  pipeline_configuration_body = templatefile("./pipeline.yaml", {
+    region          = data.aws_region.current.name
+    sts_role_arn    = module.pipeline_role.iam_role_arn
+    opensearch_host = data.aws_opensearch_domain.dragonfly_prod_eu_1_os.endpoint
+
+    msk_cluster_arn = data.aws_msk_cluster.dragonfly_msk_eu1.arn
+    kafka_topics = [
+      "falco",
+    ]
+  })
+
+  min_units = 1
+  max_units = 4
+
+  log_publishing_options = {
+    is_logging_enabled = true
+    cloudwatch_log_destination = {
+      log_group = aws_cloudwatch_log_group.dragonfly_prod_eu_1_osis_logs.name
+    }
+  }
+}

--- a/aws_dragonfly-prod_eu-central-1_os_dragonfly-prod-eu-1-osis_outputs.tf
+++ b/aws_dragonfly-prod_eu-central-1_os_dragonfly-prod-eu-1-osis_outputs.tf
@@ -1,0 +1,3 @@
+output "opensearch_pipeline_role" {
+  value = module.pipeline_role.iam_role_arn
+}

--- a/aws_dragonfly-prod_eu-central-1_os_dragonfly-prod-eu-1-osis_providers.tf
+++ b/aws_dragonfly-prod_eu-central-1_os_dragonfly-prod-eu-1-osis_providers.tf
@@ -1,0 +1,35 @@
+provider "aws" {
+  access_key = data.vault_generic_secret.aws_infra_credential.data["AWS_ACCESS_KEY_ID"]
+  secret_key = data.vault_generic_secret.aws_infra_credential.data["AWS_SECRET_ACCESS_KEY"]
+  region     = "eu-central-1"
+
+  default_tags {
+    tags = {
+      ApplicationName    = var.pipeline_name
+      CiscoMailAlias     = "eti-sre-admins@cisco.com"
+      DataClassification = "Cisco Confidential"
+      DataTaxonomy       = "Cisco Operations Data"
+      Environment        = "Prod"
+      ResourceOwner      = "ETI SRE"
+    }
+  }
+}
+
+provider "awscc" {
+  access_key = data.vault_generic_secret.aws_infra_credential.data["AWS_ACCESS_KEY_ID"]
+  secret_key = data.vault_generic_secret.aws_infra_credential.data["AWS_SECRET_ACCESS_KEY"]
+  region     = "eu-central-1"
+}
+
+provider "vault" {
+  alias     = "eticcprod"
+  address   = "https://keeper.cisco.com"
+  namespace = "eticloud/eticcprod"
+}
+
+provider "vault" {
+  alias     = "dragonfly"
+  address   = "https://keeper.cisco.com"
+  namespace = "eticloud/apps/dragonfly"
+}
+

--- a/aws_dragonfly-prod_eu-central-1_os_dragonfly-prod-eu-1-osis_providers.tf
+++ b/aws_dragonfly-prod_eu-central-1_os_dragonfly-prod-eu-1-osis_providers.tf
@@ -24,7 +24,7 @@ provider "awscc" {
 provider "vault" {
   alias     = "eticcprod"
   address   = "https://keeper.cisco.com"
-  namespace = "eticloud/eticcprod"
+  namespace = "eticloud"
 }
 
 provider "vault" {
@@ -32,4 +32,3 @@ provider "vault" {
   address   = "https://keeper.cisco.com"
   namespace = "eticloud/apps/dragonfly"
 }
-

--- a/aws_dragonfly-prod_eu-central-1_os_dragonfly-prod-eu-1-osis_providers.tf
+++ b/aws_dragonfly-prod_eu-central-1_os_dragonfly-prod-eu-1-osis_providers.tf
@@ -22,7 +22,7 @@ provider "awscc" {
 }
 
 provider "vault" {
-  alias     = "eticcprod"
+  alias     = "eticloud"
   address   = "https://keeper.cisco.com"
   namespace = "eticloud"
 }

--- a/aws_dragonfly-prod_eu-central-1_os_dragonfly-prod-eu-1-osis_variables.tf
+++ b/aws_dragonfly-prod_eu-central-1_os_dragonfly-prod-eu-1-osis_variables.tf
@@ -1,26 +1,26 @@
 variable "pipeline_name" {
   description = "The name of the pipeline"
   type        = string
-  default     = "osis-dragonfly-prod-eu-1-kafka"
+  default     = "osis-dragonfly-prod-eu1-kafka"
 }
 
 variable "domain_name" {
   description = "The name of the domain"
   type        = string
-  default     = "os-dragonfly-prod-eu-1"
+  default     = "os-dragonfly-prod-eu1"
 }
 
 variable "msk_cluster_name" {
   description = "The name of the MSK cluster"
   type        = string
-  default     = "dragonfly-msk-prod-eu-1"
+  default     = "dragonfly-msk-prod-eu1"
 }
 
 variable "tags" {
   description = "Tags to apply to all resources"
   type        = map(string)
   default = {
-    ApplicationName    = "osis-dragonfly-prod-eu-1"
+    ApplicationName    = "osis-dragonfly-prod-eu1"
     CiscoMailAlias     = "eti-sre-admins@cisco.com"
     DataClassification = "Cisco Confidential"
     DataTaxonomy       = "Cisco Operations Data"

--- a/aws_dragonfly-prod_eu-central-1_os_dragonfly-prod-eu-1-osis_variables.tf
+++ b/aws_dragonfly-prod_eu-central-1_os_dragonfly-prod-eu-1-osis_variables.tf
@@ -1,7 +1,7 @@
 variable "pipeline_name" {
   description = "The name of the pipeline"
   type        = string
-  default     = "osis-dragonfly-prod-eu1-kafka"
+  default     = "osis-dragonfly-prd-eu1-kafka"
 }
 
 variable "domain_name" {

--- a/aws_dragonfly-prod_eu-central-1_os_dragonfly-prod-eu-1-osis_variables.tf
+++ b/aws_dragonfly-prod_eu-central-1_os_dragonfly-prod-eu-1-osis_variables.tf
@@ -1,0 +1,30 @@
+variable "pipeline_name" {
+  description = "The name of the pipeline"
+  type        = string
+  default     = "osis-dragonfly-prod-eu-1-kafka"
+}
+
+variable "domain_name" {
+  description = "The name of the domain"
+  type        = string
+  default     = "os-dragonfly-prod-eu-1"
+}
+
+variable "msk_cluster_name" {
+  description = "The name of the MSK cluster"
+  type        = string
+  default     = "dragonfly-msk-prod-eu-1"
+}
+
+variable "tags" {
+  description = "Tags to apply to all resources"
+  type        = map(string)
+  default = {
+    ApplicationName    = "osis-dragonfly-prod-eu-1"
+    CiscoMailAlias     = "eti-sre-admins@cisco.com"
+    DataClassification = "Cisco Confidential"
+    DataTaxonomy       = "Cisco Operations Data"
+    Environment        = "Prod"
+    ResourceOwner      = "ETI SRE"
+  }
+}

--- a/aws_dragonfly-prod_eu-central-1_os_dragonfly-prod-eu-1-osis_versions.tf
+++ b/aws_dragonfly-prod_eu-central-1_os_dragonfly-prod-eu-1-osis_versions.tf
@@ -1,0 +1,19 @@
+terraform {
+  required_version = ">= 1.4"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 4.38"
+    }
+    awscc = {
+      source  = "hashicorp/awscc"
+      version = ">= 0.65.0"
+    }
+    vault = {
+      source  = "hashicorp/vault"
+      version = "~> 3.0"
+    }
+  }
+}
+

--- a/aws_dragonfly-prod_eu-central-1_os_dragonfly-prod-eu-1-osis_versions.tf
+++ b/aws_dragonfly-prod_eu-central-1_os_dragonfly-prod-eu-1-osis_versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.4"
+  required_version = ">= 1.5.5"
 
   required_providers {
     aws = {
@@ -16,4 +16,3 @@ terraform {
     }
   }
 }
-

--- a/aws_dragonfly-prod_eu-central-1_rds_dragonfly-rds-prod-eu1_aurora-postgres.tf
+++ b/aws_dragonfly-prod_eu-central-1_rds_dragonfly-rds-prod-eu1_aurora-postgres.tf
@@ -1,0 +1,12 @@
+module "rds" {
+  source            = "git::https://github.com/cisco-eti/sre-tf-module-aws-aurora-postgres?ref=1.1.0"
+  vpc_name          = "dragonfly-prod-data-euc1-1"
+  database_name     = "dragonfly"
+  db_instance_type  = "db.r5.xlarge"
+  cluster_name      = "dragonfly-rds-prod-eu1"
+  db_engine_version = "13.11"
+  secret_path       = "secret/eticcprod/infra/aurora-pg/eu-central-1/dragonfly-rds-prod-eu-1"
+  db_allowed_cidrs  = [
+    data.aws_vpc.eks_vpc.cidr_block,
+  ]
+}

--- a/aws_dragonfly-prod_eu-central-1_rds_dragonfly-rds-prod-eu1_backend.tf
+++ b/aws_dragonfly-prod_eu-central-1_rds_dragonfly-rds-prod-eu1_backend.tf
@@ -1,0 +1,7 @@
+terraform {
+  backend "s3" {
+    bucket = "eticloud-tf-state-prod"
+    key    = "terraform-state/aws/dragonfly-prod/eu-central-1/rds/dragonfly-rds-prod-eu1.tfstate"
+    region = "us-east-2"
+  }
+}

--- a/aws_dragonfly-prod_eu-central-1_rds_dragonfly-rds-prod-eu1_dependencies.tf
+++ b/aws_dragonfly-prod_eu-central-1_rds_dragonfly-rds-prod-eu1_dependencies.tf
@@ -1,0 +1,11 @@
+data "vault_generic_secret" "aws_infra_credential" {
+  path     = "secret/infra/aws/dragonfly-prod/terraform_admin"
+  provider = vault.eticcprod
+}
+
+data "aws_vpc" "eks_vpc" {
+  filter {
+    name   = "tag:Name"
+    values = ["dragonfly-prod-euc1-1"]
+  }
+}

--- a/aws_dragonfly-prod_eu-central-1_rds_dragonfly-rds-prod-eu1_providers.tf
+++ b/aws_dragonfly-prod_eu-central-1_rds_dragonfly-rds-prod-eu1_providers.tf
@@ -1,0 +1,22 @@
+provider "vault" {
+  alias     = "eticcprod"
+  address   = "https://keeper.cisco.com"
+  namespace = "eticloud"
+} 
+
+provider "aws" {
+  access_key  = data.vault_generic_secret.aws_infra_credential.data["AWS_ACCESS_KEY_ID"]
+  secret_key  = data.vault_generic_secret.aws_infra_credential.data["AWS_SECRET_ACCESS_KEY"]
+  region      = "eu-central-1"
+  max_retries = 3
+  default_tags {
+    tags = {
+      ApplicationName    = "dragonfly-rds-1"
+      CiscoMailAlias     = "eti-sre-admins@cisco.com"
+      DataClassification = "Cisco Confidential"
+      DataTaxonomy       = "Cisco Operations Data"
+      EnvironmentName    = "Prod"
+      ResourceOwner      = "ETI SRE"
+    }
+  }
+}

--- a/aws_dragonfly-prod_eu-central-1_rds_dragonfly-rds-prod-eu1_versions.tf
+++ b/aws_dragonfly-prod_eu-central-1_rds_dragonfly-rds-prod-eu1_versions.tf
@@ -1,0 +1,14 @@
+terraform {
+  required_version = ">= 1.5.5"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+    vault = {
+      source  = "hashicorp/vault"
+      version = "~> 3.0"
+    }
+  }
+}

--- a/aws_vowel-genai-dev_us-east-2_eks_vowel-dev-use2-2_eso.tf
+++ b/aws_vowel-genai-dev_us-east-2_eks_vowel-dev-use2-2_eso.tf
@@ -1,0 +1,38 @@
+provider "vault" {
+  alias     = "eticloud"
+  address   = "https://keeper.cisco.com"
+  namespace = "eticloud"
+}
+
+data "vault_generic_secret" "aws_infra_credential" {
+  provider    = vault.eticloud
+  path        = "secret/infra/aws/${local.aws_account_name}/terraform_admin"
+}
+
+provider "aws" {
+  alias      = "target"
+  access_key = data.vault_generic_secret.aws_infra_credential.data["AWS_ACCESS_KEY_ID"]
+  secret_key = data.vault_generic_secret.aws_infra_credential.data["AWS_SECRET_ACCESS_KEY"]
+  region     = local.region
+}
+
+data "aws_eks_cluster" "cluster" {
+  depends_on = [ module.eks_all_in_one ]
+  provider  = aws.target
+  name      = local.name
+}
+
+data "vault_generic_secret" "cluster_certificate" {
+  depends_on = [ module.eks_all_in_one ]
+  provider = vault.eticloud
+  path = "secret/infra/eks/${local.name}/certificate"
+}
+
+module "eso_eticloud" {
+  source               = "git::https://github.com/cisco-eti/sre-tf-module-eso-access.git?ref=0.0.2"
+  cluster_name         = local.name
+  vault_namespace      = "eticloud"
+  kubernetes_host      = data.aws_eks_cluster.cluster.endpoint
+  kubernetes_ca        = base64decode(data.vault_generic_secret.cluster_certificate.data["b64certificate"])
+  policies             = ["external-secrets-dev"]
+}

--- a/aws_vowel-genai-dev_us-east-2_eks_vowel-dev-use2-2_main.tf
+++ b/aws_vowel-genai-dev_us-east-2_eks_vowel-dev-use2-2_main.tf
@@ -1,0 +1,31 @@
+terraform {
+  backend "s3" {
+    # This is the name of the backend S3 bucket.
+    bucket          = "eticloud-tf-state-nonprod" # UPDATE ME.
+    # This is the path to the Terraform state file in the backend S3 bucket.
+    key             = "terraform-state/aws/vowel-genai-dev/us-east-2/eks/vowel-dev-use2-2.tfstate" # UPDATE ME.
+    # This is the region where the backend S3 bucket is located.
+    region          = "us-east-2" # DO NOT CHANGE.
+
+  }
+}
+
+locals {
+  name              = "vowel-dev-use2-2"
+  region            = "us-east-2"
+  aws_account_name  = "vowel-genai-dev"
+}
+
+module "eks_all_in_one" {
+  source            = "git::https://github.com/cisco-eti/sre-tf-module-eks-allinone.git?ref=latest" # Based on v0.0.10
+  name              = local.name              # EKS cluster name
+  region            = local.region            # AWS provider region
+  aws_account_name  = local.aws_account_name  # AWS account name
+  cidr              = "10.0.0.0/16"           # VPC CIDR
+  cluster_version   = "1.28"                  # EKS cluster version
+  # EKS Managed Private Node Group
+  instance_types    = ["m6a.2xlarge"]         # EKS instance types
+  min_size          = 3                       # EKS node group min size
+  max_size          = 15                      # EKS node group max size
+  desired_size      = 3                       # EKS node group desired size
+}


### PR DESCRIPTION
https://cisco-eti.atlassian.net/browse/SRE-7348
This is for OpenSearch and also replicates [US prod infra](https://wwwin-github.cisco.com/eti/sre-tf-infra/tree/main/aws-dragonfly-production/os/us-east-2).
Second plan is failing because the first one/project needs to be applied first in order to create one missing resource `aws_opensearch_domain`.