### PR TITLE
feat(aws-iam-s3): IAM resources for plg prod

### DIFF
--- a/aws_eticloud-plg-prod_us-east-1_iam_backend.tf
+++ b/aws_eticloud-plg-prod_us-east-1_iam_backend.tf
@@ -1,0 +1,8 @@
+# AWS account: eticloud
+terraform {
+  backend "s3" {
+    bucket  = "eticloud-tf-state-prod"
+    key     = "terraform-state/eticloud-plg-prod/iam/iam-roles.tfstate"
+    region  = "us-east-2"
+  }
+}

--- a/aws_eticloud-plg-prod_us-east-1_iam_main.tf
+++ b/aws_eticloud-plg-prod_us-east-1_iam_main.tf
@@ -1,0 +1,27 @@
+# IAM policy that allows to list a specific bucket and write objects to it
+resource "aws_iam_policy" "plg_write_to_s3" {
+  name        = "WriteToPLGAnalyticsS3Bucket"
+  description = "IAM policy that allows to write to a specific S3 bucket"
+
+  policy = jsonencode({
+    "Version" = "2012-10-17",
+    "Statement" = [
+      {
+        "Sid" = "ListObjectsInBucket",
+        "Effect" = "Allow",
+        "Action" = [
+          "s3:ListBucket"
+        ],
+        "Resource" = "arn:aws:s3:::eti-plg-analytics-s3-bucket/Rosey/*"
+      },
+       {
+        "Sid" = "AllObjectActions",
+        "Effect" = "Allow",
+        "Action" = [
+          "s3:PutObject"
+        ],
+        "Resource" = "*"
+      }
+    ]
+  })
+}

--- a/aws_eticloud-plg-prod_us-east-1_iam_providers.tf
+++ b/aws_eticloud-plg-prod_us-east-1_iam_providers.tf
@@ -1,0 +1,25 @@
+provider "vault" {
+  address   = "https://keeper.cisco.com"
+  namespace = "eticloud"
+}
+
+data "vault_generic_secret" "aws_infra_credential" {
+  path = "secret/infra/aws/eticloud-plg-prod/terraform_admin"
+}
+
+provider "aws" {
+  access_key = data.vault_generic_secret.aws_infra_credential.data["AWS_ACCESS_KEY_ID"]
+  secret_key = data.vault_generic_secret.aws_infra_credential.data["AWS_SECRET_ACCESS_KEY"]
+  region     = "us-east-1"
+
+  default_tags {
+    tags = {
+      ApplicationName    = "ETI Plg prod"
+      CiscoMailAlias     = "eti-sre-admins@cisco.com"
+      DataClassification = "Cisco Confidential"
+      DataTaxonomy       = "Cisco Operations Data"
+      EnvironmentName    = "Prod"
+      ResourceOwner      = "ETI SRE"
+    }
+  }
+}

--- a/aws_eticloud-plg-prod_us-east-1_iam_versions.tf
+++ b/aws_eticloud-plg-prod_us-east-1_iam_versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.5.5"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 4.0"
+    }
+  }
+}


### PR DESCRIPTION
https://cisco-eti.atlassian.net/browse/SRE-7888
Allow cross account S3 permissions in order to write files into an S3 bucket in that plg prod account, used for analytics purposes as far as I understand.
Starting with a workload running in a `rosey` namespace` that will grab some logs from containers and write them to said bucket (could be another OTel collector/exporter, or another type of workload).