### PR TITLE
chore(dragonfly): move MSK clusters from sre-tf-infra

### DIFF
--- a/aws_dragonfly-dev_eu-west-1_msk_dragonfly-dev-msk-1_backend.tf
+++ b/aws_dragonfly-dev_eu-west-1_msk_dragonfly-dev-msk-1_backend.tf
@@ -1,0 +1,7 @@
+terraform {
+  backend "s3" {
+    bucket = "eticloud-tf-state-nonprod"
+    key    = "terraform-state/aws-dragonfly-dev-1/msk/eu-west-1/dragonfly-msk-1.tfstate"
+    region = "us-east-2"
+  }
+}

--- a/aws_dragonfly-dev_eu-west-1_msk_dragonfly-dev-msk-1_cloudwatch.tf
+++ b/aws_dragonfly-dev_eu-west-1_msk_dragonfly-dev-msk-1_cloudwatch.tf
@@ -1,0 +1,3 @@
+resource "aws_cloudwatch_log_group" "broker_logs" {
+  name = "dragonfly-msk-1-broker-logs"
+}

--- a/aws_dragonfly-dev_eu-west-1_msk_dragonfly-dev-msk-1_dependencies.tf
+++ b/aws_dragonfly-dev_eu-west-1_msk_dragonfly-dev-msk-1_dependencies.tf
@@ -1,0 +1,59 @@
+data "vault_generic_secret" "aws_infra_credential" {
+  path     = "secret/infra/aws/${local.aws_account_name}/terraform_admin"
+  provider = vault.eticloud
+}
+
+// account information
+data "aws_caller_identity" "current" {}
+data "aws_region" "current" {}
+
+data "aws_iam_policy_document" "msk_scram_secret_policy" {
+  for_each = var.scram_kafka_clients
+
+  statement {
+    sid    = "AWSKafkaResourcePolicy"
+    effect = "Allow"
+
+    principals {
+      type        = "Service"
+      identifiers = ["kafka.amazonaws.com"]
+    }
+
+    actions   = ["secretsmanager:getSecretValue"]
+    resources = [aws_secretsmanager_secret.msk_scram_auth_credentials[each.key].arn]
+  }
+}
+
+data "aws_vpc" "eks_vpc" {
+  filter {
+    name   = "tag:Name"
+    values = ["dragonfly-dev-2-vpc"]
+  }
+}
+
+data "aws_vpc" "msk_vpc" {
+  filter {
+    name   = "tag:Name"
+    values = ["dragonfly-data-vpc"]
+  }
+}
+
+data "aws_subnets" "eks_subnets" {
+  filter {
+    name   = "vpc-id"
+    values = [data.aws_vpc.eks_vpc.id]
+  }
+  tags = {
+    Tier = "Private"
+  }
+}
+
+data "aws_subnets" "msk_subnets" {
+  filter {
+    name   = "vpc-id"
+    values = [data.aws_vpc.msk_vpc.id]
+  }
+  tags = {
+    Tier = "Private"
+  }
+}

--- a/aws_dragonfly-dev_eu-west-1_msk_dragonfly-dev-msk-1_kms.tf
+++ b/aws_dragonfly-dev_eu-west-1_msk_dragonfly-dev-msk-1_kms.tf
@@ -1,0 +1,3 @@
+resource "aws_kms_key" "encryption_key" {
+  description = "dragonfly-msk-1 MSK cluster encryption key"
+}

--- a/aws_dragonfly-dev_eu-west-1_msk_dragonfly-dev-msk-1_locals.tf
+++ b/aws_dragonfly-dev_eu-west-1_msk_dragonfly-dev-msk-1_locals.tf
@@ -1,0 +1,8 @@
+locals {
+  app_name = "dragonfly-dev"
+  aws_account_name = "dragonfly-dev"
+  aws_region       = "eu-west-1"
+  account_id       = data.aws_caller_identity.current.account_id
+
+  vpc_id = "dragonfly-dev-2-vpc"
+}

--- a/aws_dragonfly-dev_eu-west-1_msk_dragonfly-dev-msk-1_locals.tf
+++ b/aws_dragonfly-dev_eu-west-1_msk_dragonfly-dev-msk-1_locals.tf
@@ -1,5 +1,5 @@
 locals {
-  app_name = "dragonfly-dev"
+  app_name         = "dragonfly-dev"
   aws_account_name = "dragonfly-dev"
   aws_region       = "eu-west-1"
   account_id       = data.aws_caller_identity.current.account_id

--- a/aws_dragonfly-dev_eu-west-1_msk_dragonfly-dev-msk-1_msk.tf
+++ b/aws_dragonfly-dev_eu-west-1_msk_dragonfly-dev-msk-1_msk.tf
@@ -1,0 +1,154 @@
+resource "aws_msk_configuration" "configuration" {
+  kafka_versions = [var.kafka_version]
+  name           = "dragonfly-msk-1"
+
+  server_properties = <<PROPERTIES
+auto.create.topics.enable = true
+PROPERTIES
+}
+
+resource "aws_msk_scram_secret_association" "msk_scram_auth_credentials" {
+  cluster_arn = aws_msk_cluster.dragonfly_msk_1.arn
+  secret_arn_list = [
+    for s in aws_secretsmanager_secret.msk_scram_auth_credentials : s.arn
+  ]
+
+  depends_on = [aws_secretsmanager_secret_version.msk_scram_auth_credentials_v1]
+}
+
+resource "aws_msk_cluster" "dragonfly_msk_1" {
+  cluster_name           = "dragonfly-msk-1"
+  kafka_version          = var.kafka_version
+  number_of_broker_nodes = var.number_of_broker_nodes
+
+  // Broker configuration
+  broker_node_group_info {
+    instance_type = var.instance_type
+
+    client_subnets = data.aws_subnets.msk_subnets.ids
+
+    storage_info {
+      ebs_storage_info {
+        volume_size = 1000
+      }
+    }
+
+    // Turn on multi-vpc connectivity
+    connectivity_info {
+      vpc_connectivity {
+        client_authentication {
+          sasl {
+            scram = false
+            iam   = true
+          }
+        }
+      }
+    }
+
+    security_groups = [aws_security_group.dragonfly_msk_1.id]
+  }
+
+  // Encryption
+  encryption_info {
+    encryption_at_rest_kms_key_arn = aws_kms_key.encryption_key.arn
+
+    encryption_in_transit {
+      client_broker = "TLS"
+      in_cluster    = true
+    }
+  }
+
+  // Authentication
+  client_authentication {
+    sasl {
+      scram = true
+      iam   = true
+    }
+  }
+
+  // Cluster config
+  configuration_info {
+    arn      = aws_msk_configuration.configuration.arn
+    revision = aws_msk_configuration.configuration.latest_revision
+  }
+
+  // Monitoring && logging
+  open_monitoring {
+    prometheus {
+      jmx_exporter {
+        enabled_in_broker = true
+      }
+      node_exporter {
+        enabled_in_broker = true
+      }
+    }
+  }
+
+  enhanced_monitoring = "PER_TOPIC_PER_PARTITION"
+
+  logging_info {
+    broker_logs {
+      cloudwatch_logs {
+        enabled   = true
+        log_group = aws_cloudwatch_log_group.broker_logs.name
+      }
+    }
+  }
+}
+
+resource "aws_msk_cluster_policy" "opensearch_ingestion_policy" {
+  cluster_arn = aws_msk_cluster.dragonfly_msk_1.arn
+
+  policy = jsonencode({
+    "Version" : "2012-10-17",
+    "Statement" : [
+      {
+        "Effect" : "Allow",
+        "Principal" : {
+          "Service" : "osis.amazonaws.com"
+        },
+        "Action" : [
+          "kafka:CreateVpcConnection",
+          "kafka:DescribeCluster",
+          "kafka:DescribeClusterV2"
+        ],
+        "Resource" : aws_msk_cluster.dragonfly_msk_1.arn
+      },
+      {
+        "Effect" : "Allow",
+        "Principal" : {
+          "Service" : "osis-pipelines.amazonaws.com"
+        },
+        "Action" : [
+          "kafka:CreateVpcConnection",
+          "kafka:GetBootstrapBrokers",
+          "kafka:DescribeCluster",
+          "kafka:DescribeClusterV2"
+        ],
+        "Resource" : aws_msk_cluster.dragonfly_msk_1.arn
+    }]
+  })
+}
+
+// Save brokers in vault
+resource "vault_generic_secret" "msk_brokers" {
+  path = "secret/dev/msk/dragonfly-msk-1/brokers"
+
+  data_json = jsonencode({
+    brokers = aws_msk_cluster.dragonfly_msk_1.bootstrap_brokers_sasl_scram
+    brokers-iam = aws_msk_cluster.dragonfly_msk_1.bootstrap_brokers_sasl_iam
+  })
+
+  provider = vault.dragonfly
+}
+
+resource "vault_generic_secret" "msk_region_brokers" {
+  path = "secret/dev/msk/${data.aws_region.current.name}/dragonfly-msk-1/brokers"
+
+  data_json = jsonencode({
+    brokers = aws_msk_cluster.dragonfly_msk_1.bootstrap_brokers_sasl_scram
+    brokers-iam = aws_msk_cluster.dragonfly_msk_1.bootstrap_brokers_sasl_iam
+  })
+
+  provider = vault.dragonfly
+}

--- a/aws_dragonfly-dev_eu-west-1_msk_dragonfly-dev-msk-1_msk.tf
+++ b/aws_dragonfly-dev_eu-west-1_msk_dragonfly-dev-msk-1_msk.tf
@@ -135,7 +135,7 @@ resource "vault_generic_secret" "msk_brokers" {
   path = "secret/dev/msk/dragonfly-msk-1/brokers"
 
   data_json = jsonencode({
-    brokers = aws_msk_cluster.dragonfly_msk_1.bootstrap_brokers_sasl_scram
+    brokers     = aws_msk_cluster.dragonfly_msk_1.bootstrap_brokers_sasl_scram
     brokers-iam = aws_msk_cluster.dragonfly_msk_1.bootstrap_brokers_sasl_iam
   })
 
@@ -146,7 +146,7 @@ resource "vault_generic_secret" "msk_region_brokers" {
   path = "secret/dev/msk/${data.aws_region.current.name}/dragonfly-msk-1/brokers"
 
   data_json = jsonencode({
-    brokers = aws_msk_cluster.dragonfly_msk_1.bootstrap_brokers_sasl_scram
+    brokers     = aws_msk_cluster.dragonfly_msk_1.bootstrap_brokers_sasl_scram
     brokers-iam = aws_msk_cluster.dragonfly_msk_1.bootstrap_brokers_sasl_iam
   })
 

--- a/aws_dragonfly-dev_eu-west-1_msk_dragonfly-dev-msk-1_outputs.tf
+++ b/aws_dragonfly-dev_eu-west-1_msk_dragonfly-dev-msk-1_outputs.tf
@@ -1,0 +1,11 @@
+output "zookeeper_connect_string" {
+  value = aws_msk_cluster.dragonfly_msk_1.zookeeper_connect_string
+}
+
+output "bootstrap_brokers" {
+  value = aws_msk_cluster.dragonfly_msk_1.bootstrap_brokers
+}
+
+output "bootstrap_brokers_tls" {
+  value = aws_msk_cluster.dragonfly_msk_1.bootstrap_brokers_tls
+}

--- a/aws_dragonfly-dev_eu-west-1_msk_dragonfly-dev-msk-1_providers.tf
+++ b/aws_dragonfly-dev_eu-west-1_msk_dragonfly-dev-msk-1_providers.tf
@@ -1,0 +1,28 @@
+provider "aws" {
+  access_key = data.vault_generic_secret.aws_infra_credential.data["AWS_ACCESS_KEY_ID"]
+  secret_key = data.vault_generic_secret.aws_infra_credential.data["AWS_SECRET_ACCESS_KEY"]
+  region     = "eu-west-1"
+
+  default_tags {
+    tags = {
+      ApplicationName    = "dragonfly-msk-1"
+      CiscoMailAlias     = "eti-sre-admins@cisco.com"
+      DataClassification = "Cisco Confidential"
+      DataTaxonomy       = "Cisco Operations Data"
+      EnvironmentName    = "NonProd"
+      ResourceOwner      = "ETI SRE"
+    }
+  }
+}
+
+provider "vault" {
+  alias     = "eticloud"
+  address   = "https://keeper.cisco.com"
+  namespace = "eticloud"
+}
+
+provider "vault" {
+  alias     = "dragonfly"
+  address   = "https://keeper.cisco.com"
+  namespace = "eticloud/apps/dragonfly"
+}

--- a/aws_dragonfly-dev_eu-west-1_msk_dragonfly-dev-msk-1_secretsmanager.tf
+++ b/aws_dragonfly-dev_eu-west-1_msk_dragonfly-dev-msk-1_secretsmanager.tf
@@ -1,0 +1,47 @@
+// Generate random passwords
+resource "random_password" "password" {
+  for_each = var.scram_kafka_clients
+
+  length  = 64
+  special = false
+}
+
+// Save secrets in Vault
+resource "vault_generic_secret" "msk_scram_auth_credentials" {
+  for_each = var.scram_kafka_clients
+
+  path = each.value.vault_path
+
+  data_json = jsonencode({
+    username = each.key
+    password = random_password.password[each.key].result
+  })
+
+  provider = vault.dragonfly
+}
+
+// Secrets for SASL/SCRAM authentication
+resource "aws_secretsmanager_secret" "msk_scram_auth_credentials" {
+  for_each = var.scram_kafka_clients
+
+  name        = "AmazonMSK_dragonfly-msk-1-${each.key}-scram-auth"
+  description = each.value.description
+
+  kms_key_id = aws_kms_key.encryption_key.key_id
+}
+
+// Secret versions
+resource "aws_secretsmanager_secret_version" "msk_scram_auth_credentials_v1" {
+  for_each = var.scram_kafka_clients
+
+  secret_id     = aws_secretsmanager_secret.msk_scram_auth_credentials[each.key].id
+  secret_string = vault_generic_secret.msk_scram_auth_credentials[each.key].data_json
+}
+
+// Secret policy
+resource "aws_secretsmanager_secret_policy" "msk_scram_secret_policy" {
+  for_each = var.scram_kafka_clients
+
+  secret_arn = aws_secretsmanager_secret.msk_scram_auth_credentials[each.key].arn
+  policy     = data.aws_iam_policy_document.msk_scram_secret_policy[each.key].json
+}

--- a/aws_dragonfly-dev_eu-west-1_msk_dragonfly-dev-msk-1_securitygroup.tf
+++ b/aws_dragonfly-dev_eu-west-1_msk_dragonfly-dev-msk-1_securitygroup.tf
@@ -1,0 +1,80 @@
+locals {
+  msk_ingress_rules = [
+    {
+      from_port : 9094,
+      to_port : 9094,
+      protocol : "tcp",
+      cidr_blocks : [
+        data.aws_vpc.msk_vpc.cidr_block,
+        data.aws_vpc.eks_vpc.cidr_block,
+      ],
+    },
+    {
+      from_port : 9096,
+      to_port : 9096,
+      protocol : "tcp",
+      cidr_blocks : [
+        data.aws_vpc.msk_vpc.cidr_block,
+        data.aws_vpc.eks_vpc.cidr_block,
+      ],
+    },
+    {
+      from_port : 9098,
+      to_port : 9098,
+      protocol : "tcp",
+      cidr_blocks : [
+        data.aws_vpc.msk_vpc.cidr_block,
+        data.aws_vpc.eks_vpc.cidr_block,
+      ],
+    },
+    {
+      from_port : 2181,
+      to_port : 2181,
+      protocol : "tcp",
+      cidr_blocks : [
+        data.aws_vpc.msk_vpc.cidr_block,
+      ],
+    },
+  ]
+
+  msk_egress_rules = [
+    {
+      from_port : 0,
+      to_port : 65535,
+      protocol : "tcp",
+      cidr_blocks : [
+        data.aws_vpc.msk_vpc.cidr_block,
+        data.aws_vpc.eks_vpc.cidr_block,
+      ],
+    },
+  ]
+}
+
+
+resource "aws_security_group" "dragonfly_msk_1" {
+  name        = "dragonfly-msk-1-msk-default"
+  description = "dragonfly-msk-1 MSK cluster default security group"
+  vpc_id      = data.aws_vpc.msk_vpc.id
+
+  dynamic "ingress" {
+    for_each = toset(local.msk_ingress_rules)
+
+    content {
+      from_port   = ingress.value.from_port
+      to_port     = ingress.value.to_port
+      protocol    = ingress.value.protocol
+      cidr_blocks = ingress.value.cidr_blocks
+    }
+  }
+
+  dynamic "egress" {
+    for_each = toset(local.msk_egress_rules)
+
+    content {
+      from_port   = egress.value.from_port
+      to_port     = egress.value.to_port
+      protocol    = egress.value.protocol
+      cidr_blocks = egress.value.cidr_blocks
+    }
+  }
+}

--- a/aws_dragonfly-dev_eu-west-1_msk_dragonfly-dev-msk-1_variables.tf
+++ b/aws_dragonfly-dev_eu-west-1_msk_dragonfly-dev-msk-1_variables.tf
@@ -1,0 +1,39 @@
+variable "kafka_version" {
+  description = "Kafka version to deploy"
+  type        = string
+  default     = "3.6.0"
+}
+
+variable "instance_type" {
+  description = "Instance type to use for Kafka brokers"
+  type        = string
+  default     = "kafka.m5.large"
+}
+
+variable "number_of_broker_nodes" {
+  description = "Number of Kafka broker nodes to deploy"
+  type        = number
+  default     = 3
+}
+
+variable "scram_kafka_clients" {
+  description = "Kafka clients to create"
+  type = map(object({
+    description = string
+    vault_path  = string
+  }))
+  default = {
+    "otel-collector" = {
+      description = "Auth credentials of otel-collector for dragonfly-msk-1"
+      vault_path  = "secret/dev/msk/eu-west-1/dragonfly-msk-1/kafka-clients/otel-collector"
+    },
+    "notification-service" = {
+      description = "Auth credentials of notification-service for dragonfly-msk-1"
+      vault_path  = "secret/dev/msk/eu-west-1/dragonfly-msk-1/kafka-clients/notification-service"
+    },
+    "fluentbit" = {
+      description = "Auth credentials of fluentbit for dragonfly-msk-1"
+      vault_path  = "secret/dev/msk/eu-west-1/dragonfly-msk-1/kafka-clients/fluentbit"
+    },
+  }
+}

--- a/aws_dragonfly-dev_eu-west-1_msk_dragonfly-dev-msk-1_versions.tf
+++ b/aws_dragonfly-dev_eu-west-1_msk_dragonfly-dev-msk-1_versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.3.6"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+}

--- a/aws_dragonfly-prod_us-east-2_msk_dragonfly-prod-msk-1_backend.tf
+++ b/aws_dragonfly-prod_us-east-2_msk_dragonfly-prod-msk-1_backend.tf
@@ -1,0 +1,7 @@
+terraform {
+  backend "s3" {
+    bucket = "eticloud-tf-state-prod"
+    key    = "terraform-state/aws-dragonfly-production/msk/us-east-2/dragonfly-msk-prod-1.tfstate"
+    region = "us-east-2"
+  }
+}

--- a/aws_dragonfly-prod_us-east-2_msk_dragonfly-prod-msk-1_cloudwatch.tf
+++ b/aws_dragonfly-prod_us-east-2_msk_dragonfly-prod-msk-1_cloudwatch.tf
@@ -1,0 +1,3 @@
+resource "aws_cloudwatch_log_group" "broker_logs" {
+  name = "dragonfly-msk-prod-1-broker-logs"
+}

--- a/aws_dragonfly-prod_us-east-2_msk_dragonfly-prod-msk-1_dependencies.tf
+++ b/aws_dragonfly-prod_us-east-2_msk_dragonfly-prod-msk-1_dependencies.tf
@@ -1,0 +1,71 @@
+data "vault_generic_secret" "aws_infra_credential" {
+  path     = "secret/infra/aws/${local.aws_account_name}/terraform_admin"
+  provider = vault.eticloud
+}
+
+data "aws_caller_identity" "current" {} # data.aws_caller_identity.current.account_id
+data "aws_region" "current" {}          # data.aws_region.current.name
+
+data "aws_iam_policy_document" "msk_secret_policy" {
+  for_each = var.kafka_clients
+
+  statement {
+    sid    = "AWSKafkaResourcePolicy"
+    effect = "Allow"
+
+    principals {
+      type        = "Service"
+      identifiers = ["kafka.amazonaws.com"]
+    }
+
+    actions   = ["secretsmanager:getSecretValue"]
+    resources = [aws_secretsmanager_secret.msk_auth_credentials[each.key].arn]
+  }
+}
+
+data "aws_vpc" "eks_vpc" {
+  filter {
+    name   = "tag:Name"
+    values = ["dragonfly-compute-prod-1-vpc"]
+  }
+}
+
+data "aws_vpc" "msk_vpc" {
+  filter {
+    name   = "tag:Name"
+    values = ["dragonfly-data-prod-1-vpc"]
+  }
+}
+
+data "aws_subnets" "eks_subnets" {
+  filter {
+    name   = "vpc-id"
+    values = [data.aws_vpc.eks_vpc.id]
+  }
+  tags = {
+    Tier = "Private"
+  }
+}
+
+data "aws_subnets" "msk_subnets" {
+  filter {
+    name   = "vpc-id"
+    values = [data.aws_vpc.msk_vpc.id]
+  }
+  tags = {
+    Tier = "Private"
+  }
+}
+
+data "aws_s3_bucket" "mskconnect_custom_plugin_bucket" {
+  bucket = local.arango_connector_plugin_bucket
+}
+
+data "aws_s3_bucket" "mskconnect_logs_bucket" {
+  bucket = local.arangodb_connector_logs_bucket
+}
+
+data "aws_s3_object" "arangodb_connector_plugin_jar" {
+  bucket = local.arango_connector_plugin_bucket
+  key    = local.arangodb_connector_plugin_jar
+}

--- a/aws_dragonfly-prod_us-east-2_msk_dragonfly-prod-msk-1_kafka-connect.tf
+++ b/aws_dragonfly-prod_us-east-2_msk_dragonfly-prod-msk-1_kafka-connect.tf
@@ -1,10 +1,10 @@
 resource "aws_mskconnect_custom_plugin" "plugin" {
-  name = "${local.arango_connector_plugin_name}-plugin"
+  name         = "${local.arango_connector_plugin_name}-plugin"
   content_type = "JAR"
   location {
     s3 {
       bucket_arn = data.aws_s3_bucket.mskconnect_custom_plugin_bucket.arn
-      file_key = data.aws_s3_object.arangodb_connector_plugin_jar.key
+      file_key   = data.aws_s3_object.arangodb_connector_plugin_jar.key
     }
   }
 }
@@ -16,7 +16,7 @@ resource "aws_iam_role" "connector_role" {
     Statement = [
       {
         "Effect" = "Allow",
-        "Principal": {
+        "Principal" : {
           "Service" = "kafkaconnect.amazonaws.com"
         },
         "Action" = "sts:AssumeRole"
@@ -98,7 +98,7 @@ data "aws_iam_policy_document" "connector_role_policy_document" {
     ]
   }
 
-statement {
+  statement {
     effect = "Allow"
 
     actions = [
@@ -127,12 +127,12 @@ resource "vault_generic_secret" "kafka_connect_vault" {
   path = "secret/prod/dragonfly-streaman/us/msk"
 
   data_json = jsonencode({
-    mskCustomPluginArn = aws_mskconnect_custom_plugin.plugin.arn,
-    mskCustomPluginRevision = aws_mskconnect_custom_plugin.plugin.latest_revision
-    mskS3LogBucket = data.aws_s3_bucket.mskconnect_logs_bucket.bucket
+    mskCustomPluginArn         = aws_mskconnect_custom_plugin.plugin.arn,
+    mskCustomPluginRevision    = aws_mskconnect_custom_plugin.plugin.latest_revision
+    mskS3LogBucket             = data.aws_s3_bucket.mskconnect_logs_bucket.bucket
     mskServiceExecutionRoleArn = aws_iam_role.connector_role.arn
-    mskVpcSG = aws_security_group.dragonfly_msk_1.id
-    mskVpcSubnets = join(",", data.aws_subnets.msk_subnets.ids)
+    mskVpcSG                   = aws_security_group.dragonfly_msk_1.id
+    mskVpcSubnets              = join(",", data.aws_subnets.msk_subnets.ids)
   })
 
   provider = vault.dragonfly

--- a/aws_dragonfly-prod_us-east-2_msk_dragonfly-prod-msk-1_kafka-connect.tf
+++ b/aws_dragonfly-prod_us-east-2_msk_dragonfly-prod-msk-1_kafka-connect.tf
@@ -1,0 +1,139 @@
+resource "aws_mskconnect_custom_plugin" "plugin" {
+  name = "${local.arango_connector_plugin_name}-plugin"
+  content_type = "JAR"
+  location {
+    s3 {
+      bucket_arn = data.aws_s3_bucket.mskconnect_custom_plugin_bucket.arn
+      file_key = data.aws_s3_object.arangodb_connector_plugin_jar.key
+    }
+  }
+}
+
+resource "aws_iam_role" "connector_role" {
+  name = "${local.arango_connector_plugin_name}-role"
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        "Effect" = "Allow",
+        "Principal": {
+          "Service" = "kafkaconnect.amazonaws.com"
+        },
+        "Action" = "sts:AssumeRole"
+      }
+    ]
+  })
+}
+
+data "aws_iam_policy_document" "connector_role_policy_document" {
+  statement {
+    effect = "Allow"
+
+    actions = [
+      "kafka-cluster:Connect",
+      "kafka-cluster:AlterCluster",
+      "kafka-cluster:DescribeCluster",
+      "kafka:DescribeClusterV2",
+      "kafka:GetBootstrapBrokers"
+    ]
+
+    resources = [
+      aws_msk_cluster.dragonfly_msk_1.arn
+    ]
+  }
+
+  statement {
+    effect = "Allow"
+
+    actions = [
+      "kafka-cluster:*Topic*",
+      "kafka-cluster:ReadData"
+    ]
+
+    resources = [
+      "arn:aws:kafka:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:topic/${aws_msk_cluster.dragonfly_msk_1.cluster_name}/${aws_msk_cluster.dragonfly_msk_1.cluster_uuid}/*",
+    ]
+  }
+
+  statement {
+    actions = [
+      "kafka-cluster:CreateTopic",
+      "kafka-cluster:WriteData",
+      "kafka-cluster:ReadData",
+      "kafka-cluster:DescribeTopic"
+    ]
+
+    resources = [
+      "arn:aws:kafka:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:topic/${aws_msk_cluster.dragonfly_msk_1.cluster_name}/${aws_msk_cluster.dragonfly_msk_1.cluster_uuid}/__amazon_msk_connect_*",
+    ]
+  }
+
+  statement {
+    effect = "Allow"
+
+    actions = [
+      "kafka-cluster:AlterGroup",
+      "kafka-cluster:DescribeGroup"
+    ]
+
+    resources = [
+      "arn:aws:kafka:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:group/${aws_msk_cluster.dragonfly_msk_1.cluster_name}/${aws_msk_cluster.dragonfly_msk_1.cluster_uuid}/__amazon_msk_connect_*",
+      "arn:aws:kafka:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:group/${aws_msk_cluster.dragonfly_msk_1.cluster_name}/${aws_msk_cluster.dragonfly_msk_1.cluster_uuid}/connect-*",
+    ]
+  }
+
+  statement {
+    effect = "Allow"
+
+    actions = [
+      "logs:CreateLogDelivery",
+      "logs:GetLogDelivery",
+      "logs:DescribeLogDelivery",
+      "logs:DeleteLogDelivery",
+      "logs:ListLogDeliveries"
+    ]
+
+    resources = [
+      "*"
+    ]
+  }
+
+statement {
+    effect = "Allow"
+
+    actions = [
+      "s3:PutObject"
+    ]
+
+    resources = [
+      "arn:aws:s3:::${local.arangodb_connector_logs_bucket}/*"
+    ]
+  }
+}
+
+resource "aws_iam_policy" "connector_role_policy" {
+  name        = "${local.arango_connector_plugin_name}-role-policy"
+  description = "Policies for arangodb connector role"
+  policy      = data.aws_iam_policy_document.connector_role_policy_document.json
+}
+
+resource "aws_iam_role_policy_attachment" "connector_role_policy_attachment" {
+  role       = aws_iam_role.connector_role.name
+  policy_arn = aws_iam_policy.connector_role_policy.arn
+}
+
+# Export useful information to Vault
+resource "vault_generic_secret" "kafka_connect_vault" {
+  path = "secret/prod/dragonfly-streaman/us/msk"
+
+  data_json = jsonencode({
+    mskCustomPluginArn = aws_mskconnect_custom_plugin.plugin.arn,
+    mskCustomPluginRevision = aws_mskconnect_custom_plugin.plugin.latest_revision
+    mskS3LogBucket = data.aws_s3_bucket.mskconnect_logs_bucket.bucket
+    mskServiceExecutionRoleArn = aws_iam_role.connector_role.arn
+    mskVpcSG = aws_security_group.dragonfly_msk_1.id
+    mskVpcSubnets = join(",", data.aws_subnets.msk_subnets.ids)
+  })
+
+  provider = vault.dragonfly
+}

--- a/aws_dragonfly-prod_us-east-2_msk_dragonfly-prod-msk-1_kms.tf
+++ b/aws_dragonfly-prod_us-east-2_msk_dragonfly-prod-msk-1_kms.tf
@@ -1,0 +1,3 @@
+resource "aws_kms_key" "encryption_key" {
+  description = "dragonfly-msk-prod-1 MSK cluster encryption key"
+}

--- a/aws_dragonfly-prod_us-east-2_msk_dragonfly-prod-msk-1_locals.tf
+++ b/aws_dragonfly-prod_us-east-2_msk_dragonfly-prod-msk-1_locals.tf
@@ -1,0 +1,10 @@
+locals {
+  aws_account_name = "dragonfly-prod"
+  aws_region       = "us-east-2"
+
+  arango_connector_plugin_name      = "kafka-connect-arangodb"
+  arango_connector_plugin_bucket    = "dragonfly-prod-binaries-repository"
+  arangodb_connector_logs_bucket    = "dragonfly-prod-kafka-connector-log-files"
+  arangodb_connector_plugin_version = "1.2.0"
+  arangodb_connector_plugin_jar     = "kafka-connect-arangodb-${local.arangodb_connector_plugin_version}.jar"
+}

--- a/aws_dragonfly-prod_us-east-2_msk_dragonfly-prod-msk-1_msk.tf
+++ b/aws_dragonfly-prod_us-east-2_msk_dragonfly-prod-msk-1_msk.tf
@@ -1,0 +1,154 @@
+resource "aws_msk_configuration" "configuration" {
+  kafka_versions = [var.kafka_version]
+  name           = "dragonfly-msk-prod-1"
+
+  server_properties = <<PROPERTIES
+auto.create.topics.enable = true
+PROPERTIES
+}
+
+resource "aws_msk_scram_secret_association" "msk_auth_credentials" {
+  cluster_arn = aws_msk_cluster.dragonfly_msk_1.arn
+  secret_arn_list = [
+    for s in aws_secretsmanager_secret.msk_auth_credentials : s.arn
+  ]
+
+  depends_on = [aws_secretsmanager_secret_version.msk_auth_credentials_1]
+}
+
+resource "aws_msk_cluster" "dragonfly_msk_1" {
+  cluster_name           = "dragonfly-msk-prod-1"
+  kafka_version          = var.kafka_version
+  number_of_broker_nodes = var.number_of_broker_nodes
+
+  // Broker configuration
+  broker_node_group_info {
+    instance_type = var.instance_type
+
+    client_subnets = data.aws_subnets.msk_subnets.ids
+
+    storage_info {
+      ebs_storage_info {
+        volume_size = 1000
+      }
+    }
+
+    // Turn on multi-vpc connectivity
+    connectivity_info {
+      vpc_connectivity {
+        client_authentication {
+          sasl {
+            scram = false
+            iam   = true
+          }
+        }
+      }
+    }
+
+    security_groups = [aws_security_group.dragonfly_msk_1.id]
+  }
+
+  // Encryption
+  encryption_info {
+    encryption_at_rest_kms_key_arn = aws_kms_key.encryption_key.arn
+
+    encryption_in_transit {
+      client_broker = "TLS"
+      in_cluster    = true
+    }
+  }
+
+  // Authentication
+  client_authentication {
+    sasl {
+      scram = true
+      iam   = true
+    }
+  }
+
+  // Cluster config
+  configuration_info {
+    arn      = aws_msk_configuration.configuration.arn
+    revision = aws_msk_configuration.configuration.latest_revision
+  }
+
+  // Monitoring && logging
+  open_monitoring {
+    prometheus {
+      jmx_exporter {
+        enabled_in_broker = true
+      }
+      node_exporter {
+        enabled_in_broker = true
+      }
+    }
+  }
+
+  enhanced_monitoring = "PER_TOPIC_PER_PARTITION"
+
+  logging_info {
+    broker_logs {
+      cloudwatch_logs {
+        enabled   = true
+        log_group = aws_cloudwatch_log_group.broker_logs.name
+      }
+    }
+  }
+}
+
+// Save brokers in vault
+resource "vault_generic_secret" "msk_brokers_sasl_scram" {
+  path = "secret/prod/msk/dragonfly-msk-1/brokers"
+
+  data_json = jsonencode({
+    brokers = aws_msk_cluster.dragonfly_msk_1.bootstrap_brokers_sasl_scram
+  })
+
+  provider = vault.dragonfly
+}
+
+resource "aws_msk_cluster_policy" "opensearch_ingestion_policy" {
+  cluster_arn = aws_msk_cluster.dragonfly_msk_1.arn
+
+  policy = jsonencode({
+    "Version" : "2012-10-17",
+    "Statement" : [
+      {
+        "Effect" : "Allow",
+        "Principal" : {
+          "Service" : "osis.amazonaws.com"
+        },
+        "Action" : [
+          "kafka:CreateVpcConnection",
+          "kafka:DescribeCluster",
+          "kafka:DescribeClusterV2"
+        ],
+        "Resource" : aws_msk_cluster.dragonfly_msk_1.arn
+      },
+      {
+        "Effect" : "Allow",
+        "Principal" : {
+          "Service" : "osis-pipelines.amazonaws.com"
+        },
+        "Action" : [
+          "kafka:CreateVpcConnection",
+          "kafka:GetBootstrapBrokers",
+          "kafka:DescribeCluster",
+          "kafka:DescribeClusterV2"
+        ],
+        "Resource" : aws_msk_cluster.dragonfly_msk_1.arn
+    }]
+  })
+}
+
+// Save brokers in vault
+resource "vault_generic_secret" "msk_brokers" {
+  path = "secret/prod/msk/${data.aws_region.current.name}/${aws_msk_cluster.dragonfly_msk_1.cluster_name}/brokers"
+
+  data_json = jsonencode({
+    brokers = aws_msk_cluster.dragonfly_msk_1.bootstrap_brokers_sasl_scram
+    brokers-iam = aws_msk_cluster.dragonfly_msk_1.bootstrap_brokers_sasl_iam
+  })
+
+  provider = vault.dragonfly
+}

--- a/aws_dragonfly-prod_us-east-2_msk_dragonfly-prod-msk-1_msk.tf
+++ b/aws_dragonfly-prod_us-east-2_msk_dragonfly-prod-msk-1_msk.tf
@@ -146,7 +146,7 @@ resource "vault_generic_secret" "msk_brokers" {
   path = "secret/prod/msk/${data.aws_region.current.name}/${aws_msk_cluster.dragonfly_msk_1.cluster_name}/brokers"
 
   data_json = jsonencode({
-    brokers = aws_msk_cluster.dragonfly_msk_1.bootstrap_brokers_sasl_scram
+    brokers     = aws_msk_cluster.dragonfly_msk_1.bootstrap_brokers_sasl_scram
     brokers-iam = aws_msk_cluster.dragonfly_msk_1.bootstrap_brokers_sasl_iam
   })
 

--- a/aws_dragonfly-prod_us-east-2_msk_dragonfly-prod-msk-1_outputs.tf
+++ b/aws_dragonfly-prod_us-east-2_msk_dragonfly-prod-msk-1_outputs.tf
@@ -1,0 +1,19 @@
+output "zookeeper_connect_string" {
+  value = aws_msk_cluster.dragonfly_msk_1.zookeeper_connect_string
+}
+
+output "bootstrap_brokers" {
+  value = aws_msk_cluster.dragonfly_msk_1.bootstrap_brokers
+}
+
+output "bootstrap_brokers_tls" {
+  value = aws_msk_cluster.dragonfly_msk_1.bootstrap_brokers_tls
+}
+
+output "bootstrap_brokers_sasl_iam" {
+  value = aws_msk_cluster.dragonfly_msk_1.bootstrap_brokers_sasl_iam
+}
+
+output "bootstrap_brokers_sasl_scram" {
+  value = aws_msk_cluster.dragonfly_msk_1.bootstrap_brokers_sasl_scram
+}

--- a/aws_dragonfly-prod_us-east-2_msk_dragonfly-prod-msk-1_providers.tf
+++ b/aws_dragonfly-prod_us-east-2_msk_dragonfly-prod-msk-1_providers.tf
@@ -1,0 +1,28 @@
+provider "aws" {
+  access_key = data.vault_generic_secret.aws_infra_credential.data["AWS_ACCESS_KEY_ID"]
+  secret_key = data.vault_generic_secret.aws_infra_credential.data["AWS_SECRET_ACCESS_KEY"]
+  region     = local.aws_region
+
+  default_tags {
+    tags = {
+      ApplicationName    = "dragonfly-msk-prod-1"
+      CiscoMailAlias     = "eti-sre-admins@cisco.com"
+      DataClassification = "Cisco Confidential"
+      DataTaxonomy       = "Cisco Operations Data"
+      Environment        = "Prod"
+      ResourceOwner      = "ETI SRE"
+    }
+  }
+}
+
+provider "vault" {
+  alias     = "eticloud"
+  address   = "https://keeper.cisco.com"
+  namespace = "eticloud"
+}
+
+provider "vault" {
+  alias     = "dragonfly"
+  address   = "https://keeper.cisco.com"
+  namespace = "eticloud/apps/dragonfly"
+}

--- a/aws_dragonfly-prod_us-east-2_msk_dragonfly-prod-msk-1_secretsmanager.tf
+++ b/aws_dragonfly-prod_us-east-2_msk_dragonfly-prod-msk-1_secretsmanager.tf
@@ -1,0 +1,47 @@
+// Generate random passwords
+resource "random_password" "password" {
+  for_each = var.kafka_clients
+
+  length  = 64
+  special = false
+}
+
+// Save secrets in Vault
+resource "vault_generic_secret" "msk_auth_credentials" {
+  for_each = var.kafka_clients
+
+  path = each.value.vault_path
+
+  data_json = jsonencode({
+    username = each.key
+    password = random_password.password[each.key].result
+  })
+
+  provider = vault.dragonfly
+}
+
+// Secrets for SASL/SCRAM authentication
+resource "aws_secretsmanager_secret" "msk_auth_credentials" {
+  for_each = var.kafka_clients
+
+  name        = "AmazonMSK_dragonfly-msk-1-${each.key}-auth"
+  description = each.value.description
+
+  kms_key_id = aws_kms_key.encryption_key.key_id
+}
+
+// Secret versions
+resource "aws_secretsmanager_secret_version" "msk_auth_credentials_1" {
+  for_each = var.kafka_clients
+
+  secret_id     = aws_secretsmanager_secret.msk_auth_credentials[each.key].id
+  secret_string = vault_generic_secret.msk_auth_credentials[each.key].data_json
+}
+
+// Secret policy
+resource "aws_secretsmanager_secret_policy" "msk_secret_policy" {
+  for_each = var.kafka_clients
+
+  secret_arn = aws_secretsmanager_secret.msk_auth_credentials[each.key].arn
+  policy     = data.aws_iam_policy_document.msk_secret_policy[each.key].json
+}

--- a/aws_dragonfly-prod_us-east-2_msk_dragonfly-prod-msk-1_securitygroup.tf
+++ b/aws_dragonfly-prod_us-east-2_msk_dragonfly-prod-msk-1_securitygroup.tf
@@ -1,0 +1,80 @@
+locals {
+  msk_ingress_rules = [
+    {
+      from_port : 9094,
+      to_port : 9094,
+      protocol : "tcp",
+      cidr_blocks : [
+        data.aws_vpc.msk_vpc.cidr_block,
+        data.aws_vpc.eks_vpc.cidr_block,
+      ],
+    },
+    {
+      from_port : 9096,
+      to_port : 9096,
+      protocol : "tcp",
+      cidr_blocks : [
+        data.aws_vpc.msk_vpc.cidr_block,
+        data.aws_vpc.eks_vpc.cidr_block,
+      ],
+    },
+    {
+      from_port : 9098,
+      to_port : 9098,
+      protocol : "tcp",
+      cidr_blocks : [
+        data.aws_vpc.msk_vpc.cidr_block,
+        data.aws_vpc.eks_vpc.cidr_block,
+      ],
+    },
+    {
+      from_port : 2181,
+      to_port : 2181,
+      protocol : "tcp",
+      cidr_blocks : [
+        data.aws_vpc.msk_vpc.cidr_block,
+      ],
+    },
+  ]
+
+  msk_egress_rules = [
+    {
+      from_port : 0,
+      to_port : 65535,
+      protocol : "tcp",
+      cidr_blocks : [
+        data.aws_vpc.msk_vpc.cidr_block,
+        data.aws_vpc.eks_vpc.cidr_block,
+      ],
+    },
+  ]
+}
+
+
+resource "aws_security_group" "dragonfly_msk_1" {
+  name        = "dragonfly-msk-prod-1-msk-default"
+  description = "dragonfly-msk-prod-1 MSK cluster default security group"
+  vpc_id      = data.aws_vpc.msk_vpc.id
+
+  dynamic "ingress" {
+    for_each = toset(local.msk_ingress_rules)
+
+    content {
+      from_port   = ingress.value.from_port
+      to_port     = ingress.value.to_port
+      protocol    = ingress.value.protocol
+      cidr_blocks = ingress.value.cidr_blocks
+    }
+  }
+
+  dynamic "egress" {
+    for_each = toset(local.msk_egress_rules)
+
+    content {
+      from_port   = egress.value.from_port
+      to_port     = egress.value.to_port
+      protocol    = egress.value.protocol
+      cidr_blocks = egress.value.cidr_blocks
+    }
+  }
+}

--- a/aws_dragonfly-prod_us-east-2_msk_dragonfly-prod-msk-1_variables.tf
+++ b/aws_dragonfly-prod_us-east-2_msk_dragonfly-prod-msk-1_variables.tf
@@ -1,0 +1,39 @@
+variable "kafka_version" {
+  description = "Kafka version to deploy"
+  type        = string
+  default     = "3.6.0"
+}
+
+variable "instance_type" {
+  description = "Instance type to use for Kafka brokers"
+  type        = string
+  default     = "kafka.m5.xlarge"
+}
+
+variable "number_of_broker_nodes" {
+  description = "Number of Kafka broker nodes to deploy"
+  type        = number
+  default     = 3
+}
+
+variable "kafka_clients" {
+  description = "Kafka clients to create"
+  type = map(object({
+    description = string
+    vault_path  = string
+  }))
+  default = {
+    "otel-collector" = {
+      description = "Auth credentials of otel-collector for dragonfly-msk-prod-1"
+      vault_path  = "secret/prod/msk/dragonfly-msk-1/kafka-clients/otel-collector"
+    },
+    "notification-service" = {
+      description = "Auth credentials of notification-service for dragonfly-msk-prod-1"
+      vault_path  = "secret/prod/msk/dragonfly-msk-1/kafka-clients/notification-service"
+    },
+    "opensearch-ingestion-service" = {
+      description = "Auth credentials of ingestion-service for dragonfly-msk-prod-1"
+      vault_path  = "secret/prod/msk/dragonfly-msk-1/kafka-clients/opensearch-ingestion-service"
+    },
+  }
+}

--- a/aws_dragonfly-prod_us-east-2_msk_dragonfly-prod-msk-1_versions.tf
+++ b/aws_dragonfly-prod_us-east-2_msk_dragonfly-prod-msk-1_versions.tf
@@ -1,0 +1,18 @@
+terraform {
+  required_version = ">= 1.3.6"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+    vault = {
+      source  = "hashicorp/vault"
+      version = "~> 3.0"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = "~> 3.0"
+    }
+  }
+}

--- a/aws_dragonfly-staging_eu-west-1_msk_dragonfly-staging-msk-1_backend.tf
+++ b/aws_dragonfly-staging_eu-west-1_msk_dragonfly-staging-msk-1_backend.tf
@@ -1,0 +1,7 @@
+terraform {
+  backend "s3" {
+    bucket = "eticloud-tf-state-nonprod"
+    key    = "terraform-state/aws-dragonfly-staging/msk/eu-west-1/dragonfly-staging-msk-1.tfstate"
+    region = "us-east-2"
+  }
+}

--- a/aws_dragonfly-staging_eu-west-1_msk_dragonfly-staging-msk-1_cloudwatch.tf
+++ b/aws_dragonfly-staging_eu-west-1_msk_dragonfly-staging-msk-1_cloudwatch.tf
@@ -1,0 +1,3 @@
+resource "aws_cloudwatch_log_group" "broker_logs" {
+  name = "dragonfly-staging-msk-1-broker-logs"
+}

--- a/aws_dragonfly-staging_eu-west-1_msk_dragonfly-staging-msk-1_dependencies.tf
+++ b/aws_dragonfly-staging_eu-west-1_msk_dragonfly-staging-msk-1_dependencies.tf
@@ -1,0 +1,65 @@
+data "vault_generic_secret" "aws_infra_credential" {
+  path     = "secret/infra/aws/${local.aws_account_name}/terraform_admin"
+  provider = vault.eticloud
+}
+
+data "aws_caller_identity" "current" {}
+data "aws_region" "current" {}
+
+data "vault_generic_secret" "msk_auth_credentials" {
+  for_each = var.kafka_clients
+
+  path     = each.value.vault_path
+  provider = vault.dragonfly
+}
+
+data "aws_iam_policy_document" "msk_secret_policy" {
+  for_each = var.kafka_clients
+
+  statement {
+    sid    = "AWSKafkaResourcePolicy"
+    effect = "Allow"
+
+    principals {
+      type        = "Service"
+      identifiers = ["kafka.amazonaws.com"]
+    }
+
+    actions   = ["secretsmanager:getSecretValue"]
+    resources = [aws_secretsmanager_secret.msk_auth_credentials[each.key].arn]
+  }
+}
+
+data "aws_vpc" "eks_vpc" {
+  filter {
+    name   = "tag:Name"
+    values = ["dragonfly-compute-staging-1-vpc"]
+  }
+}
+
+data "aws_vpc" "msk_vpc" {
+  filter {
+    name   = "tag:Name"
+    values = ["dragonfly-data-staging-1-vpc"]
+  }
+}
+
+data "aws_subnets" "eks_subnets" {
+  filter {
+    name   = "vpc-id"
+    values = [data.aws_vpc.eks_vpc.id]
+  }
+  tags = {
+    Tier = "Private"
+  }
+}
+
+data "aws_subnets" "msk_subnets" {
+  filter {
+    name   = "vpc-id"
+    values = [data.aws_vpc.msk_vpc.id]
+  }
+  tags = {
+    Tier = "Private"
+  }
+}

--- a/aws_dragonfly-staging_eu-west-1_msk_dragonfly-staging-msk-1_kafka-connect.tf
+++ b/aws_dragonfly-staging_eu-west-1_msk_dragonfly-staging-msk-1_kafka-connect.tf
@@ -6,7 +6,7 @@ resource "aws_iam_role" "connector_role" {
     "Statement" : [
       {
         "Effect" = "Allow",
-        "Principal": {
+        "Principal" : {
           "Service" = "kafkaconnect.amazonaws.com"
         },
         "Action" = "sts:AssumeRole",

--- a/aws_dragonfly-staging_eu-west-1_msk_dragonfly-staging-msk-1_kafka-connect.tf
+++ b/aws_dragonfly-staging_eu-west-1_msk_dragonfly-staging-msk-1_kafka-connect.tf
@@ -1,0 +1,117 @@
+resource "aws_iam_role" "connector_role" {
+  name = "${local.connector_name}-role"
+
+  assume_role_policy = jsonencode({
+    "Version" : "2012-10-17"
+    "Statement" : [
+      {
+        "Effect" = "Allow",
+        "Principal": {
+          "Service" = "kafkaconnect.amazonaws.com"
+        },
+        "Action" = "sts:AssumeRole",
+      }
+    ]
+  })
+  force_detach_policies = true
+}
+
+data "aws_iam_policy_document" "connector_role_policy" {
+  statement {
+    actions = [
+      "kafka-cluster:Connect",
+      "kafka-cluster:AlterCluster",
+      "kafka-cluster:DescribeCluster",
+      "kafka:DescribeClusterV2",
+      "kafka:GetBootstrapBrokers"
+    ]
+
+    resources = [
+      "${aws_msk_cluster.dragonfly-msk-1.arn}:connector/*"
+    ]
+
+    effect = "Allow"
+  }
+
+  statement {
+    actions = [
+      "kafka-cluster:*Topic*",
+      "kafka-cluster:ReadData"
+    ]
+
+    resources = [
+      "arn:aws:kafka:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:topic/${aws_msk_cluster.dragonfly-msk-1.cluster_name}/${aws_msk_cluster.dragonfly-msk-1.cluster_uuid}/*"
+    ]
+
+    effect = "Allow"
+  }
+
+  statement {
+    actions = [
+      "kafka-cluster:CreateTopic",
+      "kafka-cluster:WriteData",
+      "kafka-cluster:ReadData",
+      "kafka-cluster:DescribeTopic"
+    ]
+
+    resources = [
+      "arn:aws:kafka:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:topic/${aws_msk_cluster.dragonfly-msk-1.cluster_name}/${aws_msk_cluster.dragonfly-msk-1.cluster_uuid}/__amazon_msk_connect_*"
+    ]
+
+    effect = "Allow"
+  }
+
+  statement {
+    actions = [
+      "kafka-cluster:AlterGroup",
+      "kafka-cluster:DescribeGroup"
+    ]
+
+    resources = [
+      "arn:aws:kafka:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:group/${aws_msk_cluster.dragonfly-msk-1.cluster_name}/${aws_msk_cluster.dragonfly-msk-1.cluster_uuid}/*",
+      # "arn:aws:kafka:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:group/${aws_msk_cluster.dragonfly-msk-1.cluster_name}/${aws_msk_cluster.dragonfly-msk-1.cluster_uuid}/__amazon_msk_connect_*",
+      # "arn:aws:kafka:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:group/${aws_msk_cluster.dragonfly-msk-1.cluster_name}/${aws_msk_cluster.dragonfly-msk-1.cluster_uuid}/connect-*"
+    ]
+
+    effect = "Allow"
+  }
+
+  statement {
+    actions = [
+      "logs:CreateLogDelivery",
+      "logs:GetLogDelivery",
+      "logs:DescribeLogDelivery",
+      "logs:DeleteLogDelivery",
+      "logs:ListLogDeliveries"
+    ]
+
+    resources = [
+      "*"
+    ]
+
+    effect = "Allow"
+  }
+
+  statement {
+    actions = [
+      "s3:PutObject"
+    ]
+
+    resources = [
+      "arn:aws:s3:::${local.connector_name}-logs/*"
+    ]
+
+    effect = "Allow"
+  }
+}
+
+resource "aws_iam_policy" "connector_role_policy" {
+  name        = "${local.connector_name}-role-policy"
+  description = "Policies for msk connector"
+  policy      = data.aws_iam_policy_document.connector_role_policy.json
+}
+
+resource "aws_iam_role_policy_attachment" "dragonfly_msk_connector_role_policy_attachment" {
+  role       = aws_iam_role.connector_role.name
+  policy_arn = aws_iam_policy.connector_role_policy.arn
+}

--- a/aws_dragonfly-staging_eu-west-1_msk_dragonfly-staging-msk-1_kms.tf
+++ b/aws_dragonfly-staging_eu-west-1_msk_dragonfly-staging-msk-1_kms.tf
@@ -1,0 +1,3 @@
+resource "aws_kms_key" "encryption_key" {
+  description = "dragonfly-staging-msk-1 MSK cluster encryption key"
+}

--- a/aws_dragonfly-staging_eu-west-1_msk_dragonfly-staging-msk-1_locals.tf
+++ b/aws_dragonfly-staging_eu-west-1_msk_dragonfly-staging-msk-1_locals.tf
@@ -1,5 +1,5 @@
 locals {
-    aws_account_name = "dragonfly-staging"
+  aws_account_name = "dragonfly-staging"
 
-    connector_name = "kafka-connect-arangodb"
+  connector_name = "kafka-connect-arangodb"
 }

--- a/aws_dragonfly-staging_eu-west-1_msk_dragonfly-staging-msk-1_locals.tf
+++ b/aws_dragonfly-staging_eu-west-1_msk_dragonfly-staging-msk-1_locals.tf
@@ -1,0 +1,5 @@
+locals {
+    aws_account_name = "dragonfly-staging"
+
+    connector_name = "kafka-connect-arangodb"
+}

--- a/aws_dragonfly-staging_eu-west-1_msk_dragonfly-staging-msk-1_msk.tf
+++ b/aws_dragonfly-staging_eu-west-1_msk_dragonfly-staging-msk-1_msk.tf
@@ -1,0 +1,143 @@
+resource "aws_msk_configuration" "configuration" {
+  kafka_versions = [var.kafka_version]
+  name           = "dragonfly-staging-msk-1"
+
+  server_properties = <<PROPERTIES
+auto.create.topics.enable = true
+PROPERTIES
+}
+
+resource "aws_msk_scram_secret_association" "msk_auth_credentials" {
+  cluster_arn = aws_msk_cluster.dragonfly-msk-1.arn
+  secret_arn_list = [
+    for s in aws_secretsmanager_secret.msk_auth_credentials : s.arn
+  ]
+
+  depends_on = [aws_secretsmanager_secret_version.msk_auth_credentials_1]
+}
+
+resource "aws_msk_cluster" "dragonfly-msk-1" {
+  cluster_name           = "dragonfly-staging-msk-1"
+  kafka_version          = var.kafka_version
+  number_of_broker_nodes = var.number_of_broker_nodes
+
+  // Broker configuration
+  broker_node_group_info {
+    instance_type = var.instance_type
+
+    client_subnets = data.aws_subnets.msk_subnets.ids
+
+    storage_info {
+      ebs_storage_info {
+        volume_size = 1000
+      }
+    }
+
+    // Turn on multi-vpc connectivity
+    connectivity_info {
+      vpc_connectivity {
+        client_authentication {
+          sasl {
+            scram = false
+            iam   = true
+          }
+        }
+      }
+    }
+
+    security_groups = [aws_security_group.dragonfly-msk-1.id]
+  }
+
+  // Encryption
+  encryption_info {
+    encryption_at_rest_kms_key_arn = aws_kms_key.encryption_key.arn
+
+    encryption_in_transit {
+      client_broker = "TLS"
+      in_cluster    = true
+    }
+  }
+
+  // Authentication
+  client_authentication {
+    sasl {
+      scram = true
+      iam   = true
+    }
+  }
+
+  // Cluster config
+  configuration_info {
+    arn      = aws_msk_configuration.configuration.arn
+    revision = aws_msk_configuration.configuration.latest_revision
+  }
+
+  // Monitoring && logging
+  open_monitoring {
+    prometheus {
+      jmx_exporter {
+        enabled_in_broker = true
+      }
+      node_exporter {
+        enabled_in_broker = true
+      }
+    }
+  }
+
+  enhanced_monitoring = "PER_TOPIC_PER_PARTITION"
+
+  logging_info {
+    broker_logs {
+      cloudwatch_logs {
+        enabled   = true
+        log_group = aws_cloudwatch_log_group.broker_logs.name
+      }
+    }
+  }
+}
+
+resource "aws_msk_cluster_policy" "opensearch_ingestion_policy" {
+  cluster_arn = aws_msk_cluster.dragonfly-msk-1.arn
+
+  policy = jsonencode({
+    "Version" : "2012-10-17",
+    "Statement" : [
+      {
+        "Effect" : "Allow",
+        "Principal" : {
+          "Service" : "osis.amazonaws.com"
+        },
+        "Action" : [
+          "kafka:CreateVpcConnection",
+          "kafka:DescribeCluster",
+          "kafka:DescribeClusterV2"
+        ],
+        "Resource" : aws_msk_cluster.dragonfly-msk-1.arn
+      },
+      {
+        "Effect" : "Allow",
+        "Principal" : {
+          "Service" : "osis-pipelines.amazonaws.com"
+        },
+        "Action" : [
+          "kafka:CreateVpcConnection",
+          "kafka:GetBootstrapBrokers",
+          "kafka:DescribeCluster",
+          "kafka:DescribeClusterV2"
+        ],
+        "Resource" : aws_msk_cluster.dragonfly-msk-1.arn
+    }]
+  })
+}
+
+// Save brokers in vault
+resource "vault_generic_secret" "msk_brokers" {
+  path = "secret/staging/msk/dragonfly-msk-1/brokers"
+
+  data_json = jsonencode({
+    brokers = aws_msk_cluster.dragonfly-msk-1.bootstrap_brokers_sasl_scram
+    brokers-iam = aws_msk_cluster.dragonfly-msk-1.bootstrap_brokers_sasl_iam
+  })
+
+  provider = vault.dragonfly
+}

--- a/aws_dragonfly-staging_eu-west-1_msk_dragonfly-staging-msk-1_msk.tf
+++ b/aws_dragonfly-staging_eu-west-1_msk_dragonfly-staging-msk-1_msk.tf
@@ -135,7 +135,7 @@ resource "vault_generic_secret" "msk_brokers" {
   path = "secret/staging/msk/dragonfly-msk-1/brokers"
 
   data_json = jsonencode({
-    brokers = aws_msk_cluster.dragonfly-msk-1.bootstrap_brokers_sasl_scram
+    brokers     = aws_msk_cluster.dragonfly-msk-1.bootstrap_brokers_sasl_scram
     brokers-iam = aws_msk_cluster.dragonfly-msk-1.bootstrap_brokers_sasl_iam
   })
 

--- a/aws_dragonfly-staging_eu-west-1_msk_dragonfly-staging-msk-1_outputs.tf
+++ b/aws_dragonfly-staging_eu-west-1_msk_dragonfly-staging-msk-1_outputs.tf
@@ -1,0 +1,11 @@
+output "zookeeper_connect_string" {
+  value = aws_msk_cluster.dragonfly-msk-1.zookeeper_connect_string
+}
+
+output "bootstrap_brokers" {
+  value = aws_msk_cluster.dragonfly-msk-1.bootstrap_brokers
+}
+
+output "bootstrap_brokers_tls" {
+  value = aws_msk_cluster.dragonfly-msk-1.bootstrap_brokers_tls
+}

--- a/aws_dragonfly-staging_eu-west-1_msk_dragonfly-staging-msk-1_providers.tf
+++ b/aws_dragonfly-staging_eu-west-1_msk_dragonfly-staging-msk-1_providers.tf
@@ -1,0 +1,28 @@
+provider "aws" {
+  access_key = data.vault_generic_secret.aws_infra_credential.data["AWS_ACCESS_KEY_ID"]
+  secret_key = data.vault_generic_secret.aws_infra_credential.data["AWS_SECRET_ACCESS_KEY"]
+  region     = "eu-west-1"
+
+  default_tags {
+    tags = {
+      ApplicationName    = "dragonfly-staging-msk-1"
+      CiscoMailAlias     = "eti-sre-admins@cisco.com"
+      DataClassification = "Cisco Confidential"
+      DataTaxonomy       = "Cisco Operations Data"
+      Environment        = "NonProd"
+      ResourceOwner      = "ETI SRE"
+    }
+  }
+}
+
+provider "vault" {
+  alias     = "eticloud"
+  address   = "https://keeper.cisco.com"
+  namespace = "eticloud"
+}
+
+provider "vault" {
+  alias     = "dragonfly"
+  address   = "https://keeper.cisco.com"
+  namespace = "eticloud/apps/dragonfly"
+}

--- a/aws_dragonfly-staging_eu-west-1_msk_dragonfly-staging-msk-1_secretsmanager.tf
+++ b/aws_dragonfly-staging_eu-west-1_msk_dragonfly-staging-msk-1_secretsmanager.tf
@@ -1,0 +1,25 @@
+// Secrets for SASL/SCRAM authentication
+resource "aws_secretsmanager_secret" "msk_auth_credentials" {
+  for_each = var.kafka_clients
+
+  name        = "AmazonMSK_dragonfly-staging-msk-1-${each.key}-auth"
+  description = each.value.description
+
+  kms_key_id = aws_kms_key.encryption_key.key_id
+}
+
+// Secret versions
+resource "aws_secretsmanager_secret_version" "msk_auth_credentials_1" {
+  for_each = var.kafka_clients
+
+  secret_id     = aws_secretsmanager_secret.msk_auth_credentials[each.key].id
+  secret_string = data.vault_generic_secret.msk_auth_credentials[each.key].data_json
+}
+
+// Secret policy
+resource "aws_secretsmanager_secret_policy" "msk_secret_policy" {
+  for_each = var.kafka_clients
+
+  secret_arn = aws_secretsmanager_secret.msk_auth_credentials[each.key].arn
+  policy     = data.aws_iam_policy_document.msk_secret_policy[each.key].json
+}

--- a/aws_dragonfly-staging_eu-west-1_msk_dragonfly-staging-msk-1_securitygroup.tf
+++ b/aws_dragonfly-staging_eu-west-1_msk_dragonfly-staging-msk-1_securitygroup.tf
@@ -1,0 +1,80 @@
+locals {
+  msk_ingress_rules = [
+    {
+      from_port : 9094,
+      to_port : 9094,
+      protocol : "tcp",
+      cidr_blocks : [
+        data.aws_vpc.msk_vpc.cidr_block,
+        data.aws_vpc.eks_vpc.cidr_block,
+      ],
+    },
+    {
+      from_port : 9096,
+      to_port : 9096,
+      protocol : "tcp",
+      cidr_blocks : [
+        data.aws_vpc.msk_vpc.cidr_block,
+        data.aws_vpc.eks_vpc.cidr_block,
+      ],
+    },
+    {
+      from_port : 9098,
+      to_port : 9098,
+      protocol : "tcp",
+      cidr_blocks : [
+        data.aws_vpc.msk_vpc.cidr_block,
+        data.aws_vpc.eks_vpc.cidr_block,
+      ],
+    },
+    {
+      from_port : 2181,
+      to_port : 2181,
+      protocol : "tcp",
+      cidr_blocks : [
+        data.aws_vpc.msk_vpc.cidr_block,
+      ],
+    },
+  ]
+
+  msk_egress_rules = [
+    {
+      from_port : 0,
+      to_port : 65535,
+      protocol : "tcp",
+      cidr_blocks : [
+        data.aws_vpc.msk_vpc.cidr_block,
+        data.aws_vpc.eks_vpc.cidr_block,
+      ],
+    },
+  ]
+}
+
+
+resource "aws_security_group" "dragonfly-msk-1" {
+  name        = "dragonfly-staging-msk-1-msk-default"
+  description = "dragonfly-staging-msk-1 MSK cluster default security group"
+  vpc_id      = data.aws_vpc.msk_vpc.id
+
+  dynamic "ingress" {
+    for_each = toset(local.msk_ingress_rules)
+
+    content {
+      from_port   = ingress.value.from_port
+      to_port     = ingress.value.to_port
+      protocol    = ingress.value.protocol
+      cidr_blocks = ingress.value.cidr_blocks
+    }
+  }
+
+  dynamic "egress" {
+    for_each = toset(local.msk_egress_rules)
+
+    content {
+      from_port   = egress.value.from_port
+      to_port     = egress.value.to_port
+      protocol    = egress.value.protocol
+      cidr_blocks = egress.value.cidr_blocks
+    }
+  }
+}

--- a/aws_dragonfly-staging_eu-west-1_msk_dragonfly-staging-msk-1_variables.tf
+++ b/aws_dragonfly-staging_eu-west-1_msk_dragonfly-staging-msk-1_variables.tf
@@ -1,0 +1,39 @@
+variable "kafka_version" {
+  description = "Kafka version to deploy"
+  type        = string
+  default     = "3.6.0"
+}
+
+variable "instance_type" {
+  description = "Instance type to use for Kafka brokers"
+  type        = string
+  default     = "kafka.m5.large"
+}
+
+variable "number_of_broker_nodes" {
+  description = "Number of Kafka broker nodes to deploy"
+  type        = number
+  default     = 3
+}
+
+variable "kafka_clients" {
+  description = "Kafka clients to create"
+  type = map(object({
+    description = string
+    vault_path  = string
+  }))
+  default = {
+    "otel-collector" = {
+      description = "Auth credentials of otel-collector for dragonfly-msk-1"
+      vault_path  = "secret/staging/msk/dragonfly-msk-1/kafka-clients/otel-collector"
+    },
+    "notification-service" = {
+      description = "Auth credentials of notification-service for dragonfly-msk-1"
+      vault_path  = "secret/staging/msk/dragonfly-msk-1/kafka-clients/notification-service"
+    },
+    "opensearch-ingestion-service" = {
+      description = "Auth credentials of ingestion-service for dragonfly-msk-1"
+      vault_path  = "secret/staging/msk/dragonfly-msk-1/kafka-clients/opensearch-ingestion-service"
+    },
+  }
+}

--- a/aws_dragonfly-staging_eu-west-1_msk_dragonfly-staging-msk-1_versions.tf
+++ b/aws_dragonfly-staging_eu-west-1_msk_dragonfly-staging-msk-1_versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.3.6"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+}


### PR DESCRIPTION
## Migration of MSK clusters from [sre-tf-infra](https://wwwin-github.cisco.com/eti/sre-tf-infra)

### Description/Justification

This PR is part of the effort of moving the tf configuration of aws managed infra from [sre-tf-infra](https://wwwin-github.cisco.com/eti/sre-tf-infra) to this repo.

### If the (atlantis) plan is destroying resources, reason for deletion  

No apply should be run as part of this PR.

### Additional details

- [x] `terraform fmt` was applied
- [ ] All atlantis plans can be applied
- [ ] (For reviewers) I have verified the resource changes
