### PR TITLE
feat(vpc-data-usw2): RDS secondary cluster needs to be bootstrapped in non default VPC

### DIFF
--- a/aws_motific-pentest_us-west-2_vpc_motf-pentest-usw2-data_vpc.tf
+++ b/aws_motific-pentest_us-west-2_vpc_motf-pentest-usw2-data_vpc.tf
@@ -1,0 +1,46 @@
+terraform {
+  backend "s3" {
+    bucket = "eticloud-tf-state-nonprod"
+    key    = "terraform-state/vpc/us-east-2/motf-pentest-usw2-data-vpc.tfstate"
+    region = "us-east-2"
+  }
+}
+
+provider "vault" {
+  alias     = "eticloud"
+  address   = "https://keeper.cisco.com"
+  namespace = "eticloud"
+}
+
+data "vault_generic_secret" "aws_infra_credential" {
+  path     = "secret/infra/aws/motf-perf-use2-1/terraform_admin"
+  provider = vault.eticloud
+}
+
+provider "aws" {
+  access_key  = data.vault_generic_secret.aws_infra_credential.data["AWS_ACCESS_KEY_ID"]
+  secret_key  = data.vault_generic_secret.aws_infra_credential.data["AWS_SECRET_ACCESS_KEY"]
+  region      = "us-west-2"
+  max_retries = 3
+  default_tags {
+    tags = {
+      ApplicationName    = "motf-pentest-usw2-data-vpc"
+      CiscoMailAlias     = "eti-sre-admins@cisco.com"
+      DataClassification = "Cisco Confidential"
+      DataTaxonomy       = "Cisco Operations Data"
+      Environment        = "NonProd"
+      ResourceOwner      = "Outshift SRE"
+    }
+  }
+}
+
+module "vpc" {
+  source                          = "git::https://github.com/cisco-eti/sre-tf-module-aws-vpc?ref=2.0.6"
+  region                          = "us-west-2"
+  vpc_cidr                        = "10.100.0.0/16"
+  vpc_name                        = "motf-pentest-usw2-data"
+  cluster_name                    = "motf-pentest-usw2-data"
+  create_database_subnet_group    = true
+  create_elasticache_subnet_group = false
+  create_secondary_subnets        = false
+}

--- a/aws_motific-pentest_us-west-2_vpc_motf-pentest-usw2-data_vpc.tf
+++ b/aws_motific-pentest_us-west-2_vpc_motf-pentest-usw2-data_vpc.tf
@@ -13,7 +13,7 @@ provider "vault" {
 }
 
 data "vault_generic_secret" "aws_infra_credential" {
-  path     = "secret/infra/aws/motf-perf-use2-1/terraform_admin"
+  path     = "secret/infra/aws/motific-pentest/terraform_admin"
   provider = vault.eticloud
 }
 

--- a/aws_motific-pentest_us-west-2_vpc_peering_compute-to-data_provider.tf
+++ b/aws_motific-pentest_us-west-2_vpc_peering_compute-to-data_provider.tf
@@ -1,0 +1,38 @@
+# By setting the AWS provider credentials via the data source above, we control in which account and region the resources get created.
+provider "aws" {
+  alias       = "primary"
+  access_key  = data.vault_generic_secret.aws_infra_credential.data["AWS_ACCESS_KEY_ID"]
+  secret_key  = data.vault_generic_secret.aws_infra_credential.data["AWS_SECRET_ACCESS_KEY"]
+  region      = "us-east-2"
+  max_retries = 3
+  default_tags {
+    tags = {
+      Name               = "VPC Peering between ${local.acceptor_vpc_name} and ${local.requestor_vpc_name}"
+      ApplicationName    = "${local.acceptor_vpc_name}-vpc-peering"
+      CiscoMailAlias     = "eti-sre@cisco.com"
+      DataClassification = "Cisco Confidential"
+      DataTaxonomy       = "Cisco Operations Data"
+      Environment        = "NonProd"
+      ResourceOwner      = "Outshift SRE"
+    }
+  }
+}
+
+provider "aws" {
+  alias       = "secondary"
+  access_key  = data.vault_generic_secret.aws_infra_credential.data["AWS_ACCESS_KEY_ID"]
+  secret_key  = data.vault_generic_secret.aws_infra_credential.data["AWS_SECRET_ACCESS_KEY"]
+  region      = "us-west-2"
+  max_retries = 3
+  default_tags {
+    tags = {
+      Name               = "VPC Peering between ${local.acceptor_vpc_name} and ${local.requestor_vpc_name}"
+      ApplicationName    = "${local.acceptor_vpc_name}-vpc-peering"
+      CiscoMailAlias     = "eti-sre@cisco.com"
+      DataClassification = "Cisco Confidential"
+      DataTaxonomy       = "Cisco Operations Data"
+      Environment        = "NonProd"
+      ResourceOwner      = "Outshift SRE"
+    }
+  }
+}

--- a/aws_motific-pentest_us-west-2_vpc_peering_compute-to-data_versions.tf
+++ b/aws_motific-pentest_us-west-2_vpc_peering_compute-to-data_versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 4.0"
+      configuration_aliases = [ aws.primary, aws.secondary ]
+    }
+  }
+  required_version = ">= 1.5.5"
+}

--- a/aws_motific-pentest_us-west-2_vpc_peering_compute-to-data_vpc-peering.tf
+++ b/aws_motific-pentest_us-west-2_vpc_peering_compute-to-data_vpc-peering.tf
@@ -5,7 +5,7 @@ provider "vault" {
 }
 
 data "vault_generic_secret" "aws_infra_credential" {
-  path     = "secret/infra/aws/motf-perf-use2-1/terraform_admin"
+  path     = "secret/infra/aws/motific-pentest/terraform_admin"
   provider = vault.eticloud
 }
 

--- a/aws_motific-pentest_us-west-2_vpc_peering_compute-to-data_vpc-peering.tf
+++ b/aws_motific-pentest_us-west-2_vpc_peering_compute-to-data_vpc-peering.tf
@@ -1,0 +1,125 @@
+provider "vault" {
+  alias     = "eticloud"
+  address   = "https://keeper.cisco.com"
+  namespace = "eticloud"
+}
+
+data "vault_generic_secret" "aws_infra_credential" {
+  path     = "secret/infra/aws/motf-perf-use2-1/terraform_admin"
+  provider = vault.eticloud
+}
+
+terraform {
+  backend "s3" {
+    bucket = "eticloud-tf-state-nonprod"
+    key    = "terraform-state/vpc-peering/us-west-2/data-motific-pentest-usw2-1.tfstate"
+    region = "us-east-2"
+  }
+}
+
+locals {
+  acceptor_vpc_name  = "motf-perf-use2-1"       # EKS cluster in us-east-2
+  requestor_vpc_name = "motf-pentest-usw2-data" # RDS cluster in us-west-2
+}
+
+# Get the VPC IDs based on the names of the VPCs
+data "aws_vpc" "acceptor_vpc" {
+  provider = aws.primary
+  filter {
+    name   = "tag:Name"
+    values = [local.acceptor_vpc_name]
+  }
+}
+
+data "aws_vpc" "requestor_vpc" {
+  provider = aws.secondary
+  filter {
+    name   = "tag:Name"
+    values = [local.requestor_vpc_name]
+  }
+}
+
+data "aws_route_tables" "acceptor_vpc_rt" {
+  provider = aws.primary
+  vpc_id   = data.aws_vpc.acceptor_vpc.id
+}
+
+data "aws_route_tables" "requestor_vpc_rt" {
+  provider = aws.secondary
+  vpc_id   = data.aws_vpc.requestor_vpc.id
+}
+
+# Use this to get the account ID
+data "aws_caller_identity" "account" {
+  # provider should not matter here, we only want the AWS account ID
+  provider = aws.primary
+}
+
+# VPC peering resources
+resource "aws_vpc_peering_connection" "primary" {
+  provider      = aws.primary
+  peer_owner_id = data.aws_caller_identity.account.account_id
+  peer_vpc_id   = data.aws_vpc.requestor_vpc.id
+  vpc_id        = data.aws_vpc.acceptor_vpc.id
+  peer_region   = "us-west-2"
+
+  accepter {
+    allow_remote_vpc_dns_resolution = true
+  }
+
+  requester {
+    allow_remote_vpc_dns_resolution = true
+  }
+}
+
+######################################
+# VPC peering accepter configuration #
+######################################
+resource "aws_vpc_peering_connection_accepter" "peer_accepter" {
+  provider                  = aws.primary
+  vpc_peering_connection_id = aws_vpc_peering_connection.primary.id
+  auto_accept               = true
+}
+
+#######################
+# VPC peering options #
+#######################
+resource "aws_vpc_peering_connection_options" "primary" {
+  provider                  = aws.primary
+  vpc_peering_connection_id = aws_vpc_peering_connection_accepter.peer_accepter.id
+
+  requester {
+    allow_remote_vpc_dns_resolution = true
+  }
+
+  depends_on = [aws_vpc_peering_connection.primary]
+}
+
+resource "aws_vpc_peering_connection_options" "secondary" {
+  provider                  = aws.secondary
+  vpc_peering_connection_id = aws_vpc_peering_connection_accepter.peer_accepter.id
+
+  accepter {
+    allow_remote_vpc_dns_resolution = true
+  }
+
+  depends_on = [aws_vpc_peering_connection.primary]
+}
+
+
+# VPC routing resources
+resource "aws_route" "eks-to-db" {
+  provider                  = aws.secondary
+  count                     = length(data.aws_route_tables.requestor_vpc_rt.ids)
+  route_table_id            = data.aws_route_tables.requestor_vpc_rt.ids[count.index]
+  destination_cidr_block    = data.aws_vpc.acceptor_vpc.cidr_block
+  vpc_peering_connection_id = aws_vpc_peering_connection.primary.id
+}
+
+resource "aws_route" "db-to-eks" {
+  provider                  = aws.primary
+  count                     = length(data.aws_route_tables.acceptor_vpc_rt.ids)
+  route_table_id            = data.aws_route_tables.acceptor_vpc_rt.ids[count.index]
+  destination_cidr_block    = data.aws_vpc.requestor_vpc.cidr_block
+  vpc_peering_connection_id = aws_vpc_peering_connection.primary.id
+}


### PR DESCRIPTION
Create data VPC in `us-west-2` in `motific-pentest` AWS account. Add cross region peering to EKS VPC in `us-east-2`.
The error in the second plan is expected (the new VPC needs to be created before peering is added).