### PR TITLE
fix(iam-s3): log shipping, serviceAccount

### DIFF
--- a/aws_eticloud-plg-prod_us-east-1_iam_iam.tf
+++ b/aws_eticloud-plg-prod_us-east-1_iam_iam.tf
@@ -43,7 +43,7 @@ module "iam_eks_role_plg_s3" {
   oidc_providers = {
     "${each.key}" = {
       provider_arn               = "arn:aws:iam::${local.aws_account_id}:oidc-provider/${each.value.eks_oidc}"
-      namespace_service_accounts = ["rosey*:rosey*"]
+      namespace_service_accounts = ["opentelemetry-exporter:*opentelemetry-exporter*"]
     }
   }
 }


### PR DESCRIPTION
Wrong serviceAccount/namespace

```
"WebIdentityErr: failed to retrieve credentials...
```

```
k get sa                                                                                                                            (⎈|cnapp-prod-euc1-1:opentelemetry-exporter)
NAME                                                              SECRETS   AGE
cnapp-prod-euc1-1-opentelemetry-exporter-opentelemetry-collecto   0         154m
```