### PR TITLE
feat(oidc): add provider IAM

### DIFF
--- a/aws_eticloud-plg-prod_us-east-1_iam_iam.tf
+++ b/aws_eticloud-plg-prod_us-east-1_iam_iam.tf
@@ -1,24 +1,5 @@
 data "aws_caller_identity" "current" {}
 
-locals {
-  aws_account_id = data.aws_caller_identity.current.account_id
-
-  cnapp_clusters = {
-    cnapp-staging-eu = {
-      eks_oidc = "oidc.eks.eu-central-1.amazonaws.com/id/66B7724A1237295F25E3FC9201787745"
-    }
-    cnapp-staging-us = {
-      eks_oidc = "oidc.eks.us-east-2.amazonaws.com/id/60EFFB82AD511AC44AB303BAB015E41A"
-    }
-    cnapp-prod-eu = {
-      eks_oidc = "oidc.eks.us-east-2.amazonaws.com/id/28A49D0DC19E0AE06F2E38C0AD473F7D"
-    }
-    cnapp-prod-us = {
-      eks_oidc = "oidc.eks.us-east-2.amazonaws.com/id/EFF9B51923E64F3067C820180603F855"
-    }
-  }
-}
-
 # IAM policy that allows to list a specific bucket and write objects to it
 resource "aws_iam_policy" "plg_write_to_s3" {
   name        = "WriteToPLGAnalyticsS3Bucket"

--- a/aws_eticloud-plg-prod_us-east-1_iam_locals.tf
+++ b/aws_eticloud-plg-prod_us-east-1_iam_locals.tf
@@ -1,0 +1,18 @@
+locals {
+  aws_account_id = data.aws_caller_identity.current.account_id
+
+  cnapp_clusters = {
+    cnapp-staging-eu = {
+      eks_oidc = "oidc.eks.eu-central-1.amazonaws.com/id/66B7724A1237295F25E3FC9201787745"
+    }
+    cnapp-staging-us = {
+      eks_oidc = "oidc.eks.us-east-2.amazonaws.com/id/60EFFB82AD511AC44AB303BAB015E41A"
+    }
+    cnapp-prod-eu = {
+      eks_oidc = "oidc.eks.us-east-2.amazonaws.com/id/28A49D0DC19E0AE06F2E38C0AD473F7D"
+    }
+    cnapp-prod-us = {
+      eks_oidc = "oidc.eks.us-east-2.amazonaws.com/id/EFF9B51923E64F3067C820180603F855"
+    }
+  }
+}

--- a/aws_eticloud-plg-prod_us-east-1_iam_oidc.tf
+++ b/aws_eticloud-plg-prod_us-east-1_iam_oidc.tf
@@ -1,6 +1,7 @@
 # required for the thumbprint list of each EKS cluster
 
 data "tls_certificate" "eks_tls_certificate" {
+  for_each = local.cnapp_clusters
   url = "https://${each.value.eks_oidc}"
 }
 

--- a/aws_eticloud-plg-prod_us-east-1_iam_oidc.tf
+++ b/aws_eticloud-plg-prod_us-east-1_iam_oidc.tf
@@ -2,7 +2,7 @@
 
 data "tls_certificate" "eks_tls_certificate" {
   for_each = local.cnapp_clusters
-  url = "https://${each.value.eks_oidc}"
+  url      = "https://${each.value.eks_oidc}"
 }
 
 resource "aws_iam_openid_connect_provider" "eks_cluster" {

--- a/aws_eticloud-plg-prod_us-east-1_iam_oidc.tf
+++ b/aws_eticloud-plg-prod_us-east-1_iam_oidc.tf
@@ -1,0 +1,16 @@
+# required for the thumbprint list of each EKS cluster
+
+data "tls_certificate" "eks_tls_certificate" {
+  url = "https://${each.value.eks_oidc}"
+}
+
+resource "aws_iam_openid_connect_provider" "eks_cluster" {
+  for_each = local.cnapp_clusters
+  url      = "https://${each.value.eks_oidc}"
+  client_id_list = [
+    "sts.amazonaws.com",
+  ]
+  thumbprint_list = [
+    data.tls_certificate.eks_tls_certificate.certificates[0].sha1_fingerprint,
+  ]
+}

--- a/aws_eticloud-plg-prod_us-east-1_iam_oidc.tf
+++ b/aws_eticloud-plg-prod_us-east-1_iam_oidc.tf
@@ -12,6 +12,6 @@ resource "aws_iam_openid_connect_provider" "eks_cluster" {
     "sts.amazonaws.com",
   ]
   thumbprint_list = [
-    data.tls_certificate.eks_tls_certificate.certificates[0].sha1_fingerprint,
+    data.tls_certificate.eks_tls_certificate[each.key].certificates[0].sha1_fingerprint,
   ]
 }


### PR DESCRIPTION
Follow up from #255, IAM Identity providers have to be added for each cluster Rosey (and Data analytics) will use.
Note: Need to investigate the use of Pod identity which removes the need to do this.