### PR TITLE
feat(liquibase/rds/postgres): deploy a test DB in order to test liquibase implementation

### DIFF
--- a/aws_eticloud-scratch-c_eu-central-1_rds_helloworld_aurora-postgres.tf
+++ b/aws_eticloud-scratch-c_eu-central-1_rds_helloworld_aurora-postgres.tf
@@ -1,0 +1,10 @@
+module "rds" {
+  source            = "git::https://github.com/cisco-eti/sre-tf-module-aws-aurora-postgres?ref=1.1.0"
+  vpc_name          = "daboucha-liquibase-2"
+  database_name     = "helloworld"
+  db_instance_type  = "db.t4g.micro"
+  cluster_name      = "helloworld"
+  db_engine_version = "15"
+  db_allowed_cidrs  = ["10.19.0.0/16"] # EKS VPC CIDR
+  secret_path       = "secret/eticcprod/infra/aurora-pg/eu-central-1/helloworld"
+}

--- a/aws_eticloud-scratch-c_eu-central-1_rds_helloworld_aurora-postgres.tf
+++ b/aws_eticloud-scratch-c_eu-central-1_rds_helloworld_aurora-postgres.tf
@@ -6,5 +6,5 @@ module "rds" {
   cluster_name      = "helloworld"
   db_engine_version = "15"
   db_allowed_cidrs  = ["10.19.0.0/16"] # EKS VPC CIDR
-  secret_path       = "secret/eticcprod/infra/aurora-pg/eu-central-1/helloworld"
+  secret_path       = "secret/teamsecrets/rds/scratch/aurora-pg/eu-central-1/helloworld"
 }

--- a/aws_eticloud-scratch-c_eu-central-1_rds_helloworld_aurora-postgres.tf
+++ b/aws_eticloud-scratch-c_eu-central-1_rds_helloworld_aurora-postgres.tf
@@ -6,5 +6,4 @@ module "rds" {
   cluster_name      = "helloworld"
   db_engine_version = "15"
   db_allowed_cidrs  = ["10.19.0.0/16"] # EKS VPC CIDR
-  secret_path       = "secret/teamsecrets/rds/scratch/aurora-pg/eu-central-1/helloworld"
 }

--- a/aws_eticloud-scratch-c_eu-central-1_rds_helloworld_backend.tf
+++ b/aws_eticloud-scratch-c_eu-central-1_rds_helloworld_backend.tf
@@ -1,0 +1,7 @@
+terraform {
+  backend "s3" {
+    bucket = "eticloud-tf-state-nonprod"
+    key    = "terraform-state/aws/eticloud-scratch-c/eu-central-1/rds/helloworld.tfstate"
+    region = "us-east-2"
+  }
+}

--- a/aws_eticloud-scratch-c_eu-central-1_rds_helloworld_dependencies.tf
+++ b/aws_eticloud-scratch-c_eu-central-1_rds_helloworld_dependencies.tf
@@ -1,3 +1,3 @@
 data "vault_generic_secret" "aws_infra_credential" {
-  path = "secret/infra/aws/eticloud-scratch-c/terraform_admin"
+  path     = "secret/infra/aws/eticloud-scratch-c/terraform_admin"
 }

--- a/aws_eticloud-scratch-c_eu-central-1_rds_helloworld_dependencies.tf
+++ b/aws_eticloud-scratch-c_eu-central-1_rds_helloworld_dependencies.tf
@@ -1,0 +1,3 @@
+data "vault_generic_secret" "aws_infra_credential" {
+  path = "secret/infra/aws/eticloud-scratch-c/terraform_admin"
+}

--- a/aws_eticloud-scratch-c_eu-central-1_rds_helloworld_providers.tf
+++ b/aws_eticloud-scratch-c_eu-central-1_rds_helloworld_providers.tf
@@ -1,0 +1,21 @@
+provider "vault" {
+  address   = "https://keeper.cisco.com"
+  namespace = "eticloud"
+}
+
+provider "aws" {
+  access_key  = data.vault_generic_secret.aws_infra_credential.data["AWS_ACCESS_KEY_ID"]
+  secret_key  = data.vault_generic_secret.aws_infra_credential.data["AWS_SECRET_ACCESS_KEY"]
+  region      = "eu-central-1"
+  max_retries = 3
+  default_tags {
+    tags = {
+      ApplicationName    = "helloworld"
+      CiscoMailAlias     = "eti-sre-admins@cisco.com"
+      DataClassification = "Cisco Confidential"
+      DataTaxonomy       = "Cisco Operations Data"
+      EnvironmentName    = "NonProd"
+      ResourceOwner      = "ETI SRE"
+    }
+  }
+}

--- a/aws_eticloud-scratch-c_eu-central-1_rds_helloworld_versions.tf
+++ b/aws_eticloud-scratch-c_eu-central-1_rds_helloworld_versions.tf
@@ -1,0 +1,14 @@
+terraform {
+  required_version = ">= 1.5.5"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+    vault = {
+      source  = "hashicorp/vault"
+      version = "~> 3.0"
+    }
+  }
+}

--- a/aws_eticloud-scratch-c_eu-central-1_rds_liquibase-rds-1_aurora-postgres.tf
+++ b/aws_eticloud-scratch-c_eu-central-1_rds_liquibase-rds-1_aurora-postgres.tf
@@ -1,0 +1,9 @@
+module "rds" {
+  source            = "git::https://github.com/cisco-eti/sre-tf-module-aws-aurora-postgres?ref=1.1.0"
+  vpc_name          = "daboucha-liquibase-2"
+  database_name     = "liquibase-rds-1"
+  db_instance_type  = "db.t4g.micro"
+  cluster_name      = "liquibase-rds-1"
+  db_engine_version = "15"
+  db_allowed_cidrs  = ["10.19.0.0/16"] # EKS VPC CIDR
+}

--- a/aws_eticloud-scratch-c_eu-central-1_rds_liquibase-rds-1_backend.tf
+++ b/aws_eticloud-scratch-c_eu-central-1_rds_liquibase-rds-1_backend.tf
@@ -1,0 +1,7 @@
+terraform {
+  backend "s3" {
+    bucket = "eticloud-tf-state-nonprod"
+    key    = "terraform-state/aws/eticloud-scratch-c/eu-central-1/rds/helloworld.tfstate"
+    region = "us-east-2"
+  }
+}

--- a/aws_eticloud-scratch-c_eu-central-1_rds_liquibase-rds-1_dependencies.tf
+++ b/aws_eticloud-scratch-c_eu-central-1_rds_liquibase-rds-1_dependencies.tf
@@ -1,0 +1,3 @@
+data "vault_generic_secret" "aws_infra_credential" {
+  path     = "secret/infra/aws/eticloud-scratch-c/terraform_admin"
+}

--- a/aws_eticloud-scratch-c_eu-central-1_rds_liquibase-rds-1_providers.tf
+++ b/aws_eticloud-scratch-c_eu-central-1_rds_liquibase-rds-1_providers.tf
@@ -1,0 +1,21 @@
+provider "vault" {
+  address   = "https://keeper.cisco.com"
+  namespace = "eticloud"
+}
+
+provider "aws" {
+  access_key  = data.vault_generic_secret.aws_infra_credential.data["AWS_ACCESS_KEY_ID"]
+  secret_key  = data.vault_generic_secret.aws_infra_credential.data["AWS_SECRET_ACCESS_KEY"]
+  region      = "eu-central-1"
+  max_retries = 3
+  default_tags {
+    tags = {
+      ApplicationName    = "liquibase-rds-1"
+      CiscoMailAlias     = "eti-sre-admins@cisco.com"
+      DataClassification = "Cisco Confidential"
+      DataTaxonomy       = "Cisco Operations Data"
+      EnvironmentName    = "NonProd"
+      ResourceOwner      = "ETI SRE"
+    }
+  }
+}

--- a/aws_eticloud-scratch-c_eu-central-1_rds_liquibase-rds-1_versions.tf
+++ b/aws_eticloud-scratch-c_eu-central-1_rds_liquibase-rds-1_versions.tf
@@ -1,0 +1,14 @@
+terraform {
+  required_version = ">= 1.5.5"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+    vault = {
+      source  = "hashicorp/vault"
+      version = "~> 3.0"
+    }
+  }
+}

--- a/aws_eticloud-scratch-c_us-east-2_rds_helloworld-rds_aurora-postgres.tf
+++ b/aws_eticloud-scratch-c_us-east-2_rds_helloworld-rds_aurora-postgres.tf
@@ -5,5 +5,6 @@ module "rds" {
   db_instance_type  = "db.t4g.micro"
   cluster_name      = "helloworld"
   db_engine_version = "15"
+  db_allowed_cidrs  = ["10.0.0.0/16"] # EKS VPC CIDR
   secret_path       = "secret/eticcprod/infra/aurora-pg/us-east-2/helloworld"
 }

--- a/aws_eticloud-scratch-c_us-east-2_rds_helloworld-rds_aurora-postgres.tf
+++ b/aws_eticloud-scratch-c_us-east-2_rds_helloworld-rds_aurora-postgres.tf
@@ -1,0 +1,12 @@
+module "rds" {
+  source            = "git::https://github.com/cisco-eti/sre-tf-module-aws-aurora-postgres?ref=1.1.0"
+  vpc_name          = "sre-dev-1"
+  database_name     = "helloworld"
+  db_instance_type  = "db.t4g.micro"
+  cluster_name      = "helloworld"
+  db_engine_version = "15"
+  secret_path       = "secret/eticcprod/infra/aurora-pg/us-east-2/helloworld"
+  db_allowed_cidrs  = [
+    data.aws_vpc.eks_vpc.cidr_block,
+  ]
+}

--- a/aws_eticloud-scratch-c_us-east-2_rds_helloworld-rds_aurora-postgres.tf
+++ b/aws_eticloud-scratch-c_us-east-2_rds_helloworld-rds_aurora-postgres.tf
@@ -1,12 +1,9 @@
 module "rds" {
   source            = "git::https://github.com/cisco-eti/sre-tf-module-aws-aurora-postgres?ref=1.1.0"
-  vpc_name          = "sre-dev-1"
+  vpc_name          = "eks-sraradhy-1"
   database_name     = "helloworld"
   db_instance_type  = "db.t4g.micro"
   cluster_name      = "helloworld"
   db_engine_version = "15"
   secret_path       = "secret/eticcprod/infra/aurora-pg/us-east-2/helloworld"
-  db_allowed_cidrs  = [
-    data.aws_vpc.eks_vpc.cidr_block,
-  ]
 }

--- a/aws_eticloud-scratch-c_us-east-2_rds_helloworld-rds_backend.tf
+++ b/aws_eticloud-scratch-c_us-east-2_rds_helloworld-rds_backend.tf
@@ -1,0 +1,7 @@
+terraform {
+  backend "s3" {
+    bucket = "eticloud-tf-state-nonprod"
+    key    = "terraform-state/aws/aws/eticloud-scratch-c/us-east-2/rds/helloworld.tfstate"
+    region = "us-east-2"
+  }
+}

--- a/aws_eticloud-scratch-c_us-east-2_rds_helloworld-rds_backend.tf
+++ b/aws_eticloud-scratch-c_us-east-2_rds_helloworld-rds_backend.tf
@@ -1,7 +1,7 @@
 terraform {
   backend "s3" {
     bucket = "eticloud-tf-state-nonprod"
-    key    = "terraform-state/aws/aws/eticloud-scratch-c/us-east-2/rds/helloworld.tfstate"
+    key    = "terraform-state/aws/eticloud-scratch-c/us-east-2/rds/helloworld.tfstate"
     region = "us-east-2"
   }
 }

--- a/aws_eticloud-scratch-c_us-east-2_rds_helloworld-rds_dependencies.tf
+++ b/aws_eticloud-scratch-c_us-east-2_rds_helloworld-rds_dependencies.tf
@@ -1,6 +1,5 @@
 data "vault_generic_secret" "aws_infra_credential" {
-  path     = "secret/infra/aws/dragonfly-prod/terraform_admin"
-  provider = vault.eticcprod
+  path        = "secret/infra/aws/aws/eticloud-scratch-c/terraform_admin"
 }
 
 data "aws_vpc" "eks_vpc" {

--- a/aws_eticloud-scratch-c_us-east-2_rds_helloworld-rds_dependencies.tf
+++ b/aws_eticloud-scratch-c_us-east-2_rds_helloworld-rds_dependencies.tf
@@ -1,5 +1,5 @@
 data "vault_generic_secret" "aws_infra_credential" {
-  path        = "secret/infra/aws/eticloud-scratch-c/terraform_admin"
+  path = "secret/infra/aws/eticloud-scratch-c/terraform_admin"
 }
 
 data "aws_vpc" "eks_vpc" {

--- a/aws_eticloud-scratch-c_us-east-2_rds_helloworld-rds_dependencies.tf
+++ b/aws_eticloud-scratch-c_us-east-2_rds_helloworld-rds_dependencies.tf
@@ -1,5 +1,5 @@
 data "vault_generic_secret" "aws_infra_credential" {
-  path        = "secret/infra/aws/aws/eticloud-scratch-c/terraform_admin"
+  path        = "secret/infra/aws/eticloud-scratch-c/terraform_admin"
 }
 
 data "aws_vpc" "eks_vpc" {

--- a/aws_eticloud-scratch-c_us-east-2_rds_helloworld-rds_dependencies.tf
+++ b/aws_eticloud-scratch-c_us-east-2_rds_helloworld-rds_dependencies.tf
@@ -1,0 +1,11 @@
+data "vault_generic_secret" "aws_infra_credential" {
+  path     = "secret/infra/aws/dragonfly-prod/terraform_admin"
+  provider = vault.eticcprod
+}
+
+data "aws_vpc" "eks_vpc" {
+  filter {
+    name   = "tag:Name"
+    values = ["eks-sraradhy-1"]
+  }
+}

--- a/aws_eticloud-scratch-c_us-east-2_rds_helloworld-rds_providers.tf
+++ b/aws_eticloud-scratch-c_us-east-2_rds_helloworld-rds_providers.tf
@@ -1,0 +1,21 @@
+provider "vault" {
+  address   = "https://keeper.cisco.com"
+  namespace = "eticloud"
+} 
+
+provider "aws" {
+  access_key  = data.vault_generic_secret.aws_infra_credential.data["AWS_ACCESS_KEY_ID"]
+  secret_key  = data.vault_generic_secret.aws_infra_credential.data["AWS_SECRET_ACCESS_KEY"]
+  region      = "us-east-2"
+  max_retries = 3
+  default_tags {
+    tags = {
+      ApplicationName    = "helloworld"
+      CiscoMailAlias     = "eti-sre-admins@cisco.com"
+      DataClassification = "Cisco Confidential"
+      DataTaxonomy       = "Cisco Operations Data"
+      EnvironmentName    = "NonProd"
+      ResourceOwner      = "ETI SRE"
+    }
+  }
+}

--- a/aws_eticloud-scratch-c_us-east-2_rds_helloworld-rds_providers.tf
+++ b/aws_eticloud-scratch-c_us-east-2_rds_helloworld-rds_providers.tf
@@ -1,7 +1,7 @@
 provider "vault" {
   address   = "https://keeper.cisco.com"
   namespace = "eticloud"
-} 
+}
 
 provider "aws" {
   access_key  = data.vault_generic_secret.aws_infra_credential.data["AWS_ACCESS_KEY_ID"]

--- a/aws_eticloud-scratch-c_us-east-2_rds_helloworld-rds_versions.tf
+++ b/aws_eticloud-scratch-c_us-east-2_rds_helloworld-rds_versions.tf
@@ -1,0 +1,14 @@
+terraform {
+  required_version = ">= 1.5.5"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+    vault = {
+      source  = "hashicorp/vault"
+      version = "~> 3.0"
+    }
+  }
+}


### PR DESCRIPTION
https://cisco-eti.atlassian.net/browse/SRE-7451
Bootstrap an RDS Postgres DB in order to test liquibase schema/migrations using an existing EKS cluster, in a different VPC from the EKS cluster's. This is to replicate a prod like setup with a dedicated VPC and a bastion host.