### PR TITLE
fix(rosey-logs): ListBucket is needed too

### DIFF
--- a/aws_cnapp-prod_rosey-logs_iam.tf
+++ b/aws_cnapp-prod_rosey-logs_iam.tf
@@ -10,13 +10,13 @@ resource "aws_iam_policy" "rosey_logs" {
     Version = "2012-10-17",
     Statement = [
       {
-        Sid    = "stsAssumeRoleWithWebIdentityLogs",
+        Sid    = "ListObjectsInBucket",
         Effect = "Allow",
         Action = [
-          "sts:AssumeRoleWithWebIdentity"
+          "s3:ListBucket"
         ],
         Resource = [
-          "arn:aws:iam::${local.account_id}:role/${aws_iam_role.rosey_logs[each.key].name}"
+          "arn:aws:s3:::rosey-logs-${each.value.region_prefix}"
         ]
       },
       {


### PR DESCRIPTION
Follow up from https://github.com/cisco-eti/platform-terraform-infra/pull/361

`AssumeRoleWithWebIdentity` shouldn't be needed as per my testing in the `rosey-test` AWS account, but we need `ListBucket` before granting perms to write to the bucket.