### PR TITLE
feat(rds): create new VPCs in secondary region for failover purposes - SRE-8012

### DIFF
--- a/aws_motific-prod_us-west-2_vpc_motf-prod-usw2-data_vpc.tf
+++ b/aws_motific-prod_us-west-2_vpc_motf-prod-usw2-data_vpc.tf
@@ -1,0 +1,47 @@
+terraform {
+  backend "s3" {
+    bucket = "eticloud-tf-state-nonprod"
+    key    = "terraform-state/vpc/us-east-2/motf-prod-usw2-data-vpc.tfstate"
+    region = "us-east-2"
+  }
+}
+
+provider "vault" {
+  alias     = "eticloud"
+  address   = "https://keeper.cisco.com"
+  namespace = "eticloud"
+}
+
+# AWS credentails are the same of cwpp-dev vault secret (we deploy on same aws account)
+data "vault_generic_secret" "aws_infra_credential" {
+  path     = "secret/infra/aws/motific-prod/terraform_admin"
+  provider = vault.eticloud
+}
+
+provider "aws" {
+  access_key  = data.vault_generic_secret.aws_infra_credential.data["AWS_ACCESS_KEY_ID"]
+  secret_key  = data.vault_generic_secret.aws_infra_credential.data["AWS_SECRET_ACCESS_KEY"]
+  region      = "us-west-2"
+  max_retries = 3
+  default_tags {
+    tags = {
+      ApplicationName    = "motf-prod-usw2-data-vpc"
+      CiscoMailAlias     = "eti-sre-admins@cisco.com"
+      DataClassification = "Cisco Confidential"
+      DataTaxonomy       = "Cisco Operations Data"
+      Environment        = "Prod"
+      ResourceOwner      = "Outshift SRE"
+    }
+  }
+}
+
+module "vpc" {
+  source                          = "git::https://github.com/cisco-eti/sre-tf-module-aws-vpc?ref=2.0.6"
+  region                          = "us-east-2"
+  vpc_cidr                        = "10.4.0.0/16"
+  vpc_name                        = "motf-prod-usw2-data"
+  cluster_name                    = "motf-prod-usw2-data"
+  create_database_subnet_group    = true
+  create_elasticache_subnet_group = false
+  create_secondary_subnets        = false
+}

--- a/aws_motific-prod_us-west-2_vpc_motf-prod-usw2-data_vpc.tf
+++ b/aws_motific-prod_us-west-2_vpc_motf-prod-usw2-data_vpc.tf
@@ -37,7 +37,7 @@ provider "aws" {
 
 module "vpc" {
   source                          = "git::https://github.com/cisco-eti/sre-tf-module-aws-vpc?ref=2.0.6"
-  region                          = "us-east-2"
+  region                          = "us-west-2"
   vpc_cidr                        = "10.4.0.0/16"
   vpc_name                        = "motf-prod-usw2-data"
   cluster_name                    = "motf-prod-usw2-data"

--- a/aws_motific-prod_us-west-2_vpc_motf-prod-usw2-data_vpc.tf
+++ b/aws_motific-prod_us-west-2_vpc_motf-prod-usw2-data_vpc.tf
@@ -1,6 +1,6 @@
 terraform {
   backend "s3" {
-    bucket = "eticloud-tf-state-nonprod"
+    bucket = "eticloud-tf-state-prod"
     key    = "terraform-state/vpc/us-east-2/motf-prod-usw2-data-vpc.tfstate"
     region = "us-east-2"
   }

--- a/aws_motific-prod_us-west-2_vpc_motf-prod-usw2-data_vpc.tf
+++ b/aws_motific-prod_us-west-2_vpc_motf-prod-usw2-data_vpc.tf
@@ -38,7 +38,7 @@ provider "aws" {
 module "vpc" {
   source                          = "git::https://github.com/cisco-eti/sre-tf-module-aws-vpc?ref=2.0.6"
   region                          = "us-west-2"
-  vpc_cidr                        = "10.4.0.0/16"
+  vpc_cidr                        = "10.100.0.0/16"
   vpc_name                        = "motf-prod-usw2-data"
   cluster_name                    = "motf-prod-usw2-data"
   create_database_subnet_group    = true

--- a/aws_motific-staging_us-west-2_vpc_motf-staging-usw2-data_vpc.tf
+++ b/aws_motific-staging_us-west-2_vpc_motf-staging-usw2-data_vpc.tf
@@ -37,7 +37,7 @@ provider "aws" {
 
 module "vpc" {
   source                          = "git::https://github.com/cisco-eti/sre-tf-module-aws-vpc?ref=2.0.6"
-  region                          = "us-east-2"
+  region                          = "us-west-2"
   vpc_cidr                        = "10.3.0.0/16"
   vpc_name                        = "motf-staging-usw2-data"
   cluster_name                    = "motf-staging-usw2-data"

--- a/aws_motific-staging_us-west-2_vpc_motf-staging-usw2-data_vpc.tf
+++ b/aws_motific-staging_us-west-2_vpc_motf-staging-usw2-data_vpc.tf
@@ -38,7 +38,7 @@ provider "aws" {
 module "vpc" {
   source                          = "git::https://github.com/cisco-eti/sre-tf-module-aws-vpc?ref=2.0.6"
   region                          = "us-west-2"
-  vpc_cidr                        = "10.3.0.0/16"
+  vpc_cidr                        = "10.100.0.0/16"
   vpc_name                        = "motf-staging-usw2-data"
   cluster_name                    = "motf-staging-usw2-data"
   create_database_subnet_group    = true

--- a/aws_motific-staging_us-west-2_vpc_motf-staging-usw2-data_vpc.tf
+++ b/aws_motific-staging_us-west-2_vpc_motf-staging-usw2-data_vpc.tf
@@ -1,0 +1,47 @@
+terraform {
+  backend "s3" {
+    bucket = "eticloud-tf-state-nonprod"
+    key    = "terraform-state/vpc/us-east-2/motf-staging-usw2-data-vpc.tfstate"
+    region = "us-east-2"
+  }
+}
+
+provider "vault" {
+  alias     = "eticloud"
+  address   = "https://keeper.cisco.com"
+  namespace = "eticloud"
+}
+
+# AWS credentails are the same of cwpp-dev vault secret (we deploy on same aws account)
+data "vault_generic_secret" "aws_infra_credential" {
+  path     = "secret/infra/aws/motific-staging/terraform_admin"
+  provider = vault.eticloud
+}
+
+provider "aws" {
+  access_key  = data.vault_generic_secret.aws_infra_credential.data["AWS_ACCESS_KEY_ID"]
+  secret_key  = data.vault_generic_secret.aws_infra_credential.data["AWS_SECRET_ACCESS_KEY"]
+  region      = "us-west-2"
+  max_retries = 3
+  default_tags {
+    tags = {
+      ApplicationName    = "motf-staging-usw2-data-vpc"
+      CiscoMailAlias     = "eti-sre-admins@cisco.com"
+      DataClassification = "Cisco Confidential"
+      DataTaxonomy       = "Cisco Operations Data"
+      Environment        = "NonProd"
+      ResourceOwner      = "Outshift SRE"
+    }
+  }
+}
+
+module "vpc" {
+  source                          = "git::https://github.com/cisco-eti/sre-tf-module-aws-vpc?ref=2.0.6"
+  region                          = "us-east-2"
+  vpc_cidr                        = "10.3.0.0/16"
+  vpc_name                        = "motf-staging-usw2-data"
+  cluster_name                    = "motf-staging-usw2-data"
+  create_database_subnet_group    = true
+  create_elasticache_subnet_group = false
+  create_secondary_subnets        = false
+}


### PR DESCRIPTION
https://cisco-eti.atlassian.net/browse/SRE-8012

New RDS reader instances in `us-west-2` (for failover) will need a new VPC otherwise they'll land in the default one.