### PR TITLE
chore(dragonfly): move VPCs from sre-tf-infra

### DIFF
--- a/aws_apisec-dev_us-east-2_eks_apisec-systest-dev_argocd.tf
+++ b/aws_apisec-dev_us-east-2_eks_apisec-systest-dev_argocd.tf
@@ -1,0 +1,30 @@
+# This file was created by Outshift Platform Self-Service automation.
+
+data "vault_generic_secret" "aws_argocd_infra_credential" {
+  provider = vault.eticloud
+  path     = "secret/infra/aws/${local.argocd_aws_account}/terraform_admin"
+}
+
+provider "aws" {
+  alias       = "argocd"
+  access_key  = data.vault_generic_secret.aws_argocd_infra_credential.data["AWS_ACCESS_KEY_ID"]
+  secret_key  = data.vault_generic_secret.aws_argocd_infra_credential.data["AWS_SECRET_ACCESS_KEY"]
+  region      = "us-east-2"
+  max_retries = 3
+}
+
+module "argocd" {
+  source            = "git::https://github.com/cisco-eti/sre-tf-module-argo-cluster-enrollment?ref=0.1.1"
+  eks_cluster_name  = local.name
+  eks_cluster_host  = data.aws_eks_cluster.eks.endpoint
+  eks_cluster_ca    = data.aws_eks_cluster.eks.certificate_authority[0].data
+  eks_cluster_token = data.aws_eks_cluster_auth.eks.token
+
+  argocd_cluster_host  = data.aws_eks_cluster.argocd.endpoint
+  argocd_cluster_token = data.aws_eks_cluster_auth.argocd.token
+  argocd_cluster_ca    = data.aws_eks_cluster.argocd.certificate_authority[0].data
+  providers = {
+    aws.eks    = aws.eks
+    aws.argocd = aws.argocd
+  }
+}

--- a/aws_apisec-dev_us-east-2_eks_apisec-systest-dev_backend.tf
+++ b/aws_apisec-dev_us-east-2_eks_apisec-systest-dev_backend.tf
@@ -1,0 +1,15 @@
+# This file was created by Outshift Platform Self-Service automation.
+terraform {
+  backend "s3" {
+    # We separate the different levels of development into different buckets.
+    # The buckets are eticloud-tf-state-sandbox, eticloud-tf-state-nonprod, eticloud-tf-state-prod.
+    # The environment should match the CSBEnvironment below.
+    bucket = "eticloud-tf-state-nonprod"
+
+    # note the path here. It should match the pattern terraform_state/<service>/<region>/<name>.tfstate
+    key = "terraform-state/apisec-dev/us-east-2/eks/apisec-systest-dev.tfstate"
+
+    # This is the region where the backend S3 bucket is located. SRE team default, Do not change.
+    region = "us-east-2"
+  }
+}

--- a/aws_apisec-dev_us-east-2_eks_apisec-systest-dev_data.tf
+++ b/aws_apisec-dev_us-east-2_eks_apisec-systest-dev_data.tf
@@ -1,0 +1,23 @@
+data "aws_eks_cluster" "eks" {
+  name       = local.name
+  provider   = aws.eks
+  depends_on = [module.eks_all_in_one]
+}
+
+data "aws_eks_cluster_auth" "eks" {
+  name       = local.name
+  provider   = aws.eks
+  depends_on = [module.eks_all_in_one]
+}
+
+data "aws_eks_cluster" "argocd" {
+  name       = local.argocd_k8s_name
+  provider   = aws.argocd
+  depends_on = [module.eks_all_in_one]
+}
+
+data "aws_eks_cluster_auth" "argocd" {
+  name       = local.argocd_k8s_name
+  provider   = aws.argocd
+  depends_on = [module.eks_all_in_one]
+}

--- a/aws_apisec-dev_us-east-2_eks_apisec-systest-dev_eso.tf
+++ b/aws_apisec-dev_us-east-2_eks_apisec-systest-dev_eso.tf
@@ -1,0 +1,15 @@
+# This file was created by Outshift Platform Self-Service automation.
+data "vault_generic_secret" "cluster_certificate" {
+  path       = "secret/infra/eks/${local.name}/certificate"
+  depends_on = [module.eks_all_in_one]
+}
+
+module "eso_eticloud" {
+  source = "git::https://github.com/cisco-eti/sre-tf-module-eso-access.git?ref=1.0.0"
+
+  cluster_name    = local.name
+  vault_namespace = "eticloud"
+  kubernetes_host = data.aws_eks_cluster.eks.endpoint
+  kubernetes_ca   = base64decode(data.vault_generic_secret.cluster_certificate.data["b64certificate"])
+  policies        = ["external-secrets-dev"]
+}

--- a/aws_apisec-dev_us-east-2_eks_apisec-systest-dev_locals.tf
+++ b/aws_apisec-dev_us-east-2_eks_apisec-systest-dev_locals.tf
@@ -1,0 +1,9 @@
+# This file was created by Outshift Platform Self-Service automation.
+locals {
+  name               = "apisec-systest-dev"
+  region             = "us-east-2"
+  eks_aws_account    = "apisec-dev"
+  vpc_cidr           = "10.10.0.0/16"
+  argocd_k8s_name    = "eks-gitops-cnapp-1"
+  argocd_aws_account = "eti-ci"
+}

--- a/aws_apisec-dev_us-east-2_eks_apisec-systest-dev_main.tf
+++ b/aws_apisec-dev_us-east-2_eks_apisec-systest-dev_main.tf
@@ -1,0 +1,22 @@
+# This file was created by Outshift Platform Self-Service automation.
+module "eks_all_in_one" {
+  source                 = "git::https://github.com/cisco-eti/sre-tf-module-eks-allinone.git?ref=latest"
+  name                   = local.name            # EKS cluster name
+  region                 = local.region          # AWS provider region
+  aws_account_name       = local.eks_aws_account # AWS account name
+  cidr                   = local.vpc_cidr        # VPC CIDR
+  cluster_version        = "1.29"                # EKS cluster version
+  bastion_instance_count = 1                     # Bastion instance count
+
+
+  # EKS Managed Private Node Group
+  instance_types          = ["m6a.xlarge"]
+  ami_type                = "CISCO_HARDENED_AL2"
+  skip_cisco_hardened_ami = "false"
+  min_size                = "3"
+  max_size                = "5"
+  desired_size            = "3"
+  create_karpenter_irsa   = "true"
+  create_alb_irsa         = "true"
+  create_otel_irsa        = "true"
+}

--- a/aws_apisec-dev_us-east-2_eks_apisec-systest-dev_provider.tf
+++ b/aws_apisec-dev_us-east-2_eks_apisec-systest-dev_provider.tf
@@ -1,0 +1,29 @@
+# This file was created by Outshift Platform Self-Service automation.
+provider "vault" {
+  alias     = "eticloud"
+  address   = "https://keeper.cisco.com"
+  namespace = "eticloud"
+}
+
+data "vault_generic_secret" "aws_infra_credential" {
+  provider = vault.eticloud
+  path     = "secret/infra/aws/${local.eks_aws_account}/terraform_admin"
+}
+
+provider "aws" {
+  alias       = "eks"
+  access_key  = data.vault_generic_secret.aws_infra_credential.data["AWS_ACCESS_KEY_ID"]
+  secret_key  = data.vault_generic_secret.aws_infra_credential.data["AWS_SECRET_ACCESS_KEY"]
+  region      = "us-east-2"
+  max_retries = 3
+  default_tags {
+    tags = {
+      ApplicationName    = "apisec-systest-dev"
+      CiscoMailAlias     = "eti-sre-admins@cisco.com"
+      DataClassification = "Cisco Restricted"
+      DataTaxonomy       = "Cisco Operations Data"
+      Environment        = "NonProd"
+      ResourceOwner      = "APISEC"
+    }
+  }
+}

--- a/aws_dragonfly-dev_eu-west-1_eks_dragonfly-dev-1-aws-alb-role_backend.tf
+++ b/aws_dragonfly-dev_eu-west-1_eks_dragonfly-dev-1-aws-alb-role_backend.tf
@@ -1,0 +1,7 @@
+terraform {
+  backend "s3" {
+    bucket = "eticloud-tf-state-nonprod"                                                                          # We separate the different environments into different buckets. The buckets are eticloud-tf-state-sandbox, eticloud-tf-state-nonprod, eticloud-tf-state-prod. The environment should match the CSBEnvironment below.
+    key    = "terraform-state/aws-dragonfly-dev-1/eks/eu-west-1/eks-dragonfly-dev-2-eks-eks-aws-alb-role.tfstate" # Note the path here. It should match the patten terraform_state/<service>/<region>/<name>.tfstate
+    region = "us-east-2"                                                                                          # Do not change
+  }
+}

--- a/aws_dragonfly-dev_eu-west-1_eks_dragonfly-dev-1-aws-alb-role_eks-alb-controller-role.tf
+++ b/aws_dragonfly-dev_eu-west-1_eks_dragonfly-dev-1-aws-alb-role_eks-alb-controller-role.tf
@@ -1,0 +1,44 @@
+data "aws_caller_identity" "current_alb" {}
+
+data "aws_eks_cluster" "cluster_alb" {
+  name = local.cluster_name_alb
+}
+locals {
+  cluster_name_alb = "eks-dragonfly-dev-2"
+  account_id_alb   = data.aws_caller_identity.current_alb.account_id
+  oidc_id_alb      = trimprefix(data.aws_eks_cluster.cluster_alb.identity[0].oidc[0].issuer, "https://")
+}
+
+resource "aws_iam_policy" "aws_alb_controller_policy" {
+  name        = "${local.cluster_name_alb}-aws-alb-controller-policy"
+  description = "${local.cluster_name_alb} AWS ALB Controller Role IAM Policy"
+  policy      = file("./resources/eks-alb-controller-role-policy.json")
+}
+
+resource "aws_iam_role" "aws_alb_controller_role" {
+  name = "${local.cluster_name_alb}-aws-alb-controller-role"
+  assume_role_policy = jsonencode({
+    "Version" : "2012-10-17"
+    "Statement" : [
+      {
+        "Effect" : "Allow",
+        "Principal" : {
+          "Federated" : "arn:aws:iam::${local.account_id_alb}:oidc-provider/${local.oidc_id_alb}"
+        },
+        "Action" : "sts:AssumeRoleWithWebIdentity",
+        "Condition" : {
+          "StringEquals" : {
+            "${local.oidc_id_alb}:aud" : "sts.amazonaws.com",
+            "${local.oidc_id_alb}:sub" : "system:serviceaccount:kube-system:aws-load-balancer-controller"
+          }
+        }
+      }
+    ]
+  })
+  force_detach_policies = true
+}
+
+resource "aws_iam_role_policy_attachment" "aws_alb_controller_attachment" {
+  role       = aws_iam_role.aws_alb_controller_role.name
+  policy_arn = aws_iam_policy.aws_alb_controller_policy.arn
+}

--- a/aws_dragonfly-dev_eu-west-1_eks_dragonfly-dev-1-aws-alb-role_provider.tf
+++ b/aws_dragonfly-dev_eu-west-1_eks_dragonfly-dev-1-aws-alb-role_provider.tf
@@ -1,0 +1,28 @@
+provider "aws" {
+  access_key  = data.vault_generic_secret.aws_infra_credential.data["AWS_ACCESS_KEY_ID"]
+  secret_key  = data.vault_generic_secret.aws_infra_credential.data["AWS_SECRET_ACCESS_KEY"]
+  region      = "eu-west-1"
+  max_retries = 3
+  default_tags {
+    tags = {
+      DataClassification = "Cisco Restricted"
+      Environment        = "NonProd"
+      ApplicationName    = "eks-dragonfly-dev-2"
+      ResourceOwner      = "eti sre"
+      CiscoMailAlias     = "eti-sre-admins@cisco.com"
+      DataTaxonomy       = "Cisco Operations Data"
+    }
+  }
+}
+
+
+provider "vault" {
+  alias     = "eticloud"
+  address   = "https://keeper.cisco.com"
+  namespace = "eticloud"
+}
+
+data "vault_generic_secret" "aws_infra_credential" {
+  path     = "secret/infra/aws/dragonfly-dev/terraform_admin"
+  provider = vault.eticloud
+}

--- a/aws_dragonfly-dev_eu-west-1_eks_dragonfly-dev-1-aws-alb-role_versions.tf
+++ b/aws_dragonfly-dev_eu-west-1_eks_dragonfly-dev-1-aws-alb-role_versions.tf
@@ -1,0 +1,9 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 4.0"
+    }
+  }
+  required_version = ">= 1.3.6"
+}

--- a/aws_dragonfly-dev_eu-west-1_eks_dragonfly-dev-1-cm_aws-auth-configmap.tf
+++ b/aws_dragonfly-dev_eu-west-1_eks_dragonfly-dev-1-cm_aws-auth-configmap.tf
@@ -1,0 +1,92 @@
+provider "vault" {
+  alias     = "eticloud"
+  address   = "https://keeper.cisco.com"
+  namespace = "eticloud"
+}
+
+data "vault_generic_secret" "aws_infra_credential" {
+  path     = "secret/infra/aws/dragonfly-dev/terraform_admin"
+  provider = vault.eticloud
+}
+
+terraform {
+  backend "s3" {
+    bucket = "eticloud-tf-state-nonprod"                                                            # We separate the different environments into different buckets. The buckets are eticloud-tf-state-sandbox, eticloud-tf-state-nonprod, eticloud-tf-state-prod. The environment should match the CSBEnvironment below.
+    key    = "terraform-state/aws-dragonfly-dev-1/eks/eu-west-1/eks-dragonfly-dev-2-eks-cm.tfstate" # Note the path here. It should match the patten terraform_state/<service>/<region>/<name>.tfstate
+    region = "us-east-2"                                                                            # Do not change
+  }
+  required_providers {
+    tls = {
+      source  = "hashicorp/tls"
+      version = "3.4.0"
+    }
+  }
+}
+
+variable "AWS_INFRA_REGION" {
+  description = "AWS Region"
+  default     = "eu-west-1" #Set the region for the resources to be created.
+}
+
+# Infra AWS Provider
+provider "aws" {
+  access_key  = data.vault_generic_secret.aws_infra_credential.data["AWS_ACCESS_KEY_ID"]
+  secret_key  = data.vault_generic_secret.aws_infra_credential.data["AWS_SECRET_ACCESS_KEY"]
+  region      = "eu-west-1"
+  max_retries = 3
+  default_tags {
+    tags = {
+      DataClassification = "Cisco Restricted"
+      Environment        = "NonProd"
+      ApplicationName    = "eks-dragonfly-dev-2"
+      ResourceOwner      = "eti sre"
+      CiscoMailAlias     = "eti-sre-admins@cisco.com"
+      DataTaxonomy       = "Cisco Operations Data"
+    }
+  }
+}
+
+data "vault_generic_secret" "cluster_certificate" {
+  path     = "secret/infra/eks/eks-dragonfly-dev-2/certificate"
+  provider = vault.eticloud
+}
+
+data "vault_generic_secret" "aws_auth_configmap" {
+  path     = "secret/infra/eks/eks-dragonfly-dev-2/aws-auth"
+  provider = vault.eticloud
+}
+
+data "aws_eks_cluster" "cluster" {
+  name = "eks-dragonfly-dev-2"
+}
+
+data "aws_eks_cluster_auth" "cluster" {
+  name = "eks-dragonfly-dev-2"
+}
+
+provider "kubernetes" {
+  host                   = data.aws_eks_cluster.cluster.endpoint
+  cluster_ca_certificate = base64decode(data.vault_generic_secret.cluster_certificate.data["b64certificate"])
+  token                  = data.aws_eks_cluster_auth.cluster.token
+  alias                  = "eks"
+}
+
+resource "kubernetes_config_map_v1_data" "aws_auth_sre_data" {
+  provider = kubernetes.eks
+  force    = true
+
+  metadata {
+    name      = "aws-auth"
+    namespace = "kube-system"
+  }
+
+  data = local.aws_auth_configmap_data
+}
+
+locals {
+  aws_auth_configmap_b64_decode  = base64decode(data.vault_generic_secret.aws_auth_configmap.data["sre_configmap_json_b64"])
+  aws_auth_configmap_json_decode = jsondecode(local.aws_auth_configmap_b64_decode)
+  aws_auth_configmap_data = {
+    mapRoles = yamlencode(local.aws_auth_configmap_json_decode)
+  }
+}

--- a/aws_dragonfly-dev_eu-west-1_eks_dragonfly-dev-1-iam_backend.tf
+++ b/aws_dragonfly-dev_eu-west-1_eks_dragonfly-dev-1-iam_backend.tf
@@ -1,0 +1,7 @@
+terraform {
+  backend "s3" {
+    bucket = "eticloud-tf-state-nonprod"
+    key    = "terraform-state/aws/dragonfly-dev/eu-west-1/eks/dragonfly-dev-2-eks-iam.tfstate"
+    region = "us-east-2"
+  }
+}

--- a/aws_dragonfly-dev_eu-west-1_eks_dragonfly-dev-1-iam_dependencies.tf
+++ b/aws_dragonfly-dev_eu-west-1_eks_dragonfly-dev-1-iam_dependencies.tf
@@ -1,0 +1,48 @@
+data "vault_generic_secret" "aws_infra_credential" {
+  path     = "secret/infra/aws/${local.aws_account_name}/terraform_admin"
+  provider = vault.eticloud
+}
+
+// account information
+data "aws_caller_identity" "current" {}
+data "aws_region" "current" {}
+
+data "aws_vpc" "compute_vpc" {
+  filter {
+    name = "tag:Name"
+    values = [
+      local.vpc_id
+    ]
+  }
+}
+
+data "aws_subnets" "compute_subnets" {
+  filter {
+    name   = "vpc-id"
+    values = [data.aws_vpc.compute_vpc.id]
+  }
+  tags = {
+    Tier = "Private"
+  }
+}
+
+data "aws_msk_cluster" "dragonfly_msk_1" {
+  cluster_name = local.dragonfly_msk_cluster_name
+}
+
+// EKS
+data "aws_eks_cluster" "cluster" {
+  name = local.cluster_name
+}
+
+data "aws_s3_bucket" "mskconnect_custom_plugin_bucket" {
+  bucket = local.arango_connector_plugin_bucket
+}
+
+data "aws_s3_bucket" "mskconnect_logs_bucket" {
+  bucket = local.arangodb_connector_logs_bucket
+}
+
+data "aws_iam_role" "mskconnect_arangodb_execution_role" {
+  name = local.arangodb_connector_execution_role
+}

--- a/aws_dragonfly-dev_eu-west-1_eks_dragonfly-dev-1-iam_locals.tf
+++ b/aws_dragonfly-dev_eu-west-1_eks_dragonfly-dev-1-iam_locals.tf
@@ -1,0 +1,22 @@
+locals {
+  app_name         = "dragonfly-dev"
+  aws_account_name = "dragonfly-dev"
+  aws_region       = "eu-west-1"
+  account_id       = data.aws_caller_identity.current.account_id
+
+  vpc_id = "dragonfly-dev-2-vpc"
+
+  cluster_name = "eks-dragonfly-dev-2"
+  oidc_id      = trimprefix(data.aws_eks_cluster.cluster.identity[0].oidc[0].issuer, "https://")
+
+  dragonfly_backend_namespace = "dragonfly-backend"
+  dragonfly_msk_cluster_name  = "dragonfly-msk-1"
+
+  arango_connector_plugin_bucket    = "dragonfly-dev-binaries-repository"
+  arangodb_connector_logs_bucket    = "dragonfly-dev-kafka-connector-log-files"
+  arangodb_connector_execution_role = "kafka-connect-arangodb-role"
+
+  dragonfly_argo_service_account                = "${local.dragonfly_backend_namespace}:dragonfly-thrill-argo"
+  dragonfly_streaman_service_account            = "${local.dragonfly_backend_namespace}:dragonfly-streaman-service-account"
+  dragonfly_ml_inference_client_service_account = "${local.dragonfly_backend_namespace}:dragonfly-ml-inferenceclient-a-dev-app"
+}

--- a/aws_dragonfly-dev_eu-west-1_eks_dragonfly-dev-1-iam_outputs.tf
+++ b/aws_dragonfly-dev_eu-west-1_eks_dragonfly-dev-1-iam_outputs.tf
@@ -1,0 +1,4 @@
+# Role ID
+output "dragonfly_thrill_msk_role_id" {
+  value = aws_iam_role.dragonfly_thrill_msk_writer.arn
+}

--- a/aws_dragonfly-dev_eu-west-1_eks_dragonfly-dev-1-iam_providers.tf
+++ b/aws_dragonfly-dev_eu-west-1_eks_dragonfly-dev-1-iam_providers.tf
@@ -1,0 +1,23 @@
+provider "vault" {
+  alias     = "eticloud"
+  address   = "https://keeper.cisco.com"
+  namespace = "eticloud"
+}
+
+provider "aws" {
+  access_key  = data.vault_generic_secret.aws_infra_credential.data["AWS_ACCESS_KEY_ID"]
+  secret_key  = data.vault_generic_secret.aws_infra_credential.data["AWS_SECRET_ACCESS_KEY"]
+  region      = local.aws_region
+  max_retries = 3
+
+  default_tags {
+    tags = {
+      ApplicationName    = local.app_name
+      CiscoMailAlias     = "eti-sre-admins@cisco.com"
+      DataClassification = "Cisco Confidential"
+      DataTaxonomy       = "Cisco Operations Data"
+      EnvironmentName    = "NonProd"
+      ResourceOwner      = "ETI SRE"
+    }
+  }
+}

--- a/aws_dragonfly-dev_eu-west-1_eks_dragonfly-dev-1-iam_role-thrill-msk-writer.tf
+++ b/aws_dragonfly-dev_eu-west-1_eks_dragonfly-dev-1-iam_role-thrill-msk-writer.tf
@@ -1,0 +1,66 @@
+resource "aws_iam_role" "dragonfly_thrill_msk_writer" {
+  name = "thrill-msk-writer-role"
+
+  assume_role_policy = jsonencode({
+    "Version" : "2012-10-17"
+    "Statement" : [
+      {
+        "Effect" : "Allow",
+        "Principal" : {
+          "Federated" : "arn:aws:iam::${local.account_id}:oidc-provider/${local.oidc_id}"
+        },
+        "Action" : "sts:AssumeRoleWithWebIdentity",
+        "Condition" : {
+          "StringEquals" : {
+            "${local.oidc_id}:aud" : "sts.amazonaws.com",
+            "${local.oidc_id}:sub" : "system:serviceaccount:${local.dragonfly_argo_service_account}"
+          }
+        }
+      }
+    ]
+  })
+  force_detach_policies = true
+}
+
+data "aws_iam_policy_document" "dragonfly_thrill_msk_writer_policies" {
+  statement {
+    sid = "access"
+
+    actions = [
+      "kafka-cluster:Connect",
+    ]
+
+    resources = [
+      "arn:aws:kafka:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:cluster/${data.aws_msk_cluster.dragonfly_msk_1.cluster_name}/${data.aws_msk_cluster.dragonfly_msk_1.cluster_uuid}"
+    ]
+
+    effect = "Allow"
+  }
+
+  statement {
+    sid = "topic"
+
+    actions = [
+      "kafka-cluster:DescribeTopic",
+      "kafka-cluster:WriteData",
+    ]
+
+    resources = [
+      "arn:aws:kafka:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:topic/${data.aws_msk_cluster.dragonfly_msk_1.cluster_name}/${data.aws_msk_cluster.dragonfly_msk_1.cluster_uuid}/threat",
+      "arn:aws:kafka:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:topic/${data.aws_msk_cluster.dragonfly_msk_1.cluster_name}/${data.aws_msk_cluster.dragonfly_msk_1.cluster_uuid}/attack",
+    ]
+
+    effect = "Allow"
+  }
+}
+
+resource "aws_iam_policy" "dragonfly_thrill_msk_writer_policies" {
+  name        = "dragonfly-thrill-msk-writer-policies"
+  description = "Policies for thrill MSK writer role on threat and attack topics"
+  policy      = data.aws_iam_policy_document.dragonfly_thrill_msk_writer_policies.json
+}
+
+resource "aws_iam_role_policy_attachment" "dragonfly_thrill_msk_writer_policy_attachment" {
+  role       = aws_iam_role.dragonfly_thrill_msk_writer.name
+  policy_arn = aws_iam_policy.dragonfly_thrill_msk_writer_policies.arn
+}

--- a/aws_dragonfly-dev_eu-west-1_eks_dragonfly-dev-1-karpenter-roles_karpenter-roles.tf
+++ b/aws_dragonfly-dev_eu-west-1_eks_dragonfly-dev-1-karpenter-roles_karpenter-roles.tf
@@ -1,0 +1,243 @@
+# Backend
+terraform {
+  backend "s3" {
+    bucket = "eticloud-tf-state-nonprod"                                                                             # We separate the different environments into different buckets. The buckets are eticloud-tf-state-sandbox, eticloud-tf-state-nonprod, eticloud-tf-state-prod. The environment should match the CSBEnvironment below.
+    key    = "terraform-state/aws-dragonfly-dev-1/eks/eu-west-1/eks-dragonfly-dev-2-eks-eks-karpenter-roles.tfstate" # Note the path here. It should match the patten terraform_state/<service>/<region>/<name>.tfstate
+    region = "us-east-2"                                                                                             # Do not change
+  }
+  required_providers {
+    tls = {
+      source  = "hashicorp/tls"
+      version = "3.4.0"
+    }
+  }
+}
+
+# Infra AWS Provider
+provider "vault" {
+  alias     = "eticloud"
+  address   = "https://keeper.cisco.com"
+  namespace = "eticloud"
+}
+
+data "vault_generic_secret" "aws_infra_credential" {
+  path     = "secret/infra/aws/dragonfly-dev/terraform_admin"
+  provider = vault.eticloud
+}
+
+provider "aws" {
+  access_key  = data.vault_generic_secret.aws_infra_credential.data["AWS_ACCESS_KEY_ID"]
+  secret_key  = data.vault_generic_secret.aws_infra_credential.data["AWS_SECRET_ACCESS_KEY"]
+  region      = "eu-west-1"
+  max_retries = 3
+  default_tags {
+    tags = {
+      DataClassification = "Cisco Restricted"
+      Environment        = "NonProd"
+      ApplicationName    = "eks-dragonfly-dev-2"
+      ResourceOwner      = "eti sre"
+      CiscoMailAlias     = "eti-sre-admins@cisco.com"
+      DataTaxonomy       = "Cisco Operations Data"
+    }
+  }
+}
+
+data "aws_caller_identity" "current" {}
+data "aws_eks_cluster" "cluster" {
+  name = local.eks_name
+}
+
+# locals
+locals {
+  account_id         = data.aws_caller_identity.current.account_id
+  oidc_id            = trimprefix(data.aws_eks_cluster.cluster.identity[0].oidc[0].issuer, "https://")
+  vpc_name           = "dragonfly-dev-2"
+  eks_name           = "eks-dragonfly-dev-2"
+  aws_default_region = "eu-west-1"
+}
+
+resource "aws_iam_policy" "aws_karpenter_controller_policy" {
+  name        = "KarpenterControllerPolicy-${local.eks_name}"
+  description = "${local.eks_name} AWS Karpenter Controller Role IAM Policy"
+  policy = jsonencode({
+    "Version" : "2012-10-17",
+    "Statement" : [
+      {
+        "Action" : [
+          "ssm:GetParameter",
+          "ec2:DescribeImages",
+          "ec2:RunInstances",
+          "ec2:DescribeSubnets",
+          "ec2:DescribeSecurityGroups",
+          "ec2:DescribeLaunchTemplates",
+          "ec2:DescribeInstances",
+          "ec2:DescribeInstanceTypes",
+          "ec2:DescribeInstanceTypeOfferings",
+          "ec2:DescribeAvailabilityZones",
+          "ec2:DeleteLaunchTemplate",
+          "ec2:CreateTags",
+          "ec2:CreateLaunchTemplate",
+          "ec2:CreateFleet",
+          "ec2:DescribeSpotPriceHistory",
+          "pricing:GetProducts"
+        ],
+        "Effect" : "Allow",
+        "Resource" : "*",
+        "Sid" : "Karpenter"
+      },
+      {
+        "Action" : "ec2:TerminateInstances",
+        "Condition" : {
+          "StringLike" : {
+            "ec2:ResourceTag/karpenter.sh/nodepool" : "*"
+          }
+        },
+        "Effect" : "Allow",
+        "Resource" : "*",
+        "Sid" : "ConditionalEC2Termination"
+      },
+      {
+        "Effect" : "Allow",
+        "Action" : "iam:PassRole",
+        "Resource" : "arn:aws:iam::${local.account_id}:role/KarpenterNodeRole-${local.eks_name}",
+        "Sid" : "PassNodeIAMRole"
+      },
+      {
+        "Effect" : "Allow",
+        "Action" : "eks:DescribeCluster",
+        "Resource" : "arn:aws:eks:${local.aws_default_region}:${local.account_id}:cluster/${local.eks_name}",
+        "Sid" : "EKSClusterEndpointLookup"
+      },
+      {
+        "Sid" : "AllowScopedInstanceProfileCreationActions",
+        "Effect" : "Allow",
+        "Resource" : "*",
+        "Action" : [
+          "iam:CreateInstanceProfile"
+        ],
+        "Condition" : {
+          "StringEquals" : {
+            "aws:RequestTag/kubernetes.io/cluster/${local.eks_name}" : "owned",
+            "aws:RequestTag/topology.kubernetes.io/region" : "${local.aws_default_region}"
+          },
+          "StringLike" : {
+            "aws:RequestTag/karpenter.k8s.aws/ec2nodeclass" : "*"
+          }
+        }
+      },
+      {
+        "Sid" : "AllowScopedInstanceProfileTagActions",
+        "Effect" : "Allow",
+        "Resource" : "*",
+        "Action" : [
+          "iam:TagInstanceProfile"
+        ],
+        "Condition" : {
+          "StringEquals" : {
+            "aws:ResourceTag/kubernetes.io/cluster/${local.eks_name}" : "owned",
+            "aws:ResourceTag/topology.kubernetes.io/region" : "${local.aws_default_region}",
+            "aws:RequestTag/kubernetes.io/cluster/${local.eks_name}" : "owned",
+            "aws:RequestTag/topology.kubernetes.io/region" : "${local.aws_default_region}"
+          },
+          "StringLike" : {
+            "aws:ResourceTag/karpenter.k8s.aws/ec2nodeclass" : "*",
+            "aws:RequestTag/karpenter.k8s.aws/ec2nodeclass" : "*"
+          }
+        }
+      },
+      {
+        "Sid" : "AllowScopedInstanceProfileActions",
+        "Effect" : "Allow",
+        "Resource" : "*",
+        "Action" : [
+          "iam:AddRoleToInstanceProfile",
+          "iam:RemoveRoleFromInstanceProfile",
+          "iam:DeleteInstanceProfile"
+        ],
+        "Condition" : {
+          "StringEquals" : {
+            "aws:ResourceTag/kubernetes.io/cluster/${local.eks_name}" : "owned",
+            "aws:ResourceTag/topology.kubernetes.io/region" : "${local.aws_default_region}"
+          },
+          "StringLike" : {
+            "aws:ResourceTag/karpenter.k8s.aws/ec2nodeclass" : "*"
+          }
+        }
+      },
+      {
+        "Sid" : "AllowInstanceProfileReadActions",
+        "Effect" : "Allow",
+        "Resource" : "*",
+        "Action" : "iam:GetInstanceProfile"
+      }
+    ]
+
+  })
+}
+
+resource "aws_iam_role" "aws_karpenter_controller_role" {
+  name = "KarpenterControllerRole-${local.eks_name}"
+  assume_role_policy = jsonencode({
+    "Version" : "2012-10-17"
+    "Statement" : [
+      {
+        "Effect" : "Allow",
+        "Principal" : {
+          "Federated" : "arn:aws:iam::${local.account_id}:oidc-provider/${local.oidc_id}"
+        },
+        "Action" : "sts:AssumeRoleWithWebIdentity",
+        "Condition" : {
+          "StringEquals" : {
+            "${local.oidc_id}:aud" : "sts.amazonaws.com"
+          }
+        }
+      }
+    ]
+  })
+  force_detach_policies = true
+}
+
+
+resource "aws_iam_role" "aws_karpenter_node_role" {
+  name = "KarpenterNodeRole-${local.eks_name}"
+  assume_role_policy = jsonencode({
+    "Version" : "2012-10-17",
+    "Statement" : [
+      {
+        "Effect" : "Allow",
+        "Principal" : {
+          "Service" : "ec2.amazonaws.com"
+        },
+        "Action" : "sts:AssumeRole"
+      }
+    ]
+  })
+  force_detach_policies = true
+}
+resource "aws_iam_role_policy_attachment" "aws_karpenter_controller_attachment" {
+  role       = aws_iam_role.aws_karpenter_controller_role.name
+  policy_arn = aws_iam_policy.aws_karpenter_controller_policy.arn
+}
+resource "aws_iam_role_policy_attachment" "aws_karpenter_node_attachment_1" {
+  role       = aws_iam_role.aws_karpenter_node_role.name
+  policy_arn = "arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryReadOnly"
+}
+resource "aws_iam_role_policy_attachment" "aws_karpenter_node_attachment_2" {
+  role       = aws_iam_role.aws_karpenter_node_role.name
+  policy_arn = "arn:aws:iam::aws:policy/AmazonEKS_CNI_Policy"
+}
+
+resource "aws_iam_role_policy_attachment" "aws_karpenter_node_attachment_3" {
+  role       = aws_iam_role.aws_karpenter_node_role.name
+  policy_arn = "arn:aws:iam::aws:policy/AmazonEKSWorkerNodePolicy"
+}
+
+resource "aws_iam_role_policy_attachment" "aws_karpenter_node_attachment_4" {
+  role       = aws_iam_role.aws_karpenter_node_role.name
+  policy_arn = "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"
+}
+
+resource "aws_iam_role_policy_attachment" "aws_karpenter_node_attachment_5" {
+  role       = aws_iam_role.aws_karpenter_node_role.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonEBSCSIDriverPolicy"
+}

--- a/aws_dragonfly-dev_eu-west-1_eks_dragonfly-dev-1_eks.tf
+++ b/aws_dragonfly-dev_eu-west-1_eks_dragonfly-dev-1_eks.tf
@@ -1,0 +1,108 @@
+terraform {
+  backend "s3" {
+    bucket = "eticloud-tf-state-nonprod"
+    key    = "terraform-state/aws-dragonfly-dev-1/eks/eu-west-1/eks-dragonfly-dev-2-eks.tfstate"
+    region = "us-east-2"
+  }
+}
+
+provider "aws" {
+  access_key = data.vault_generic_secret.aws_infra_credential.data["AWS_ACCESS_KEY_ID"]
+  secret_key = data.vault_generic_secret.aws_infra_credential.data["AWS_SECRET_ACCESS_KEY"]
+  region     = "eu-west-1"
+  default_tags {
+    tags = {
+      ApplicationName    = "dragonfly-dev-2-eks"
+      CiscoMailAlias     = "eti-sre-admins@cisco.com"
+      DataClassification = "Cisco Confidential"
+      DataTaxonomy       = "Cisco Operations Data"
+      EnvironmentName    = "NonProd"
+      ResourceOwner      = "ETI SRE"
+    }
+  }
+}
+
+provider "vault" {
+  alias     = "eticloud"
+  address   = "https://keeper.cisco.com"
+  namespace = "eticloud"
+}
+
+data "vault_generic_secret" "aws_infra_credential" {
+  path     = "secret/infra/aws/dragonfly-dev/terraform_admin"
+  provider = vault.eticloud
+}
+
+data "aws_caller_identity" "current" {}
+
+locals {
+  cluster_name = "eks-dragonfly-dev-2"
+}
+module "eks" {
+  source          = "git::https://github.com/cisco-eti/sre-tf-module-aws-eks?ref=2.0.1"
+  cluster_name    = local.cluster_name
+  cluster_version = "1.27" # don't roll back!
+  cluster_os      = "AmazonLinux2"
+  vpc_name        = "dragonfly-dev-2-vpc"
+
+  # Private Node group options
+  create_private_nodegroup            = true            # Defaults to true. Must be true for any of the below to be set by the module,
+  private_node_group_desired_capacity = 5               # The desired number of worker nodes. Once this is set, the number of desired instances must be manually modified.
+  private_node_group_min_capacity     = 5               # The minimum number of worker nodes.
+  private_node_group_max_capacity     = 10              # The maximium number of worker nodes.
+  private_node_group_instance_type    = ["m5a.2xlarge"] # The instance type for the worker nodes.
+
+  # Public Node group options
+  create_public_nodegroup            = false          # Defaults to false. Must be true for any of the below to be set by the module,
+  public_node_group_desired_capacity = 0              # The desired number of worker nodes. Once this is set, the number of desired instances must be manually modified.
+  public_node_group_min_capacity     = 0              # The minimum number of worker nodes.
+  public_node_group_max_capacity     = 0              # The maximium number of worker nodes.
+  public_node_group_instance_type    = ["m5a.xlarge"] # The instance type for the worker nodes.
+
+  # aws-auth configmap
+  create_aws_auth_configmap = false
+  manage_aws_auth_configmap = false # Set to false in SRE module
+
+  aws_auth_additional_roles = [
+    {
+      rolearn  = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/admin"
+      username = "admin"
+      groups   = ["system:masters"]
+    },
+    {
+      rolearn  = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/devops",
+      username = "devops",
+      groups   = ["system:masters"]
+    },
+    {
+      rolearn  = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/KarpenterNodeRole-${local.cluster_name}",
+      username = "system:node:{{EC2PrivateDNSName}}",
+      groups   = ["system:bootstrappers", "system:nodes"]
+    }
+  ]
+
+  cluster_addons = {
+    coredns = {
+      addon_version = "v1.10.1-eksbuild.4"
+    }
+    kube-proxy = {
+      addon_version = "v1.27.6-eksbuild.2"
+    }
+    vpc-cni = {
+      addon_version = "v1.15.1-eksbuild.1"
+      configuration_values = jsonencode({
+        env = {
+          # Reference docs https://docs.aws.amazon.com/eks/latest/userguide/cni-increase-ip-addresses.html
+          ENABLE_PREFIX_DELEGATION = "false"
+          WARM_PREFIX_TARGET       = "0"
+        }
+      })
+    }
+    aws-ebs-csi-driver = {
+      addon_version = "v1.23.1-eksbuild.1"
+    }
+  }
+  providers = {
+    vault = vault.eticloud
+  }
+}

--- a/aws_dragonfly-dev_eu-west-1_msk_dragonfly-dev-msk-1_backend.tf
+++ b/aws_dragonfly-dev_eu-west-1_msk_dragonfly-dev-msk-1_backend.tf
@@ -1,0 +1,7 @@
+terraform {
+  backend "s3" {
+    bucket = "eticloud-tf-state-nonprod"
+    key    = "terraform-state/aws-dragonfly-dev-1/msk/eu-west-1/dragonfly-msk-1.tfstate"
+    region = "us-east-2"
+  }
+}

--- a/aws_dragonfly-dev_eu-west-1_msk_dragonfly-dev-msk-1_cloudwatch.tf
+++ b/aws_dragonfly-dev_eu-west-1_msk_dragonfly-dev-msk-1_cloudwatch.tf
@@ -1,0 +1,3 @@
+resource "aws_cloudwatch_log_group" "broker_logs" {
+  name = "dragonfly-msk-1-broker-logs"
+}

--- a/aws_dragonfly-dev_eu-west-1_msk_dragonfly-dev-msk-1_dependencies.tf
+++ b/aws_dragonfly-dev_eu-west-1_msk_dragonfly-dev-msk-1_dependencies.tf
@@ -1,0 +1,59 @@
+data "vault_generic_secret" "aws_infra_credential" {
+  path     = "secret/infra/aws/${local.aws_account_name}/terraform_admin"
+  provider = vault.eticloud
+}
+
+// account information
+data "aws_caller_identity" "current" {}
+data "aws_region" "current" {}
+
+data "aws_iam_policy_document" "msk_scram_secret_policy" {
+  for_each = var.scram_kafka_clients
+
+  statement {
+    sid    = "AWSKafkaResourcePolicy"
+    effect = "Allow"
+
+    principals {
+      type        = "Service"
+      identifiers = ["kafka.amazonaws.com"]
+    }
+
+    actions   = ["secretsmanager:getSecretValue"]
+    resources = [aws_secretsmanager_secret.msk_scram_auth_credentials[each.key].arn]
+  }
+}
+
+data "aws_vpc" "eks_vpc" {
+  filter {
+    name   = "tag:Name"
+    values = ["dragonfly-dev-2-vpc"]
+  }
+}
+
+data "aws_vpc" "msk_vpc" {
+  filter {
+    name   = "tag:Name"
+    values = ["dragonfly-data-vpc"]
+  }
+}
+
+data "aws_subnets" "eks_subnets" {
+  filter {
+    name   = "vpc-id"
+    values = [data.aws_vpc.eks_vpc.id]
+  }
+  tags = {
+    Tier = "Private"
+  }
+}
+
+data "aws_subnets" "msk_subnets" {
+  filter {
+    name   = "vpc-id"
+    values = [data.aws_vpc.msk_vpc.id]
+  }
+  tags = {
+    Tier = "Private"
+  }
+}

--- a/aws_dragonfly-dev_eu-west-1_msk_dragonfly-dev-msk-1_kms.tf
+++ b/aws_dragonfly-dev_eu-west-1_msk_dragonfly-dev-msk-1_kms.tf
@@ -1,0 +1,3 @@
+resource "aws_kms_key" "encryption_key" {
+  description = "dragonfly-msk-1 MSK cluster encryption key"
+}

--- a/aws_dragonfly-dev_eu-west-1_msk_dragonfly-dev-msk-1_locals.tf
+++ b/aws_dragonfly-dev_eu-west-1_msk_dragonfly-dev-msk-1_locals.tf
@@ -1,0 +1,8 @@
+locals {
+  app_name         = "dragonfly-dev"
+  aws_account_name = "dragonfly-dev"
+  aws_region       = "eu-west-1"
+  account_id       = data.aws_caller_identity.current.account_id
+
+  vpc_id = "dragonfly-dev-2-vpc"
+}

--- a/aws_dragonfly-dev_eu-west-1_msk_dragonfly-dev-msk-1_msk.tf
+++ b/aws_dragonfly-dev_eu-west-1_msk_dragonfly-dev-msk-1_msk.tf
@@ -1,0 +1,154 @@
+resource "aws_msk_configuration" "configuration" {
+  kafka_versions = [var.kafka_version]
+  name           = "dragonfly-msk-1"
+
+  server_properties = <<PROPERTIES
+auto.create.topics.enable = true
+PROPERTIES
+}
+
+resource "aws_msk_scram_secret_association" "msk_scram_auth_credentials" {
+  cluster_arn = aws_msk_cluster.dragonfly_msk_1.arn
+  secret_arn_list = [
+    for s in aws_secretsmanager_secret.msk_scram_auth_credentials : s.arn
+  ]
+
+  depends_on = [aws_secretsmanager_secret_version.msk_scram_auth_credentials_v1]
+}
+
+resource "aws_msk_cluster" "dragonfly_msk_1" {
+  cluster_name           = "dragonfly-msk-1"
+  kafka_version          = var.kafka_version
+  number_of_broker_nodes = var.number_of_broker_nodes
+
+  // Broker configuration
+  broker_node_group_info {
+    instance_type = var.instance_type
+
+    client_subnets = data.aws_subnets.msk_subnets.ids
+
+    storage_info {
+      ebs_storage_info {
+        volume_size = 1000
+      }
+    }
+
+    // Turn on multi-vpc connectivity
+    connectivity_info {
+      vpc_connectivity {
+        client_authentication {
+          sasl {
+            scram = false
+            iam   = true
+          }
+        }
+      }
+    }
+
+    security_groups = [aws_security_group.dragonfly_msk_1.id]
+  }
+
+  // Encryption
+  encryption_info {
+    encryption_at_rest_kms_key_arn = aws_kms_key.encryption_key.arn
+
+    encryption_in_transit {
+      client_broker = "TLS"
+      in_cluster    = true
+    }
+  }
+
+  // Authentication
+  client_authentication {
+    sasl {
+      scram = true
+      iam   = true
+    }
+  }
+
+  // Cluster config
+  configuration_info {
+    arn      = aws_msk_configuration.configuration.arn
+    revision = aws_msk_configuration.configuration.latest_revision
+  }
+
+  // Monitoring && logging
+  open_monitoring {
+    prometheus {
+      jmx_exporter {
+        enabled_in_broker = true
+      }
+      node_exporter {
+        enabled_in_broker = true
+      }
+    }
+  }
+
+  enhanced_monitoring = "PER_TOPIC_PER_PARTITION"
+
+  logging_info {
+    broker_logs {
+      cloudwatch_logs {
+        enabled   = true
+        log_group = aws_cloudwatch_log_group.broker_logs.name
+      }
+    }
+  }
+}
+
+resource "aws_msk_cluster_policy" "opensearch_ingestion_policy" {
+  cluster_arn = aws_msk_cluster.dragonfly_msk_1.arn
+
+  policy = jsonencode({
+    "Version" : "2012-10-17",
+    "Statement" : [
+      {
+        "Effect" : "Allow",
+        "Principal" : {
+          "Service" : "osis.amazonaws.com"
+        },
+        "Action" : [
+          "kafka:CreateVpcConnection",
+          "kafka:DescribeCluster",
+          "kafka:DescribeClusterV2"
+        ],
+        "Resource" : aws_msk_cluster.dragonfly_msk_1.arn
+      },
+      {
+        "Effect" : "Allow",
+        "Principal" : {
+          "Service" : "osis-pipelines.amazonaws.com"
+        },
+        "Action" : [
+          "kafka:CreateVpcConnection",
+          "kafka:GetBootstrapBrokers",
+          "kafka:DescribeCluster",
+          "kafka:DescribeClusterV2"
+        ],
+        "Resource" : aws_msk_cluster.dragonfly_msk_1.arn
+    }]
+  })
+}
+
+// Save brokers in vault
+resource "vault_generic_secret" "msk_brokers" {
+  path = "secret/dev/msk/dragonfly-msk-1/brokers"
+
+  data_json = jsonencode({
+    brokers     = aws_msk_cluster.dragonfly_msk_1.bootstrap_brokers_sasl_scram
+    brokers-iam = aws_msk_cluster.dragonfly_msk_1.bootstrap_brokers_sasl_iam
+  })
+
+  provider = vault.dragonfly
+}
+
+resource "vault_generic_secret" "msk_region_brokers" {
+  path = "secret/dev/msk/${data.aws_region.current.name}/dragonfly-msk-1/brokers"
+
+  data_json = jsonencode({
+    brokers     = aws_msk_cluster.dragonfly_msk_1.bootstrap_brokers_sasl_scram
+    brokers-iam = aws_msk_cluster.dragonfly_msk_1.bootstrap_brokers_sasl_iam
+  })
+
+  provider = vault.dragonfly
+}

--- a/aws_dragonfly-dev_eu-west-1_msk_dragonfly-dev-msk-1_outputs.tf
+++ b/aws_dragonfly-dev_eu-west-1_msk_dragonfly-dev-msk-1_outputs.tf
@@ -1,0 +1,11 @@
+output "zookeeper_connect_string" {
+  value = aws_msk_cluster.dragonfly_msk_1.zookeeper_connect_string
+}
+
+output "bootstrap_brokers" {
+  value = aws_msk_cluster.dragonfly_msk_1.bootstrap_brokers
+}
+
+output "bootstrap_brokers_tls" {
+  value = aws_msk_cluster.dragonfly_msk_1.bootstrap_brokers_tls
+}

--- a/aws_dragonfly-dev_eu-west-1_msk_dragonfly-dev-msk-1_providers.tf
+++ b/aws_dragonfly-dev_eu-west-1_msk_dragonfly-dev-msk-1_providers.tf
@@ -1,0 +1,28 @@
+provider "aws" {
+  access_key = data.vault_generic_secret.aws_infra_credential.data["AWS_ACCESS_KEY_ID"]
+  secret_key = data.vault_generic_secret.aws_infra_credential.data["AWS_SECRET_ACCESS_KEY"]
+  region     = "eu-west-1"
+
+  default_tags {
+    tags = {
+      ApplicationName    = "dragonfly-msk-1"
+      CiscoMailAlias     = "eti-sre-admins@cisco.com"
+      DataClassification = "Cisco Confidential"
+      DataTaxonomy       = "Cisco Operations Data"
+      EnvironmentName    = "NonProd"
+      ResourceOwner      = "ETI SRE"
+    }
+  }
+}
+
+provider "vault" {
+  alias     = "eticloud"
+  address   = "https://keeper.cisco.com"
+  namespace = "eticloud"
+}
+
+provider "vault" {
+  alias     = "dragonfly"
+  address   = "https://keeper.cisco.com"
+  namespace = "eticloud/apps/dragonfly"
+}

--- a/aws_dragonfly-dev_eu-west-1_msk_dragonfly-dev-msk-1_secretsmanager.tf
+++ b/aws_dragonfly-dev_eu-west-1_msk_dragonfly-dev-msk-1_secretsmanager.tf
@@ -1,0 +1,47 @@
+// Generate random passwords
+resource "random_password" "password" {
+  for_each = var.scram_kafka_clients
+
+  length  = 64
+  special = false
+}
+
+// Save secrets in Vault
+resource "vault_generic_secret" "msk_scram_auth_credentials" {
+  for_each = var.scram_kafka_clients
+
+  path = each.value.vault_path
+
+  data_json = jsonencode({
+    username = each.key
+    password = random_password.password[each.key].result
+  })
+
+  provider = vault.dragonfly
+}
+
+// Secrets for SASL/SCRAM authentication
+resource "aws_secretsmanager_secret" "msk_scram_auth_credentials" {
+  for_each = var.scram_kafka_clients
+
+  name        = "AmazonMSK_dragonfly-msk-1-${each.key}-scram-auth"
+  description = each.value.description
+
+  kms_key_id = aws_kms_key.encryption_key.key_id
+}
+
+// Secret versions
+resource "aws_secretsmanager_secret_version" "msk_scram_auth_credentials_v1" {
+  for_each = var.scram_kafka_clients
+
+  secret_id     = aws_secretsmanager_secret.msk_scram_auth_credentials[each.key].id
+  secret_string = vault_generic_secret.msk_scram_auth_credentials[each.key].data_json
+}
+
+// Secret policy
+resource "aws_secretsmanager_secret_policy" "msk_scram_secret_policy" {
+  for_each = var.scram_kafka_clients
+
+  secret_arn = aws_secretsmanager_secret.msk_scram_auth_credentials[each.key].arn
+  policy     = data.aws_iam_policy_document.msk_scram_secret_policy[each.key].json
+}

--- a/aws_dragonfly-dev_eu-west-1_msk_dragonfly-dev-msk-1_securitygroup.tf
+++ b/aws_dragonfly-dev_eu-west-1_msk_dragonfly-dev-msk-1_securitygroup.tf
@@ -1,0 +1,80 @@
+locals {
+  msk_ingress_rules = [
+    {
+      from_port : 9094,
+      to_port : 9094,
+      protocol : "tcp",
+      cidr_blocks : [
+        data.aws_vpc.msk_vpc.cidr_block,
+        data.aws_vpc.eks_vpc.cidr_block,
+      ],
+    },
+    {
+      from_port : 9096,
+      to_port : 9096,
+      protocol : "tcp",
+      cidr_blocks : [
+        data.aws_vpc.msk_vpc.cidr_block,
+        data.aws_vpc.eks_vpc.cidr_block,
+      ],
+    },
+    {
+      from_port : 9098,
+      to_port : 9098,
+      protocol : "tcp",
+      cidr_blocks : [
+        data.aws_vpc.msk_vpc.cidr_block,
+        data.aws_vpc.eks_vpc.cidr_block,
+      ],
+    },
+    {
+      from_port : 2181,
+      to_port : 2181,
+      protocol : "tcp",
+      cidr_blocks : [
+        data.aws_vpc.msk_vpc.cidr_block,
+      ],
+    },
+  ]
+
+  msk_egress_rules = [
+    {
+      from_port : 0,
+      to_port : 65535,
+      protocol : "tcp",
+      cidr_blocks : [
+        data.aws_vpc.msk_vpc.cidr_block,
+        data.aws_vpc.eks_vpc.cidr_block,
+      ],
+    },
+  ]
+}
+
+
+resource "aws_security_group" "dragonfly_msk_1" {
+  name        = "dragonfly-msk-1-msk-default"
+  description = "dragonfly-msk-1 MSK cluster default security group"
+  vpc_id      = data.aws_vpc.msk_vpc.id
+
+  dynamic "ingress" {
+    for_each = toset(local.msk_ingress_rules)
+
+    content {
+      from_port   = ingress.value.from_port
+      to_port     = ingress.value.to_port
+      protocol    = ingress.value.protocol
+      cidr_blocks = ingress.value.cidr_blocks
+    }
+  }
+
+  dynamic "egress" {
+    for_each = toset(local.msk_egress_rules)
+
+    content {
+      from_port   = egress.value.from_port
+      to_port     = egress.value.to_port
+      protocol    = egress.value.protocol
+      cidr_blocks = egress.value.cidr_blocks
+    }
+  }
+}

--- a/aws_dragonfly-dev_eu-west-1_msk_dragonfly-dev-msk-1_variables.tf
+++ b/aws_dragonfly-dev_eu-west-1_msk_dragonfly-dev-msk-1_variables.tf
@@ -1,0 +1,39 @@
+variable "kafka_version" {
+  description = "Kafka version to deploy"
+  type        = string
+  default     = "3.6.0"
+}
+
+variable "instance_type" {
+  description = "Instance type to use for Kafka brokers"
+  type        = string
+  default     = "kafka.m5.large"
+}
+
+variable "number_of_broker_nodes" {
+  description = "Number of Kafka broker nodes to deploy"
+  type        = number
+  default     = 3
+}
+
+variable "scram_kafka_clients" {
+  description = "Kafka clients to create"
+  type = map(object({
+    description = string
+    vault_path  = string
+  }))
+  default = {
+    "otel-collector" = {
+      description = "Auth credentials of otel-collector for dragonfly-msk-1"
+      vault_path  = "secret/dev/msk/eu-west-1/dragonfly-msk-1/kafka-clients/otel-collector"
+    },
+    "notification-service" = {
+      description = "Auth credentials of notification-service for dragonfly-msk-1"
+      vault_path  = "secret/dev/msk/eu-west-1/dragonfly-msk-1/kafka-clients/notification-service"
+    },
+    "fluentbit" = {
+      description = "Auth credentials of fluentbit for dragonfly-msk-1"
+      vault_path  = "secret/dev/msk/eu-west-1/dragonfly-msk-1/kafka-clients/fluentbit"
+    },
+  }
+}

--- a/aws_dragonfly-dev_eu-west-1_msk_dragonfly-dev-msk-1_versions.tf
+++ b/aws_dragonfly-dev_eu-west-1_msk_dragonfly-dev-msk-1_versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.3.6"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+}

--- a/aws_dragonfly-dev_eu-west-1_os_dragonfly-dev-1-os_backend.tf
+++ b/aws_dragonfly-dev_eu-west-1_os_dragonfly-dev-1-os_backend.tf
@@ -1,0 +1,7 @@
+terraform {
+  backend "s3" {
+    bucket = "eticloud-tf-state-nonprod"
+    key    = "terraform-state/aws-dragonfly-dev-1/os/eu-west-1/dragonfly-dev-1-os.tfstate"
+    region = "us-east-2"
+  }
+}

--- a/aws_dragonfly-dev_eu-west-1_os_dragonfly-dev-1-os_cloudwatch.tf
+++ b/aws_dragonfly-dev_eu-west-1_os_dragonfly-dev-1-os_cloudwatch.tf
@@ -1,0 +1,8 @@
+resource "aws_cloudwatch_log_group" "dragonfly_dev_1_os_logs" {
+  name = "dragonfly-dev-1-os-logs"
+}
+
+resource "aws_cloudwatch_log_resource_policy" "opensearch_log_publishing_policy" {
+  policy_document = data.aws_iam_policy_document.opensearch_log_publishing_policy.json
+  policy_name     = "opensearch-log-publishing-policy"
+}

--- a/aws_dragonfly-dev_eu-west-1_os_dragonfly-dev-1-os_dependencies.tf
+++ b/aws_dragonfly-dev_eu-west-1_os_dragonfly-dev-1-os_dependencies.tf
@@ -1,0 +1,52 @@
+data "vault_generic_secret" "aws_infra_credential" {
+  path     = "secret/infra/aws/${local.aws_account_name}/terraform_admin"
+  provider = vault.eticloud
+}
+
+data "vault_generic_secret" "os_auth_credentials" {
+  path     = "secret/dev/os/eu-west-1/os-dragonfly-dev-1/master-user"
+  provider = vault.dragonfly
+}
+
+# OS account and region
+data "aws_caller_identity" "current" {} # data.aws_caller_identity.current.account_id
+data "aws_region" "current" {}          # data.aws_region.current.name
+
+data "aws_vpc" "database_vpc" {
+  filter {
+    name   = "tag:Name"
+    values = [local.data_vpc_name]
+  }
+}
+
+data "aws_subnets" "db_subnets" {
+  filter {
+    name   = "vpc-id"
+    values = [data.aws_vpc.database_vpc.id]
+  }
+  filter {
+    name = "tag:Name"
+    values = [
+      "dragonfly-data-vpc-db-eu-west-1a",
+      "dragonfly-data-vpc-db-eu-west-1b",
+      "dragonfly-data-vpc-db-eu-west-1c",
+    ]
+  }
+}
+
+data "aws_vpc" "compute_vpc" {
+  filter {
+    name   = "tag:Name"
+    values = [local.eks_vpc_name]
+  }
+}
+
+data "aws_subnets" "compute_subnets" {
+  filter {
+    name   = "vpc-id"
+    values = [data.aws_vpc.compute_vpc.id]
+  }
+  tags = {
+    Tier = "Private"
+  }
+}

--- a/aws_dragonfly-dev_eu-west-1_os_dragonfly-dev-1-os_iam.tf
+++ b/aws_dragonfly-dev_eu-west-1_os_dragonfly-dev-1-os_iam.tf
@@ -1,0 +1,37 @@
+# resource "aws_iam_service_linked_role" "dragonfly_linked_role" {
+#   aws_service_name = "opensearchservice.amazonaws.com"
+# }
+
+data "aws_iam_policy_document" "dragonfly_admin_access_policy" {
+  statement {
+    sid = "admin"
+
+    effect = "Allow"
+
+    principals {
+      type        = "AWS"
+      identifiers = ["*"]
+    }
+
+    actions = ["es:*"]
+
+    resources = ["arn:aws:es:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:domain/${var.domain_name}/*"]
+  }
+}
+
+data "aws_iam_policy_document" "opensearch_log_publishing_policy" {
+  statement {
+    actions = [
+      "logs:CreateLogStream",
+      "logs:PutLogEvents",
+      "logs:PutLogEventsBatch",
+    ]
+
+    resources = ["arn:aws:logs:*"]
+
+    principals {
+      identifiers = ["opensearchservice.amazonaws.com"]
+      type        = "Service"
+    }
+  }
+}

--- a/aws_dragonfly-dev_eu-west-1_os_dragonfly-dev-1-os_kms.tf
+++ b/aws_dragonfly-dev_eu-west-1_os_dragonfly-dev-1-os_kms.tf
@@ -1,0 +1,3 @@
+resource "aws_kms_key" "encryption_key" {
+  description = "${var.domain_name} encryption key"
+}

--- a/aws_dragonfly-dev_eu-west-1_os_dragonfly-dev-1-os_locals.tf
+++ b/aws_dragonfly-dev_eu-west-1_os_dragonfly-dev-1-os_locals.tf
@@ -1,0 +1,6 @@
+locals {
+  eks_vpc_name     = "dragonfly-dev-2-vpc"
+  data_vpc_name    = "dragonfly-data-vpc"
+  region           = "eu-west-1"
+  aws_account_name = "dragonfly-dev"
+}

--- a/aws_dragonfly-dev_eu-west-1_os_dragonfly-dev-1-os_main.tf
+++ b/aws_dragonfly-dev_eu-west-1_os_dragonfly-dev-1-os_main.tf
@@ -1,0 +1,101 @@
+resource "aws_opensearch_domain" "dragonfly_dev_1_os" {
+  depends_on = [
+    # aws_iam_service_linked_role.dragonfly_linked_role,
+    aws_cloudwatch_log_group.dragonfly_dev_1_os_logs,
+  ]
+
+  domain_name     = var.domain_name
+  engine_version  = var.engine_version
+  access_policies = null
+
+  cluster_config {
+    dedicated_master_enabled = true
+    dedicated_master_count   = 3
+    dedicated_master_type    = var.instance_type
+
+    instance_count = 3
+    instance_type  = var.instance_type
+
+    warm_enabled = true
+    warm_count   = 3
+    warm_type    = var.warm_instance_type
+
+    zone_awareness_enabled = true
+
+    zone_awareness_config {
+      availability_zone_count = 3
+    }
+
+    cold_storage_options {
+      enabled = true
+    }
+  }
+
+  vpc_options {
+    subnet_ids = data.aws_subnets.db_subnets.ids
+    security_group_ids = [
+      aws_security_group.dragonfly_dev_1_os.id
+    ]
+  }
+
+  advanced_security_options {
+    enabled                        = true
+    anonymous_auth_enabled         = false
+    internal_user_database_enabled = true
+
+    master_user_options {
+      master_user_name     = data.vault_generic_secret.os_auth_credentials.data["username"]
+      master_user_password = data.vault_generic_secret.os_auth_credentials.data["password"]
+    }
+  }
+
+  domain_endpoint_options {
+    enforce_https       = true
+    tls_security_policy = "Policy-Min-TLS-1-2-2019-07"
+
+    custom_endpoint_enabled = false
+  }
+
+  node_to_node_encryption {
+    enabled = true
+  }
+
+  encrypt_at_rest {
+    enabled    = true
+    kms_key_id = aws_kms_key.encryption_key.arn
+  }
+
+  ebs_options {
+    ebs_enabled = true
+    volume_type = "gp3"
+    volume_size = 1000
+    iops        = 3000
+    throughput  = 250
+  }
+
+  log_publishing_options {
+    log_type                 = "AUDIT_LOGS"
+    enabled                  = true
+    cloudwatch_log_group_arn = aws_cloudwatch_log_group.dragonfly_dev_1_os_logs.arn
+  }
+
+  auto_tune_options {
+    desired_state       = "ENABLED"
+    rollback_on_disable = "NO_ROLLBACK"
+  }
+
+
+  tags = {
+    DataClassification = "Cisco Restricted"
+    Environment        = "NonProd"
+    ApplicationName    = var.domain_name
+    ResourceOwner      = "eti sre"
+    CiscoMailAlias     = "eti-sre-admins@cisco.com"
+    DataTaxonomy       = "Cisco Operations Data"
+  }
+}
+
+resource "aws_opensearch_domain_policy" "this" {
+  domain_name     = aws_opensearch_domain.dragonfly_dev_1_os.domain_name
+  access_policies = data.aws_iam_policy_document.dragonfly_admin_access_policy.json
+}

--- a/aws_dragonfly-dev_eu-west-1_os_dragonfly-dev-1-os_providers.tf
+++ b/aws_dragonfly-dev_eu-west-1_os_dragonfly-dev-1-os_providers.tf
@@ -1,0 +1,28 @@
+provider "aws" {
+  access_key = data.vault_generic_secret.aws_infra_credential.data["AWS_ACCESS_KEY_ID"]
+  secret_key = data.vault_generic_secret.aws_infra_credential.data["AWS_SECRET_ACCESS_KEY"]
+  region     = "eu-west-1"
+
+  default_tags {
+    tags = {
+      ApplicationName    = var.domain_name
+      CiscoMailAlias     = "eti-sre-admins@cisco.com"
+      DataClassification = "Cisco Confidential"
+      DataTaxonomy       = "Cisco Operations Data"
+      EnvironmentName    = "NonProd"
+      ResourceOwner      = "ETI SRE"
+    }
+  }
+}
+
+provider "vault" {
+  alias     = "eticloud"
+  address   = "https://keeper.cisco.com"
+  namespace = "eticloud"
+}
+
+provider "vault" {
+  alias     = "dragonfly"
+  address   = "https://keeper.cisco.com"
+  namespace = "eticloud/apps/dragonfly"
+}

--- a/aws_dragonfly-dev_eu-west-1_os_dragonfly-dev-1-os_securitygroups.tf
+++ b/aws_dragonfly-dev_eu-west-1_os_dragonfly-dev-1-os_securitygroups.tf
@@ -1,0 +1,43 @@
+locals {
+  msk_ingress_rules = [
+    {
+      from_port : 443,
+      to_port : 443,
+      protocol : "tcp",
+      cidr_blocks : [
+        data.aws_vpc.compute_vpc.cidr_block,
+      ],
+    },
+  ]
+
+  msk_egress_rules = []
+}
+
+
+resource "aws_security_group" "dragonfly_dev_1_os" {
+  name        = "${var.domain_name}-default"
+  description = "${var.domain_name} opensearch cluster default security group"
+  vpc_id      = data.aws_vpc.database_vpc.id
+
+  dynamic "ingress" {
+    for_each = toset(local.msk_ingress_rules)
+
+    content {
+      from_port   = ingress.value.from_port
+      to_port     = ingress.value.to_port
+      protocol    = ingress.value.protocol
+      cidr_blocks = ingress.value.cidr_blocks
+    }
+  }
+
+  dynamic "egress" {
+    for_each = toset(local.msk_egress_rules)
+
+    content {
+      from_port   = egress.value.from_port
+      to_port     = egress.value.to_port
+      protocol    = egress.value.protocol
+      cidr_blocks = egress.value.cidr_blocks
+    }
+  }
+}

--- a/aws_dragonfly-dev_eu-west-1_os_dragonfly-dev-1-os_variables.tf
+++ b/aws_dragonfly-dev_eu-west-1_os_dragonfly-dev-1-os_variables.tf
@@ -1,0 +1,63 @@
+variable "cisco_cidrs" {
+  description = "Cisco network CIDRs"
+  default = [
+    "52.177.206.0/24",
+    "216.151.141.0/24",
+    "171.68.0.0/14",
+    "66.163.32.0/20",
+    "40.79.24.0/24",
+    "13.68.72.0/24",
+    "40.79.68.0/24",
+    "64.103.0.0/16",
+    "128.107.0.0/16",
+    "20.186.6.0/24",
+    "104.208.221.0/24",
+    "52.254.19.0/24",
+    "13.68.74.0/24",
+    "52.254.51.0/24",
+    "192.168.24.0/24",
+    "171.38.209.0/24",
+    "207.182.160.0/19",
+    "64.102.0.0/16",
+    "66.114.160.0/20",
+    "20.186.37.0/24",
+    "40.79.62.0/24",
+    "52.251.62.0/24",
+    "52.232.186.0/24",
+    "161.44.0.0/16",
+    "52.254.17.0/24",
+    "104.209.145.0/24",
+    "209.197.192.0/21",
+    "40.84.4.0/24",
+    "172.27.27.128/26",
+    "52.179.217.112/28",
+    "40.79.70.0/24",
+    "52.254.77.0/24",
+    "192.168.5.0/24",
+    "3.21.137.64/26",
+    "192.168.110.0/23",
+    "173.36.0.0/14",
+    "72.163.220.0/22",
+    "172.18.136.0/21"
+  ]
+}
+
+variable "domain_name" {
+  description = "Domain name for the Amazon OpenSearch Service domain"
+  default     = "os-dragonfly-dev-1"
+}
+
+variable "engine_version" {
+  description = "Engine version for the Amazon OpenSearch Service domain"
+  default     = "OpenSearch_2.11"
+}
+
+variable "instance_type" {
+  description = "Instance type to use for the Amazon OpenSearch Service domain"
+  default     = "r6g.large.search"
+}
+
+variable "warm_instance_type" {
+  description = "Warm instance type to use for the Amazon OpenSearch Service domain"
+  default     = "ultrawarm1.medium.search"
+}

--- a/aws_dragonfly-dev_eu-west-1_os_dragonfly-dev-1-os_versions.tf
+++ b/aws_dragonfly-dev_eu-west-1_os_dragonfly-dev-1-os_versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.3.6"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+}

--- a/aws_dragonfly-dev_eu-west-1_os_dragonfly-dev-1-osis_backend.tf
+++ b/aws_dragonfly-dev_eu-west-1_os_dragonfly-dev-1-osis_backend.tf
@@ -1,0 +1,7 @@
+terraform {
+  backend "s3" {
+    bucket = "eticloud-tf-state-nonprod"
+    key    = "terraform-state/aws-dragonfly-dev-1/os/eu-west-1/dragonfly-dev-1-osis.tfstate"
+    region = "us-east-2"
+  }
+}

--- a/aws_dragonfly-dev_eu-west-1_os_dragonfly-dev-1-osis_dependencies.tf
+++ b/aws_dragonfly-dev_eu-west-1_os_dragonfly-dev-1-osis_dependencies.tf
@@ -1,0 +1,85 @@
+# AWS credentials
+data "vault_generic_secret" "aws_infra_credential" {
+  path     = "secret/infra/aws/dragonfly-dev/terraform_admin"
+  provider = vault.eticloud
+}
+
+# OS account and region
+data "aws_caller_identity" "current" {} # data.aws_caller_identity.current.account_id
+data "aws_region" "current" {}          # data.aws_region.current.name
+
+# OS domain
+data "aws_opensearch_domain" "dragonfly_dev_1_os" {
+  domain_name = var.domain_name
+}
+
+# MSK cluster
+data "aws_msk_cluster" "dragonfly_msk_1" {
+  cluster_name = var.msk_cluster_name
+}
+
+data "aws_iam_policy_document" "pipeline_opensearch" {
+  statement {
+    effect  = "Allow"
+    actions = ["es:DescribeDomain"]
+    resources = [
+      data.aws_opensearch_domain.dragonfly_dev_1_os.arn,
+    ]
+  }
+
+  statement {
+    effect = "Allow"
+    actions = [
+      "es:ESHttp*",
+    ]
+    resources = [
+      "${data.aws_opensearch_domain.dragonfly_dev_1_os.arn}/*",
+    ]
+  }
+}
+
+data "aws_iam_policy_document" "pipeline_kafka" {
+  statement {
+    effect  = "Allow"
+    actions = ["es:DescribeDomain"]
+    resources = [
+      data.aws_opensearch_domain.dragonfly_dev_1_os.arn,
+    ]
+  }
+
+  statement {
+    effect = "Allow"
+    actions = [
+      "kafka-cluster:Connect",
+      "kafka-cluster:AlterCluster",
+      "kafka-cluster:DescribeCluster",
+      "kafka:DescribeClusterV2",
+      "kafka:GetBootstrapBrokers",
+    ]
+    resources = [
+      data.aws_msk_cluster.dragonfly_msk_1.arn,
+    ]
+  }
+
+  statement {
+    effect = "Allow"
+    actions = [
+      "kafka-cluster:*Topic*",
+      "kafka-cluster:ReadData",
+    ]
+    resources = [
+      "arn:aws:kafka:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:topic/${var.msk_cluster_name}/*",
+    ]
+  }
+
+  statement {
+    effect = "Allow"
+    actions = [
+      "kafka-cluster:AlterGroup",
+      "kafka-cluster:DescribeGroup"
+    ]
+    resources = [
+      "arn:aws:kafka:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:group/${var.msk_cluster_name}/*",
+    ]
+  }
+}

--- a/aws_dragonfly-dev_eu-west-1_os_dragonfly-dev-1-osis_iam.tf
+++ b/aws_dragonfly-dev_eu-west-1_os_dragonfly-dev-1-osis_iam.tf
@@ -1,0 +1,49 @@
+module "pipeline_role" {
+  source  = "terraform-aws-modules/iam/aws//modules/iam-assumable-role"
+  version = "~> 5.0"
+
+  create_role = true
+
+  role_name        = "${var.domain_name}-pipeline-role"
+  role_description = "IAM Role to be assumed by Opensearch ingestion pipeline"
+
+  trusted_role_services = [
+    "osis-pipelines.amazonaws.com",
+  ]
+
+  role_requires_mfa       = false
+  custom_role_policy_arns = [
+    module.pipeline_opensearch_policy.arn,
+    module.pipeline_kafka_policy.arn,
+  ]
+
+  tags = var.tags
+}
+
+module "pipeline_opensearch_policy" {
+  source  = "terraform-aws-modules/iam/aws//modules/iam-policy"
+  version = "~> 5.0"
+
+  create_policy = true
+
+  name        = "${var.domain_name}-ingestion-policy"
+  path        = "/"
+  description = "IAM Policy for Opensearch ingestion"
+  policy      = data.aws_iam_policy_document.pipeline_opensearch.json
+
+  tags = var.tags
+}
+
+module "pipeline_kafka_policy" {
+  source  = "terraform-aws-modules/iam/aws//modules/iam-policy"
+  version = "~> 5.0"
+
+  create_policy = true
+
+  name        = "${var.domain_name}-kafka-consumer-policy"
+  path        = "/"
+  description = "IAM Policy for Kafka consumer"
+  policy      = data.aws_iam_policy_document.pipeline_kafka.json
+
+  tags = var.tags
+}

--- a/aws_dragonfly-dev_eu-west-1_os_dragonfly-dev-1-osis_main.tf
+++ b/aws_dragonfly-dev_eu-west-1_os_dragonfly-dev-1-osis_main.tf
@@ -1,0 +1,61 @@
+locals {
+  pipelines = {
+    "dragonfly-osis-pipeline-1" = {
+      topics = [
+        "monitoring",
+      ],
+      min_units              = 1,
+      max_units              = 4,
+      pipeline_template_file = "./pipeline-monitoring.yaml",
+    },
+    "dragonfly-osis-pipeline-2" = {
+      topics = [
+        "threat",
+        "attack",
+      ]
+      min_units              = 1,
+      max_units              = 4,
+      pipeline_template_file = "./pipeline-threats-attacks.yaml",
+    },
+    "dragonfly-osis-pipeline-3" = {
+      topics = [
+        "falco",
+        "cloudtrail-ocsf",
+      ]
+      min_units              = 1,
+      max_units              = 4,
+      pipeline_template_file = "./pipeline-sa.yaml",
+    },
+  }
+}
+
+resource "awscc_osis_pipeline" "ingestion_pipeline" {
+  for_each = local.pipelines
+
+  pipeline_name = each.key
+  pipeline_configuration_body = templatefile(
+    each.value.pipeline_template_file, {
+    region          = data.aws_region.current.name
+    sts_role_arn    = module.pipeline_role.iam_role_arn
+    opensearch_host = data.aws_opensearch_domain.dragonfly_dev_1_os.endpoint
+
+    msk_cluster_arn = data.aws_msk_cluster.dragonfly_msk_1.arn
+    kafka_topics    = each.value.topics
+  })
+
+  min_units = each.value.min_units
+  max_units = each.value.max_units
+
+  log_publishing_options = {
+    is_logging_enabled = true
+    cloudwatch_log_destination = {
+      log_group = aws_cloudwatch_log_group.dragonfly_dev_1_osis_logs[each.key].name
+    }
+  }
+}
+
+resource "aws_cloudwatch_log_group" "dragonfly_dev_1_osis_logs" {
+  for_each = local.pipelines
+
+  name = "/aws/vendedlogs/OpenSearchIngestion/${each.key}/audit-logs"
+}

--- a/aws_dragonfly-dev_eu-west-1_os_dragonfly-dev-1-osis_providers.tf
+++ b/aws_dragonfly-dev_eu-west-1_os_dragonfly-dev-1-osis_providers.tf
@@ -1,0 +1,34 @@
+provider "aws" {
+  access_key = data.vault_generic_secret.aws_infra_credential.data["AWS_ACCESS_KEY_ID"]
+  secret_key = data.vault_generic_secret.aws_infra_credential.data["AWS_SECRET_ACCESS_KEY"]
+  region     = "eu-west-1"
+
+  default_tags {
+    tags = {
+      ApplicationName    = "osis-dragonfly-dev-1"
+      CiscoMailAlias     = "eti-sre-admins@cisco.com"
+      DataClassification = "Cisco Confidential"
+      DataTaxonomy       = "Cisco Operations Data"
+      EnvironmentName    = "NonProd"
+      ResourceOwner      = "ETI SRE"
+    }
+  }
+}
+
+provider "awscc" {
+  access_key = data.vault_generic_secret.aws_infra_credential.data["AWS_ACCESS_KEY_ID"]
+  secret_key = data.vault_generic_secret.aws_infra_credential.data["AWS_SECRET_ACCESS_KEY"]
+  region     = "eu-west-1"
+}
+
+provider "vault" {
+  alias     = "eticloud"
+  address   = "https://keeper.cisco.com"
+  namespace = "eticloud"
+}
+
+provider "vault" {
+  alias     = "dragonfly"
+  address   = "https://keeper.cisco.com"
+  namespace = "eticloud/apps/dragonfly"
+}

--- a/aws_dragonfly-dev_eu-west-1_os_dragonfly-dev-1-osis_variables.tf
+++ b/aws_dragonfly-dev_eu-west-1_os_dragonfly-dev-1-osis_variables.tf
@@ -1,0 +1,36 @@
+variable "domain_name" {
+  description = "The name of the domain"
+  type        = string
+  default     = "os-dragonfly-dev-1"
+}
+
+variable "msk_cluster_name" {
+  description = "The name of the MSK cluster"
+  type        = string
+  default     = "dragonfly-msk-1"
+}
+
+variable "kakfa_topic" {
+  description = "The name of the Kafka topic"
+  type        = string
+  default     = "test-topic"
+}
+
+variable "kakfa_group" {
+  description = "The name of the Kafka topic"
+  type        = string
+  default     = "test-group"
+}
+
+variable "tags" {
+  description = "Tags to apply to all resources"
+  type        = map(string)
+  default = {
+    ApplicationName    = "osis-dragonfly-dev-1"
+    CiscoMailAlias     = "eti-sre-admins@cisco.com"
+    DataClassification = "Cisco Confidential"
+    DataTaxonomy       = "Cisco Operations Data"
+    EnvironmentName    = "NonProd"
+    ResourceOwner      = "ETI SRE"
+  }
+}

--- a/aws_dragonfly-dev_eu-west-1_os_dragonfly-dev-1-osis_versions.tf
+++ b/aws_dragonfly-dev_eu-west-1_os_dragonfly-dev-1-osis_versions.tf
@@ -1,0 +1,14 @@
+terraform {
+  required_version = ">= 1.4"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 4.38"
+    }
+    awscc = {
+      source  = "hashicorp/awscc"
+      version = ">= 0.65.0"
+    }
+  }
+}

--- a/aws_dragonfly-dev_eu-west-1_rds_dragonfly-dev-rds-1_aurora-postgres.tf
+++ b/aws_dragonfly-dev_eu-west-1_rds_dragonfly-dev-rds-1_aurora-postgres.tf
@@ -1,0 +1,12 @@
+module "rds" {
+  source            = "git::https://github.com/cisco-eti/sre-tf-module-aws-aurora-postgres?ref=1.0.7"
+  vpc_name          = "dragonfly-data-vpc"
+  database_name     = "dragonflywheel"
+  db_instance_type  = "db.r5.xlarge"
+  cluster_name      = "dragonfly-rds-1"
+  db_engine_version = "13.12"
+  secret_path       = "secret/eticcprod/infra/aurora-pg/eu-west-1/dragonfly-rds-1"
+  db_allowed_cidrs = [
+    data.aws_vpc.eks_vpc.cidr_block,
+  ]
+}

--- a/aws_dragonfly-dev_eu-west-1_rds_dragonfly-dev-rds-1_backend.tf
+++ b/aws_dragonfly-dev_eu-west-1_rds_dragonfly-dev-rds-1_backend.tf
@@ -1,0 +1,7 @@
+terraform {
+  backend "s3" {
+    bucket = "eticloud-tf-state-nonprod"
+    key    = "terraform-state/aws-dragonfly-dev-1/aurora-postgres/eu-west-1/dragonfly-rds-1.tfstate"
+    region = "us-east-2"
+  }
+}

--- a/aws_dragonfly-dev_eu-west-1_rds_dragonfly-dev-rds-1_dependencies.tf
+++ b/aws_dragonfly-dev_eu-west-1_rds_dragonfly-dev-rds-1_dependencies.tf
@@ -1,0 +1,11 @@
+data "vault_generic_secret" "aws_infra_credential" {
+  path     = "secret/infra/aws/dragonfly-dev/terraform_admin"
+  provider = vault.eticloud
+}
+
+data "aws_vpc" "eks_vpc" {
+  filter {
+    name   = "tag:Name"
+    values = ["dragonfly-dev-2-vpc"]
+  }
+}

--- a/aws_dragonfly-dev_eu-west-1_rds_dragonfly-dev-rds-1_providers.tf
+++ b/aws_dragonfly-dev_eu-west-1_rds_dragonfly-dev-rds-1_providers.tf
@@ -1,0 +1,22 @@
+provider "vault" {
+  alias     = "eticloud"
+  address   = "https://keeper.cisco.com"
+  namespace = "eticloud"
+}
+
+provider "aws" {
+  access_key  = data.vault_generic_secret.aws_infra_credential.data["AWS_ACCESS_KEY_ID"]
+  secret_key  = data.vault_generic_secret.aws_infra_credential.data["AWS_SECRET_ACCESS_KEY"]
+  region      = "eu-west-1"
+  max_retries = 3
+  default_tags {
+    tags = {
+      ApplicationName    = "dragonfly-rds-1"
+      CiscoMailAlias     = "eti-sre-admins@cisco.com"
+      DataClassification = "Cisco Confidential"
+      DataTaxonomy       = "Cisco Operations Data"
+      EnvironmentName    = "NonProd"
+      ResourceOwner      = "ETI SRE"
+    }
+  }
+}

--- a/aws_dragonfly-dev_eu-west-1_rds_dragonfly-dev-rds-1_versions.tf
+++ b/aws_dragonfly-dev_eu-west-1_rds_dragonfly-dev-rds-1_versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.3.6"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 4.0"
+    }
+  }
+}

--- a/aws_dragonfly-dev_eu-west-1_redis_dragonfly-dev-redis-euw1-1_main.tf
+++ b/aws_dragonfly-dev_eu-west-1_redis_dragonfly-dev-redis-euw1-1_main.tf
@@ -1,0 +1,99 @@
+terraform {
+  backend "s3" {
+    # This is the name of the backend S3 bucket.
+    bucket = "eticloud-tf-state-nonprod"
+    # This is the path to the Terraform state file in the backend S3 bucket.
+    key = "terraform-state/aws/aws-dragonfly-dev-1/eu-west-1/redis/dragonfly-dev-redis-euw1-1.tfstate"
+    # This is the region where the backend S3 bucket is located.
+    region = "us-east-2" # DO NOT CHANGE.
+  }
+}
+
+locals {
+  name              = "dragonfly-dev-euw1-1"
+  eks_vpc_name      = "dragonfly-dev-2-vpc"
+  data_vpc_name     = "dragonfly-data-vpc"
+  region            = "eu-west-1"
+  aws_account_name  = "dragonfly-dev"
+  node_type         = "cache.t2.small"
+  subnet_group_name = "dragonfly-dev-data-sg-euw1-1"
+}
+
+provider "vault" {
+  alias     = "eticloud"
+  address   = "https://keeper.cisco.com"
+  namespace = "eticloud"
+}
+
+data "vault_generic_secret" "aws_infra_credential" {
+  provider = vault.eticloud
+  path     = "secret/infra/aws/${local.aws_account_name}/terraform_admin"
+}
+
+provider "aws" {
+  access_key = data.vault_generic_secret.aws_infra_credential.data["AWS_ACCESS_KEY_ID"]
+  secret_key = data.vault_generic_secret.aws_infra_credential.data["AWS_SECRET_ACCESS_KEY"]
+  region     = local.region
+}
+
+data "aws_vpc" "cluster_vpc" {
+  filter {
+    name   = "tag:Name"
+    values = [local.eks_vpc_name]
+  }
+}
+
+data "aws_vpc" "redis_vpc" {
+  filter {
+    name   = "tag:Name"
+    values = [local.data_vpc_name]
+  }
+}
+
+data "aws_subnets" "redis_subnets" {
+  filter {
+    name   = "vpc-id"
+    values = [data.aws_vpc.redis_vpc.id]
+  }
+  tags = {
+    Name = "*private*"
+  }
+}
+
+# Create a subnet group for the Elasticache service
+resource "aws_elasticache_subnet_group" "redis_subnet_group" {
+  name       = local.subnet_group_name
+  subnet_ids = data.aws_subnets.redis_subnets.ids
+}
+
+# Create a security group for the Elasticache service
+resource "aws_security_group" "redis_security_group" {
+  name   = local.subnet_group_name
+  vpc_id = data.aws_vpc.redis_vpc.id
+  ingress {
+    from_port   = 6379
+    to_port     = 6379
+    protocol    = "tcp"
+    cidr_blocks = [data.aws_vpc.cluster_vpc.cidr_block]
+  }
+}
+
+resource "aws_elasticache_replication_group" "dragonfly-dev-euw1-1" {
+  replication_group_id = local.name
+  description          = "Redis cluster ElastiCache"
+  engine               = "redis"
+  engine_version       = "7.1"
+
+  node_type                  = local.node_type
+  port                       = 6379
+  parameter_group_name       = "default.redis7.cluster.on"
+  automatic_failover_enabled = true
+  at_rest_encryption_enabled = true
+  transit_encryption_enabled = true
+
+  num_node_groups         = 1
+  replicas_per_node_group = 1
+
+  subnet_group_name  = local.subnet_group_name
+  security_group_ids = [aws_security_group.redis_security_group.id]
+}

--- a/aws_dragonfly-dev_eu-west-1_vpc-peering_dragonfly-dev-compute-to-data-peering-1_vpc-peering.tf
+++ b/aws_dragonfly-dev_eu-west-1_vpc-peering_dragonfly-dev-compute-to-data-peering-1_vpc-peering.tf
@@ -1,0 +1,126 @@
+terraform {
+  backend "s3" {
+    bucket = "eticloud-tf-state-nonprod"
+    key    = "terraform-state/aws-dragonfly-dev-1/vpc-peering/eu-west-1/compute-to-data/vpc-peering.tfstate"
+    region = "us-east-2"
+  }
+}
+
+provider "vault" {
+  alias     = "eticloud"
+  address   = "https://keeper.cisco.com"
+  namespace = "eticloud"
+}
+
+data "vault_generic_secret" "aws_infra_credential" {
+  path     = "secret/infra/aws/dragonfly-dev/terraform_admin"
+  provider = vault.eticloud
+}
+
+# Get the VPC IDs based on the names of the VPCs
+data "aws_vpc" "requestor_vpc" {
+  filter {
+    name   = "tag:ApplicationName"
+    values = ["dragonfly-dev-2"]
+  }
+}
+
+data "aws_vpc" "acceptor_vpc" {
+  filter {
+    name   = "tag:ApplicationName"
+    values = ["dragonfly-data-vpc"]
+  }
+}
+
+data "aws_route_tables" "requestor_vpc_rt" {
+  vpc_id = data.aws_vpc.requestor_vpc.id
+}
+
+data "aws_route_tables" "acceptor_vpc_rt" {
+  vpc_id = data.aws_vpc.acceptor_vpc.id
+}
+
+# Use this to get the account ID
+data "aws_caller_identity" "current" {}
+
+
+# By setting the AWS provider credentials via the data source above, we control in which account and region the resources get created.
+provider "aws" {
+  access_key  = data.vault_generic_secret.aws_infra_credential.data["AWS_ACCESS_KEY_ID"]
+  secret_key  = data.vault_generic_secret.aws_infra_credential.data["AWS_SECRET_ACCESS_KEY"]
+  region      = "eu-west-1"
+  max_retries = 3
+}
+
+# VPC peering resources
+resource "aws_vpc_peering_connection" "data_to_compute" {
+  peer_owner_id = data.aws_caller_identity.current.account_id
+  peer_vpc_id   = data.aws_vpc.acceptor_vpc.id
+  vpc_id        = data.aws_vpc.requestor_vpc.id
+  auto_accept   = true
+
+  accepter {
+    allow_remote_vpc_dns_resolution = true
+  }
+
+  requester {
+    allow_remote_vpc_dns_resolution = true
+  }
+
+  tags = {
+    Name                  = "VPC Peering between dragonfly-dev-2-vpc and dragonfly-data-vpc"
+    CSBApplicationName    = "nonprod-dragonfly-compute-data-peering"
+    CSBCiscoMailAlias     = "eti-sre@cisco.com"
+    CSBDataClassification = "Cisco Confidential"
+    CSBDataTaxonomy       = "Cisco Operations Data"
+    CSBEnvironment        = "NonProd"
+    CSBResourceOwner      = "ETI SRE"
+  }
+}
+
+# VPC routing resources
+resource "aws_route" "compute_to_data" {
+  count                     = length(data.aws_route_tables.requestor_vpc_rt.ids)
+  route_table_id            = data.aws_route_tables.requestor_vpc_rt.ids[count.index]
+  destination_cidr_block    = data.aws_vpc.acceptor_vpc.cidr_block
+  vpc_peering_connection_id = aws_vpc_peering_connection.data_to_compute.id
+}
+
+resource "aws_route" "data_to_compute" {
+  count                     = length(data.aws_route_tables.acceptor_vpc_rt.ids)
+  route_table_id            = data.aws_route_tables.acceptor_vpc_rt.ids[count.index]
+  destination_cidr_block    = data.aws_vpc.requestor_vpc.cidr_block
+  vpc_peering_connection_id = aws_vpc_peering_connection.data_to_compute.id
+}
+
+# Security groups
+resource "aws_security_group" "compute_to_data" {
+  name        = "compute-pvc-to-data-pvc"
+  description = "Allows all communication into data-pvc from the compute-pvc"
+  vpc_id      = data.aws_vpc.acceptor_vpc.id
+}
+
+resource "aws_security_group" "data_to_compute" {
+  name        = "eks-dev-1-to-nonprod-db-vpc-1"
+  description = "Allows all communication into compute-pvc from the data-pvc"
+  vpc_id      = data.aws_vpc.requestor_vpc.id
+}
+
+# security group rules because the rules are going to reference the groups
+resource "aws_security_group_rule" "compute_to_data" {
+  type                     = "ingress"
+  from_port                = 0
+  to_port                  = 65535
+  protocol                 = "-1"
+  security_group_id        = aws_security_group.compute_to_data.id
+  source_security_group_id = aws_security_group.data_to_compute.id
+}
+
+resource "aws_security_group_rule" "data_to_compute" {
+  type                     = "ingress"
+  from_port                = 0
+  to_port                  = 65535
+  protocol                 = "-1"
+  security_group_id        = aws_security_group.data_to_compute.id
+  source_security_group_id = aws_security_group.compute_to_data.id
+}

--- a/aws_dragonfly-dev_eu-west-1_vpc_dragonfly-dev-compute-vpc-1_vpc.tf
+++ b/aws_dragonfly-dev_eu-west-1_vpc_dragonfly-dev-compute-vpc-1_vpc.tf
@@ -35,7 +35,7 @@ data "vault_generic_secret" "aws_infra_credential" {
 }
 
 module "vpc" {
-  source                          = "git::https://github.cisco.com/cisco-eti/sre-tf-module-aws-vpc?ref=fix-bastion-sg"
+  source                          = "git::https://github.com/cisco-eti/sre-tf-module-aws-vpc?ref=fix-bastion-sg"
   region                          = "eu-west-1"
   vpc_cidr                        = "10.10.0.0/16"
   vpc_name                        = "dragonfly-dev-2"

--- a/aws_dragonfly-dev_eu-west-1_vpc_dragonfly-dev-compute-vpc-1_vpc.tf
+++ b/aws_dragonfly-dev_eu-west-1_vpc_dragonfly-dev-compute-vpc-1_vpc.tf
@@ -1,0 +1,45 @@
+terraform {
+  backend "s3" {
+    bucket = "eticloud-tf-state-nonprod"
+    key    = "terraform-state/aws-dragonfly-dev-1/vpc/eu-west-1/dragonfly-dev-2-vpc.tfstate"
+    region = "us-east-2"
+  }
+}
+
+provider "aws" {
+  access_key  = data.vault_generic_secret.aws_infra_credential.data["AWS_ACCESS_KEY_ID"]
+  secret_key  = data.vault_generic_secret.aws_infra_credential.data["AWS_SECRET_ACCESS_KEY"]
+  region      = "eu-west-1"
+  max_retries = 3
+  default_tags {
+    tags = {
+      ApplicationName    = "dragonfly-dev-2"
+      CiscoMailAlias     = "eti-sre-admins@cisco.com"
+      DataClassification = "Cisco Confidential"
+      DataTaxonomy       = "Cisco Operations Data"
+      EnvironmentName    = "NonProd"
+      ResourceOwner      = "ETI SRE"
+    }
+  }
+}
+
+provider "vault" {
+  alias     = "eticloud"
+  address   = "https://keeper.cisco.com"
+  namespace = "eticloud"
+}
+
+data "vault_generic_secret" "aws_infra_credential" {
+  path     = "secret/infra/aws/dragonfly-dev/terraform_admin"
+  provider = vault.eticloud
+}
+
+module "vpc" {
+  source                          = "git::https://github.cisco.com/cisco-eti/sre-tf-module-aws-vpc?ref=fix-bastion-sg"
+  region                          = "eu-west-1"
+  vpc_cidr                        = "10.10.0.0/16"
+  vpc_name                        = "dragonfly-dev-2"
+  cluster_name                    = "eks-dragonfly-dev-2"
+  create_database_subnet_group    = true
+  create_elasticache_subnet_group = false
+}

--- a/aws_dragonfly-dev_eu-west-1_vpc_dragonfly-dev-compute-vpc-1_vpc.tf
+++ b/aws_dragonfly-dev_eu-west-1_vpc_dragonfly-dev-compute-vpc-1_vpc.tf
@@ -35,7 +35,7 @@ data "vault_generic_secret" "aws_infra_credential" {
 }
 
 module "vpc" {
-  source                          = "git::https://github.com/cisco-eti/sre-tf-module-aws-vpc?ref=fix-bastion-sg"
+  source                          = "git::https://github.com/cisco-eti/sre-tf-module-aws-vpc?ref=2.0.6"
   region                          = "eu-west-1"
   vpc_cidr                        = "10.10.0.0/16"
   vpc_name                        = "dragonfly-dev-2"

--- a/aws_dragonfly-dev_eu-west-1_vpc_dragonfly-dev-data-vpc-1_vpc.tf
+++ b/aws_dragonfly-dev_eu-west-1_vpc_dragonfly-dev-data-vpc-1_vpc.tf
@@ -1,0 +1,45 @@
+terraform {
+  backend "s3" {
+    bucket = "eticloud-tf-state-nonprod"
+    key    = "terraform-state/aws-dragonfly-dev-1/vpc/eu-west-1/dragonfly-data-vpc.tfstate"
+    region = "us-east-2"
+  }
+}
+
+provider "aws" {
+  access_key  = data.vault_generic_secret.aws_infra_credential.data["AWS_ACCESS_KEY_ID"]
+  secret_key  = data.vault_generic_secret.aws_infra_credential.data["AWS_SECRET_ACCESS_KEY"]
+  region      = "eu-west-1"
+  max_retries = 3
+  default_tags {
+    tags = {
+      ApplicationName    = "dragonfly-data-vpc"
+      CiscoMailAlias     = "eti-sre-admins@cisco.com"
+      DataClassification = "Cisco Confidential"
+      DataTaxonomy       = "Cisco Operations Data"
+      EnvironmentName    = "NonProd"
+      ResourceOwner      = "ETI SRE"
+    }
+  }
+}
+
+provider "vault" {
+  alias     = "eticloud"
+  address   = "https://keeper.cisco.com"
+  namespace = "eticloud"
+}
+
+data "vault_generic_secret" "aws_infra_credential" {
+  path     = "secret/infra/aws/dragonfly-dev/terraform_admin"
+  provider = vault.eticloud
+}
+
+module "vpc" {
+  source                          = "git::https://github.cisco.com/cisco-eti/sre-tf-module-aws-vpc?ref=2.0.4"
+  region                          = "eu-west-1"
+  vpc_cidr                        = "10.11.0.0/16"
+  vpc_name                        = "dragonfly-data"
+  cluster_name                    = "dragonfly-msk-eks"
+  create_database_subnet_group    = true
+  create_elasticache_subnet_group = false
+}

--- a/aws_dragonfly-dev_eu-west-1_vpc_dragonfly-dev-data-vpc-1_vpc.tf
+++ b/aws_dragonfly-dev_eu-west-1_vpc_dragonfly-dev-data-vpc-1_vpc.tf
@@ -35,7 +35,7 @@ data "vault_generic_secret" "aws_infra_credential" {
 }
 
 module "vpc" {
-  source                          = "git::https://github.cisco.com/cisco-eti/sre-tf-module-aws-vpc?ref=2.0.4"
+  source                          = "git::https://github.com/cisco-eti/sre-tf-module-aws-vpc?ref=2.0.4"
   region                          = "eu-west-1"
   vpc_cidr                        = "10.11.0.0/16"
   vpc_name                        = "dragonfly-data"

--- a/aws_dragonfly-dev_eu-west-1_vpc_dragonfly-dev-data-vpc-1_vpc.tf
+++ b/aws_dragonfly-dev_eu-west-1_vpc_dragonfly-dev-data-vpc-1_vpc.tf
@@ -35,7 +35,7 @@ data "vault_generic_secret" "aws_infra_credential" {
 }
 
 module "vpc" {
-  source                          = "git::https://github.com/cisco-eti/sre-tf-module-aws-vpc?ref=2.0.4"
+  source                          = "git::https://github.com/cisco-eti/sre-tf-module-aws-vpc?ref=2.0.6"
   region                          = "eu-west-1"
   vpc_cidr                        = "10.11.0.0/16"
   vpc_name                        = "dragonfly-data"

--- a/aws_dragonfly-prod_us-east-2_eks_dragonfly-prod-1-alb-iam_backend.tf
+++ b/aws_dragonfly-prod_us-east-2_eks_dragonfly-prod-1-alb-iam_backend.tf
@@ -1,0 +1,7 @@
+terraform {
+  backend "s3" {
+    bucket = "eticloud-tf-state-prod"
+    key    = "terraform-state/aws-dragonfly-production/iam/eks-dragonfly-prod-1-alb-iam.tfstate"
+    region = "us-east-2"
+  }
+}

--- a/aws_dragonfly-prod_us-east-2_eks_dragonfly-prod-1-alb-iam_dependencies.tf
+++ b/aws_dragonfly-prod_us-east-2_eks_dragonfly-prod-1-alb-iam_dependencies.tf
@@ -1,0 +1,9 @@
+data "vault_generic_secret" "aws_infra_credential" {
+  path = "secret/infra/aws/dragonfly-prod/terraform_admin"
+}
+
+data "aws_eks_cluster" "cluster" {
+  name = var.cluster_name
+}
+
+data "aws_caller_identity" "current" {}

--- a/aws_dragonfly-prod_us-east-2_eks_dragonfly-prod-1-alb-iam_main.tf
+++ b/aws_dragonfly-prod_us-east-2_eks_dragonfly-prod-1-alb-iam_main.tf
@@ -1,0 +1,38 @@
+locals {
+  account_id = data.aws_caller_identity.current.account_id
+  oidc_id    = trimprefix(data.aws_eks_cluster.cluster.identity[0].oidc[0].issuer, "https://")
+}
+
+resource "aws_iam_policy" "aws_alb_controller_policy" {
+  name        = "${var.cluster_name}-aws-alb-controller-policy"
+  description = "${var.cluster_name} AWS ALB Controller Role IAM Policy"
+  policy      = file("./resources/aws_alb_controller_policy.json")
+}
+
+resource "aws_iam_role" "aws_alb_controller_role" {
+  name = "${var.cluster_name}-aws-alb-controller-role"
+  assume_role_policy = jsonencode({
+    "Version" : "2012-10-17"
+    "Statement" : [
+      {
+        "Effect" : "Allow",
+        "Principal" : {
+          "Federated" : "arn:aws:iam::${local.account_id}:oidc-provider/${local.oidc_id}"
+        },
+        "Action" : "sts:AssumeRoleWithWebIdentity",
+        "Condition" : {
+          "StringEquals" : {
+            "${local.oidc_id}:aud" : "sts.amazonaws.com",
+            "${local.oidc_id}:sub" : "system:serviceaccount:kube-system:aws-load-balancer-controller"
+          }
+        }
+      }
+    ]
+  })
+  force_detach_policies = true
+}
+
+resource "aws_iam_role_policy_attachment" "aws_alb_controller_attachment" {
+  role       = aws_iam_role.aws_alb_controller_role.name
+  policy_arn = aws_iam_policy.aws_alb_controller_policy.arn
+}

--- a/aws_dragonfly-prod_us-east-2_eks_dragonfly-prod-1-alb-iam_providers.tf
+++ b/aws_dragonfly-prod_us-east-2_eks_dragonfly-prod-1-alb-iam_providers.tf
@@ -1,0 +1,23 @@
+provider "vault" {
+  address   = "https://keeper.cisco.com"
+  namespace = "eticloud"
+}
+
+provider "aws" {
+  access_key  = data.vault_generic_secret.aws_infra_credential.data["AWS_ACCESS_KEY_ID"]
+  secret_key  = data.vault_generic_secret.aws_infra_credential.data["AWS_SECRET_ACCESS_KEY"]
+  region      = "us-east-2"
+  max_retries = 3
+  default_tags {
+    # These tags are required for security compliance.
+    # For more information on Data Classification and Data Taxonomy, please talk to the SRE team.
+    tags = {
+      ApplicationName    = "${var.cluster_name} aws alb controller IAM"
+      CiscoMailAlias     = "eti-sre-admins@cisco.com"
+      DataClassification = "Cisco Confidential"
+      DataTaxonomy       = "Cisco Operations Data"
+      Environment        = "Prod"
+      ResourceOwner      = "ETI SRE"
+    }
+  }
+}

--- a/aws_dragonfly-prod_us-east-2_eks_dragonfly-prod-1-alb-iam_variables.tf
+++ b/aws_dragonfly-prod_us-east-2_eks_dragonfly-prod-1-alb-iam_variables.tf
@@ -1,0 +1,4 @@
+variable "cluster_name" {
+  type    = string
+  default = "dragonfly-prod-1"
+}

--- a/aws_dragonfly-prod_us-east-2_eks_dragonfly-prod-1-cm_aws-auth-configmap.tf
+++ b/aws_dragonfly-prod_us-east-2_eks_dragonfly-prod-1-cm_aws-auth-configmap.tf
@@ -1,0 +1,19 @@
+locals {
+  aws_auth_configmap_b64_decode  = base64decode(data.vault_generic_secret.aws_auth_configmap.data["sre_configmap_json_b64"])
+  aws_auth_configmap_json_decode = jsondecode(local.aws_auth_configmap_b64_decode)
+  aws_auth_configmap_data = {
+    mapRoles = yamlencode(local.aws_auth_configmap_json_decode)
+  }
+}
+
+resource "kubernetes_config_map_v1_data" "aws_auth_sre_data" {
+  provider = kubernetes.eks
+  force    = true
+
+  metadata {
+    name      = "aws-auth"
+    namespace = "kube-system"
+  }
+
+  data = local.aws_auth_configmap_data
+}

--- a/aws_dragonfly-prod_us-east-2_eks_dragonfly-prod-1-cm_backend.tf
+++ b/aws_dragonfly-prod_us-east-2_eks_dragonfly-prod-1-cm_backend.tf
@@ -1,0 +1,7 @@
+terraform {
+  backend "s3" {
+    bucket = "eticloud-tf-state-prod"                                                                 # We separate the different environments into different buckets. The buckets are eticloud-tf-state-sandbox, eticloud-tf-state-nonprod, eticloud-tf-state-prod. The environment should match the CSBEnvironment below.
+    key    = "terraform-state/aws-dragonfly-production/eks/us-east-2/eks-dragonfly-prod-1-cm.tfstate" # Note the path here. It should match the patten terraform_state/<service>/<region>/<name>.tfstate
+    region = "us-east-2"                                                                              # Do not change
+  }
+}

--- a/aws_dragonfly-prod_us-east-2_eks_dragonfly-prod-1-cm_dependencies.tf
+++ b/aws_dragonfly-prod_us-east-2_eks_dragonfly-prod-1-cm_dependencies.tf
@@ -1,0 +1,22 @@
+data "vault_generic_secret" "aws_infra_credential" {
+  path     = "secret/infra/aws/dragonfly-prod/terraform_admin"
+  provider = vault.eticloud
+}
+
+data "vault_generic_secret" "cluster_certificate" {
+  path     = "secret/infra/eks/dragonfly-prod-1/certificate"
+  provider = vault.eticloud
+}
+
+data "vault_generic_secret" "aws_auth_configmap" {
+  path     = "secret/infra/eks/dragonfly-prod-1/aws-auth"
+  provider = vault.eticloud
+}
+
+data "aws_eks_cluster" "cluster" {
+  name = "dragonfly-prod-1"
+}
+
+data "aws_eks_cluster_auth" "cluster" {
+  name = "dragonfly-prod-1"
+}

--- a/aws_dragonfly-prod_us-east-2_eks_dragonfly-prod-1-cm_providers.tf
+++ b/aws_dragonfly-prod_us-east-2_eks_dragonfly-prod-1-cm_providers.tf
@@ -1,0 +1,30 @@
+provider "vault" {
+  address   = "https://keeper.cisco.com"
+  namespace = "eticloud"
+  alias     = "eticloud"
+}
+
+# Infra AWS Provider
+provider "aws" {
+  access_key  = data.vault_generic_secret.aws_infra_credential.data["AWS_ACCESS_KEY_ID"]
+  secret_key  = data.vault_generic_secret.aws_infra_credential.data["AWS_SECRET_ACCESS_KEY"]
+  region      = "us-east-2"
+  max_retries = 3
+  default_tags {
+    tags = {
+      DataClassification = "Cisco Restricted"
+      Environment        = "Prod"
+      ApplicationName    = "dragonfly-prod-1"
+      ResourceOwner      = "eti sre"
+      CiscoMailAlias     = "eti-sre-admins@cisco.com"
+      DataTaxonomy       = "Cisco Operations Data"
+    }
+  }
+}
+
+provider "kubernetes" {
+  host                   = data.aws_eks_cluster.cluster.endpoint
+  cluster_ca_certificate = base64decode(data.vault_generic_secret.cluster_certificate.data["b64certificate"])
+  token                  = data.aws_eks_cluster_auth.cluster.token
+  alias                  = "eks"
+}

--- a/aws_dragonfly-prod_us-east-2_eks_dragonfly-prod-1-cm_versions.tf
+++ b/aws_dragonfly-prod_us-east-2_eks_dragonfly-prod-1-cm_versions.tf
@@ -1,0 +1,14 @@
+terraform {
+  required_version = ">= 1.3.6"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+    vault = {
+      source  = "hashicorp/vault"
+      version = "~> 3.0"
+    }
+  }
+}

--- a/aws_dragonfly-prod_us-east-2_eks_dragonfly-prod-1-iam_backend.tf
+++ b/aws_dragonfly-prod_us-east-2_eks_dragonfly-prod-1-iam_backend.tf
@@ -1,0 +1,7 @@
+terraform {
+  backend "s3" {
+    bucket = "eticloud-tf-state-nonprod"
+    key    = "terraform-state/aws/dragonfly-prod/us-east-2/eks/dragonfly-prod-1-iam.tfstate"
+    region = "us-east-2"
+  }
+}

--- a/aws_dragonfly-prod_us-east-2_eks_dragonfly-prod-1-iam_dependencies.tf
+++ b/aws_dragonfly-prod_us-east-2_eks_dragonfly-prod-1-iam_dependencies.tf
@@ -1,0 +1,29 @@
+data "vault_generic_secret" "aws_infra_credential" {
+  path     = "secret/infra/aws/${local.aws_account_name}/terraform_admin"
+  provider = vault.eticloud
+}
+
+// account information
+data "aws_caller_identity" "current" {}
+data "aws_region" "current" {}
+
+data "aws_msk_cluster" "dragonfly_msk_1" {
+  cluster_name = local.dragonfly_msk_cluster_name
+}
+
+// EKS
+data "aws_eks_cluster" "cluster" {
+  name = local.cluster_name
+}
+
+data "aws_s3_bucket" "mskconnect_custom_plugin_bucket" {
+  bucket = local.arango_connector_plugin_bucket
+}
+
+data "aws_s3_bucket" "mskconnect_logs_bucket" {
+  bucket = local.arangodb_connector_logs_bucket
+}
+
+data "aws_iam_role" "mskconnect_arangodb_execution_role" {
+  name = local.arangodb_connector_execution_role
+}

--- a/aws_dragonfly-prod_us-east-2_eks_dragonfly-prod-1-iam_locals.tf
+++ b/aws_dragonfly-prod_us-east-2_eks_dragonfly-prod-1-iam_locals.tf
@@ -1,0 +1,20 @@
+locals {
+  app_name         = "dragonfly-prod"
+  aws_account_name = "dragonfly-prod"
+  aws_region       = "us-east-2"
+  account_id       = data.aws_caller_identity.current.account_id
+
+  cluster_name = "dragonfly-prod-1"
+  oidc_id      = trimprefix(data.aws_eks_cluster.cluster.identity[0].oidc[0].issuer, "https://")
+
+  dragonfly_backend_namespace = "dragonfly-backend"
+  dragonfly_msk_cluster_name  = "dragonfly-msk-prod-1"
+
+  arango_connector_plugin_bucket    = "dragonfly-prod-binaries-repository"
+  arangodb_connector_logs_bucket    = "dragonfly-prod-kafka-connector-log-files"
+  arangodb_connector_execution_role = "kafka-connect-arangodb-role"
+
+  dragonfly_argo_service_account                = "${local.dragonfly_backend_namespace}:dragonfly-thrill-argo"
+  dragonfly_streaman_service_account            = "${local.dragonfly_backend_namespace}:dragonfly-streaman-service-account"
+  dragonfly_ml_inference_client_service_account = "${local.dragonfly_backend_namespace}:dragonfly-ml-inferenceclient-a-dev-app"
+}

--- a/aws_dragonfly-prod_us-east-2_eks_dragonfly-prod-1-iam_outputs.tf
+++ b/aws_dragonfly-prod_us-east-2_eks_dragonfly-prod-1-iam_outputs.tf
@@ -1,0 +1,8 @@
+# Role ID
+output "dragonfly_streaman_connector_role_id" {
+  value = aws_iam_role.dragonfly_streaman.arn
+}
+
+output "dragonfly_thrill_msk_role_id" {
+  value = aws_iam_role.dragonfly_thrill_msk_writer.arn
+}

--- a/aws_dragonfly-prod_us-east-2_eks_dragonfly-prod-1-iam_providers.tf
+++ b/aws_dragonfly-prod_us-east-2_eks_dragonfly-prod-1-iam_providers.tf
@@ -1,0 +1,23 @@
+provider "vault" {
+  alias     = "eticloud"
+  address   = "https://keeper.cisco.com"
+  namespace = "eticloud"
+}
+
+provider "aws" {
+  access_key  = data.vault_generic_secret.aws_infra_credential.data["AWS_ACCESS_KEY_ID"]
+  secret_key  = data.vault_generic_secret.aws_infra_credential.data["AWS_SECRET_ACCESS_KEY"]
+  region      = local.aws_region
+  max_retries = 3
+
+  default_tags {
+    tags = {
+      ApplicationName    = local.app_name
+      CiscoMailAlias     = "eti-sre-admins@cisco.com"
+      DataClassification = "Cisco Confidential"
+      DataTaxonomy       = "Cisco Operations Data"
+      EnvironmentName    = "NonProd"
+      ResourceOwner      = "ETI SRE"
+    }
+  }
+}

--- a/aws_dragonfly-prod_us-east-2_eks_dragonfly-prod-1-iam_role-streaman.tf
+++ b/aws_dragonfly-prod_us-east-2_eks_dragonfly-prod-1-iam_role-streaman.tf
@@ -1,0 +1,109 @@
+resource "aws_iam_role" "dragonfly_streaman" {
+  name = "${local.cluster_name}-streaman-role"
+
+  assume_role_policy = jsonencode({
+    "Version" : "2012-10-17"
+    "Statement" : [
+      {
+        "Effect" : "Allow",
+        "Principal" : {
+          "Federated" : "arn:aws:iam::${local.account_id}:oidc-provider/${local.oidc_id}"
+        },
+        "Action" : "sts:AssumeRoleWithWebIdentity",
+        "Condition" : {
+          "StringEquals" : {
+            "${local.oidc_id}:aud" : "sts.amazonaws.com",
+            "${local.oidc_id}:sub" : "system:serviceaccount:${local.dragonfly_streaman_service_account}"
+          }
+        }
+      }
+    ]
+  })
+  force_detach_policies = true
+}
+
+data "aws_iam_policy_document" "dragonfly_streaman_kafka_policy" {
+  statement {
+    sid = "access"
+
+    actions = [
+      "kafka-cluster:Connect",
+      "kafka-cluster:AlterCluster",
+      "kafka-cluster:DescribeCluster",
+      "kafka:DescribeClusterV2",
+      "kafka:GetBootstrapBrokers",
+    ]
+
+    resources = [
+      "arn:aws:kafka:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:cluster/${data.aws_msk_cluster.dragonfly_msk_1.cluster_name}/${data.aws_msk_cluster.dragonfly_msk_1.cluster_uuid}"
+    ]
+  }
+
+  statement {
+    sid = "kafkawriter"
+
+    actions = [
+      "kafka-cluster:*Topic*",
+    ]
+
+    resources = [
+      "arn:aws:kafka:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:topic/${data.aws_msk_cluster.dragonfly_msk_1.cluster_name}/${data.aws_msk_cluster.dragonfly_msk_1.cluster_uuid}/kg-node*",
+      "arn:aws:kafka:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:topic/${data.aws_msk_cluster.dragonfly_msk_1.cluster_name}/${data.aws_msk_cluster.dragonfly_msk_1.cluster_uuid}/kg-edge*",
+    ]
+  }
+
+  statement {
+    sid = "kafkareader"
+
+    actions = [
+      "kafka-cluster:*Topic*",
+      "kafka-cluster:ReadData",
+    ]
+
+    resources = [
+      "arn:aws:kafka:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:topic/${data.aws_msk_cluster.dragonfly_msk_1.cluster_name}/${data.aws_msk_cluster.dragonfly_msk_1.id}/falco",
+      "arn:aws:kafka:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:topic/${data.aws_msk_cluster.dragonfly_msk_1.cluster_name}/${data.aws_msk_cluster.dragonfly_msk_1.id}/monitoring",
+    ]
+  }
+
+  statement {
+    sid = "kafkagroupreader"
+
+    actions = [
+      "kafka-cluster:AlterGroup",
+      "kafka-cluster:DescribeGroup",
+    ]
+
+    resources = [
+      "arn:aws:kafka:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:group/${data.aws_msk_cluster.dragonfly_msk_1.cluster_name}/${data.aws_msk_cluster.dragonfly_msk_1.id}/*",
+      "arn:aws:kafka:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:group/${data.aws_msk_cluster.dragonfly_msk_1.cluster_name}/${data.aws_msk_cluster.dragonfly_msk_1.id}/*",
+    ]
+  }
+}
+
+resource "aws_iam_policy" "dragonfly_streaman_kafka_policy" {
+  name        = "${local.cluster_name}-streaman-connector-writer-policy"
+  description = "Policies for streaman role"
+  policy      = data.aws_iam_policy_document.dragonfly_streaman_kafka_policy.json
+}
+
+resource "aws_iam_policy" "dragonfly_streaman_kafkconnect_policy" {
+  name        = "${local.cluster_name}-streaman-kafkaconnect-polic"
+  description = "${local.cluster_name} policy for streaman role"
+  policy = templatefile(
+    "${path.module}/resources/msk-connect-policy.json", {
+      kakfa_connect_arangodb_logs_bucket    = data.aws_s3_bucket.mskconnect_logs_bucket.arn
+      kakfa_connect_arangodb_execution_role = data.aws_iam_role.mskconnect_arangodb_execution_role.arn
+      dragonly_binaries_bucket              = data.aws_s3_bucket.mskconnect_custom_plugin_bucket.arn
+  })
+}
+
+resource "aws_iam_role_policy_attachment" "dragonfly_msk_argo_writer_policy_attachment" {
+  for_each = {
+    kafka-policy         = aws_iam_policy.dragonfly_streaman_kafka_policy.arn,
+    kafka-connect-policy = aws_iam_policy.dragonfly_streaman_kafkconnect_policy.arn
+  }
+
+  role       = aws_iam_role.dragonfly_streaman.name
+  policy_arn = each.value
+}

--- a/aws_dragonfly-prod_us-east-2_eks_dragonfly-prod-1-iam_role-thrill-msk-writer.tf
+++ b/aws_dragonfly-prod_us-east-2_eks_dragonfly-prod-1-iam_role-thrill-msk-writer.tf
@@ -1,0 +1,66 @@
+resource "aws_iam_role" "dragonfly_thrill_msk_writer" {
+  name = "${local.cluster_name}-thrill-msk-writer-role"
+
+  assume_role_policy = jsonencode({
+    "Version" : "2012-10-17"
+    "Statement" : [
+      {
+        "Effect" : "Allow",
+        "Principal" : {
+          "Federated" : "arn:aws:iam::${local.account_id}:oidc-provider/${local.oidc_id}"
+        },
+        "Action" : "sts:AssumeRoleWithWebIdentity",
+        "Condition" : {
+          "StringEquals" : {
+            "${local.oidc_id}:aud" : "sts.amazonaws.com",
+            "${local.oidc_id}:sub" : "system:serviceaccount:${local.dragonfly_argo_service_account}"
+          }
+        }
+      }
+    ]
+  })
+  force_detach_policies = true
+}
+
+data "aws_iam_policy_document" "dragonfly_thrill_msk_writer_policies" {
+  statement {
+    sid = "access"
+
+    actions = [
+      "kafka-cluster:Connect",
+    ]
+
+    resources = [
+      "arn:aws:kafka:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:cluster/${data.aws_msk_cluster.dragonfly_msk_1.cluster_name}/${data.aws_msk_cluster.dragonfly_msk_1.cluster_uuid}"
+    ]
+
+    effect = "Allow"
+  }
+
+  statement {
+    sid = "topic"
+
+    actions = [
+      "kafka-cluster:DescribeTopic",
+      "kafka-cluster:WriteData",
+    ]
+
+    resources = [
+      "arn:aws:kafka:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:topic/${data.aws_msk_cluster.dragonfly_msk_1.cluster_name}/${data.aws_msk_cluster.dragonfly_msk_1.cluster_uuid}/threat",
+      "arn:aws:kafka:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:topic/${data.aws_msk_cluster.dragonfly_msk_1.cluster_name}/${data.aws_msk_cluster.dragonfly_msk_1.cluster_uuid}/attack",
+    ]
+
+    effect = "Allow"
+  }
+}
+
+resource "aws_iam_policy" "dragonfly_thrill_msk_writer_policies" {
+  name        = "${local.cluster_name}-thrill-msk-writer-policies"
+  description = "Policies for thrill MSK writer role on threat and attack topics"
+  policy      = data.aws_iam_policy_document.dragonfly_thrill_msk_writer_policies.json
+}
+
+resource "aws_iam_role_policy_attachment" "dragonfly_thrill_msk_writer_policy_attachment" {
+  role       = aws_iam_role.dragonfly_thrill_msk_writer.name
+  policy_arn = aws_iam_policy.dragonfly_thrill_msk_writer_policies.arn
+}

--- a/aws_dragonfly-prod_us-east-2_eks_dragonfly-prod-1_backend.tf
+++ b/aws_dragonfly-prod_us-east-2_eks_dragonfly-prod-1_backend.tf
@@ -1,0 +1,7 @@
+terraform {
+  backend "s3" {
+    bucket = "eticloud-tf-state-prod"
+    key    = "terraform-state/aws-dragonfly-production/eks/us-east-2/eks-dragonfly-prod-1.tfstate"
+    region = "us-east-2"
+  }
+}

--- a/aws_dragonfly-prod_us-east-2_eks_dragonfly-prod-1_dependencies.tf
+++ b/aws_dragonfly-prod_us-east-2_eks_dragonfly-prod-1_dependencies.tf
@@ -1,0 +1,5 @@
+data "vault_generic_secret" "aws_infra_credential" {
+  path = "secret/infra/aws/dragonfly-prod/terraform_admin"
+}
+
+data "aws_caller_identity" "current" {}

--- a/aws_dragonfly-prod_us-east-2_eks_dragonfly-prod-1_eks.tf
+++ b/aws_dragonfly-prod_us-east-2_eks_dragonfly-prod-1_eks.tf
@@ -1,0 +1,69 @@
+module "eks" {
+  source          = "git::https://github.com/cisco-eti/sre-tf-module-aws-eks?ref=2.0.1"
+  cluster_name    = "dragonfly-prod-1"
+  cluster_version = "1.27" # don't roll back!
+  cluster_os      = "AmazonLinux2"
+  vpc_name        = "dragonfly-compute-prod-1-vpc"
+
+  # Private Node group options
+  create_private_nodegroup            = true            # Defaults to true. Must be true for any of the below to be set by the module,
+  private_node_group_desired_capacity = 6               # The desired number of worker nodes. Once this is set, the number of desired instances must be manually modified.
+  private_node_group_min_capacity     = 5               # The minimum number of worker nodes.
+  private_node_group_max_capacity     = 10              # The maximium number of worker nodes.
+  private_node_group_instance_type    = ["m5a.2xlarge"] # The instance type for the worker nodes.
+
+  # Public Node group options
+  create_public_nodegroup            = false          # Defaults to false. Must be true for any of the below to be set by the module,
+  public_node_group_desired_capacity = 0              # The desired number of worker nodes. Once this is set, the number of desired instances must be manually modified.
+  public_node_group_min_capacity     = 0              # The minimum number of worker nodes.
+  public_node_group_max_capacity     = 0              # The maximium number of worker nodes.
+  public_node_group_instance_type    = ["m5a.xlarge"] # The instance type for the worker nodes.
+
+  # aws-auth configmap
+  create_aws_auth_configmap = false
+  manage_aws_auth_configmap = false # Set to false in SRE module
+
+  aws_auth_additional_roles = [
+    {
+      rolearn  = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/admin"
+      username = "admin"
+      groups   = ["system:masters"]
+    },
+    {
+      rolearn  = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/devops",
+      username = "devops",
+      groups   = ["system:masters"]
+    },
+    { # Role for karpenter
+      rolearn  = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/KarpenterNodeRole-dragonfly-prod-1",
+      username = "system:node:{{EC2PrivateDNSName}}",
+      groups   = ["system:bootstrappers", "system:nodes"]
+    }
+  ]
+
+  cluster_addons = {
+    coredns = {
+      addon_version = "v1.10.1-eksbuild.4"
+    }
+    kube-proxy = {
+      addon_version = "v1.27.6-eksbuild.2"
+    }
+    vpc-cni = {
+      addon_version = "v1.15.1-eksbuild.1"
+      configuration_values = jsonencode({
+        env = {
+          # Reference docs https://docs.aws.amazon.com/eks/latest/userguide/cni-increase-ip-addresses.html
+          ENABLE_PREFIX_DELEGATION = "false"
+          WARM_PREFIX_TARGET       = "0"
+        }
+      })
+    }
+    aws-ebs-csi-driver = {
+      addon_version = "v1.23.1-eksbuild.1"
+    }
+  }
+
+  providers = {
+    vault = vault.eticloud
+  }
+}

--- a/aws_dragonfly-prod_us-east-2_eks_dragonfly-prod-1_providers.tf
+++ b/aws_dragonfly-prod_us-east-2_eks_dragonfly-prod-1_providers.tf
@@ -1,0 +1,21 @@
+provider "aws" {
+  access_key = data.vault_generic_secret.aws_infra_credential.data["AWS_ACCESS_KEY_ID"]
+  secret_key = data.vault_generic_secret.aws_infra_credential.data["AWS_SECRET_ACCESS_KEY"]
+  region     = "us-east-2"
+  default_tags {
+    tags = {
+      ApplicationName    = "dragonfly-prod-1"
+      CiscoMailAlias     = "eti-sre-admins@cisco.com"
+      DataClassification = "Cisco Confidential"
+      DataTaxonomy       = "Cisco Operations Data"
+      Environment        = "Prod"
+      ResourceOwner      = "ETI SRE"
+    }
+  }
+}
+
+provider "vault" {
+  address   = "https://keeper.cisco.com"
+  namespace = "eticloud"
+  alias     = "eticloud"
+}

--- a/aws_dragonfly-prod_us-east-2_eks_dragonfly-prod-1_versions.tf
+++ b/aws_dragonfly-prod_us-east-2_eks_dragonfly-prod-1_versions.tf
@@ -1,0 +1,14 @@
+terraform {
+  required_version = ">= 1.3.6"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+    vault = {
+      source  = "hashicorp/vault"
+      version = "~> 2.0"
+    }
+  }
+}

--- a/aws_dragonfly-prod_us-east-2_msk_dragonfly-prod-msk-1_backend.tf
+++ b/aws_dragonfly-prod_us-east-2_msk_dragonfly-prod-msk-1_backend.tf
@@ -1,0 +1,7 @@
+terraform {
+  backend "s3" {
+    bucket = "eticloud-tf-state-prod"
+    key    = "terraform-state/aws-dragonfly-production/msk/us-east-2/dragonfly-msk-prod-1.tfstate"
+    region = "us-east-2"
+  }
+}

--- a/aws_dragonfly-prod_us-east-2_msk_dragonfly-prod-msk-1_cloudwatch.tf
+++ b/aws_dragonfly-prod_us-east-2_msk_dragonfly-prod-msk-1_cloudwatch.tf
@@ -1,0 +1,3 @@
+resource "aws_cloudwatch_log_group" "broker_logs" {
+  name = "dragonfly-msk-prod-1-broker-logs"
+}

--- a/aws_dragonfly-prod_us-east-2_msk_dragonfly-prod-msk-1_dependencies.tf
+++ b/aws_dragonfly-prod_us-east-2_msk_dragonfly-prod-msk-1_dependencies.tf
@@ -1,0 +1,71 @@
+data "vault_generic_secret" "aws_infra_credential" {
+  path     = "secret/infra/aws/${local.aws_account_name}/terraform_admin"
+  provider = vault.eticloud
+}
+
+data "aws_caller_identity" "current" {} # data.aws_caller_identity.current.account_id
+data "aws_region" "current" {}          # data.aws_region.current.name
+
+data "aws_iam_policy_document" "msk_secret_policy" {
+  for_each = var.kafka_clients
+
+  statement {
+    sid    = "AWSKafkaResourcePolicy"
+    effect = "Allow"
+
+    principals {
+      type        = "Service"
+      identifiers = ["kafka.amazonaws.com"]
+    }
+
+    actions   = ["secretsmanager:getSecretValue"]
+    resources = [aws_secretsmanager_secret.msk_auth_credentials[each.key].arn]
+  }
+}
+
+data "aws_vpc" "eks_vpc" {
+  filter {
+    name   = "tag:Name"
+    values = ["dragonfly-compute-prod-1-vpc"]
+  }
+}
+
+data "aws_vpc" "msk_vpc" {
+  filter {
+    name   = "tag:Name"
+    values = ["dragonfly-data-prod-1-vpc"]
+  }
+}
+
+data "aws_subnets" "eks_subnets" {
+  filter {
+    name   = "vpc-id"
+    values = [data.aws_vpc.eks_vpc.id]
+  }
+  tags = {
+    Tier = "Private"
+  }
+}
+
+data "aws_subnets" "msk_subnets" {
+  filter {
+    name   = "vpc-id"
+    values = [data.aws_vpc.msk_vpc.id]
+  }
+  tags = {
+    Tier = "Private"
+  }
+}
+
+data "aws_s3_bucket" "mskconnect_custom_plugin_bucket" {
+  bucket = local.arango_connector_plugin_bucket
+}
+
+data "aws_s3_bucket" "mskconnect_logs_bucket" {
+  bucket = local.arangodb_connector_logs_bucket
+}
+
+data "aws_s3_object" "arangodb_connector_plugin_jar" {
+  bucket = local.arango_connector_plugin_bucket
+  key    = local.arangodb_connector_plugin_jar
+}

--- a/aws_dragonfly-prod_us-east-2_msk_dragonfly-prod-msk-1_kafka-connect.tf
+++ b/aws_dragonfly-prod_us-east-2_msk_dragonfly-prod-msk-1_kafka-connect.tf
@@ -1,0 +1,139 @@
+resource "aws_mskconnect_custom_plugin" "plugin" {
+  name         = "${local.arango_connector_plugin_name}-plugin"
+  content_type = "JAR"
+  location {
+    s3 {
+      bucket_arn = data.aws_s3_bucket.mskconnect_custom_plugin_bucket.arn
+      file_key   = data.aws_s3_object.arangodb_connector_plugin_jar.key
+    }
+  }
+}
+
+resource "aws_iam_role" "connector_role" {
+  name = "${local.arango_connector_plugin_name}-role"
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        "Effect" = "Allow",
+        "Principal" : {
+          "Service" = "kafkaconnect.amazonaws.com"
+        },
+        "Action" = "sts:AssumeRole"
+      }
+    ]
+  })
+}
+
+data "aws_iam_policy_document" "connector_role_policy_document" {
+  statement {
+    effect = "Allow"
+
+    actions = [
+      "kafka-cluster:Connect",
+      "kafka-cluster:AlterCluster",
+      "kafka-cluster:DescribeCluster",
+      "kafka:DescribeClusterV2",
+      "kafka:GetBootstrapBrokers"
+    ]
+
+    resources = [
+      aws_msk_cluster.dragonfly_msk_1.arn
+    ]
+  }
+
+  statement {
+    effect = "Allow"
+
+    actions = [
+      "kafka-cluster:*Topic*",
+      "kafka-cluster:ReadData"
+    ]
+
+    resources = [
+      "arn:aws:kafka:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:topic/${aws_msk_cluster.dragonfly_msk_1.cluster_name}/${aws_msk_cluster.dragonfly_msk_1.cluster_uuid}/*",
+    ]
+  }
+
+  statement {
+    actions = [
+      "kafka-cluster:CreateTopic",
+      "kafka-cluster:WriteData",
+      "kafka-cluster:ReadData",
+      "kafka-cluster:DescribeTopic"
+    ]
+
+    resources = [
+      "arn:aws:kafka:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:topic/${aws_msk_cluster.dragonfly_msk_1.cluster_name}/${aws_msk_cluster.dragonfly_msk_1.cluster_uuid}/__amazon_msk_connect_*",
+    ]
+  }
+
+  statement {
+    effect = "Allow"
+
+    actions = [
+      "kafka-cluster:AlterGroup",
+      "kafka-cluster:DescribeGroup"
+    ]
+
+    resources = [
+      "arn:aws:kafka:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:group/${aws_msk_cluster.dragonfly_msk_1.cluster_name}/${aws_msk_cluster.dragonfly_msk_1.cluster_uuid}/__amazon_msk_connect_*",
+      "arn:aws:kafka:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:group/${aws_msk_cluster.dragonfly_msk_1.cluster_name}/${aws_msk_cluster.dragonfly_msk_1.cluster_uuid}/connect-*",
+    ]
+  }
+
+  statement {
+    effect = "Allow"
+
+    actions = [
+      "logs:CreateLogDelivery",
+      "logs:GetLogDelivery",
+      "logs:DescribeLogDelivery",
+      "logs:DeleteLogDelivery",
+      "logs:ListLogDeliveries"
+    ]
+
+    resources = [
+      "*"
+    ]
+  }
+
+  statement {
+    effect = "Allow"
+
+    actions = [
+      "s3:PutObject"
+    ]
+
+    resources = [
+      "arn:aws:s3:::${local.arangodb_connector_logs_bucket}/*"
+    ]
+  }
+}
+
+resource "aws_iam_policy" "connector_role_policy" {
+  name        = "${local.arango_connector_plugin_name}-role-policy"
+  description = "Policies for arangodb connector role"
+  policy      = data.aws_iam_policy_document.connector_role_policy_document.json
+}
+
+resource "aws_iam_role_policy_attachment" "connector_role_policy_attachment" {
+  role       = aws_iam_role.connector_role.name
+  policy_arn = aws_iam_policy.connector_role_policy.arn
+}
+
+# Export useful information to Vault
+resource "vault_generic_secret" "kafka_connect_vault" {
+  path = "secret/prod/dragonfly-streaman/us/msk"
+
+  data_json = jsonencode({
+    mskCustomPluginArn         = aws_mskconnect_custom_plugin.plugin.arn,
+    mskCustomPluginRevision    = aws_mskconnect_custom_plugin.plugin.latest_revision
+    mskS3LogBucket             = data.aws_s3_bucket.mskconnect_logs_bucket.bucket
+    mskServiceExecutionRoleArn = aws_iam_role.connector_role.arn
+    mskVpcSG                   = aws_security_group.dragonfly_msk_1.id
+    mskVpcSubnets              = join(",", data.aws_subnets.msk_subnets.ids)
+  })
+
+  provider = vault.dragonfly
+}

--- a/aws_dragonfly-prod_us-east-2_msk_dragonfly-prod-msk-1_kms.tf
+++ b/aws_dragonfly-prod_us-east-2_msk_dragonfly-prod-msk-1_kms.tf
@@ -1,0 +1,3 @@
+resource "aws_kms_key" "encryption_key" {
+  description = "dragonfly-msk-prod-1 MSK cluster encryption key"
+}

--- a/aws_dragonfly-prod_us-east-2_msk_dragonfly-prod-msk-1_locals.tf
+++ b/aws_dragonfly-prod_us-east-2_msk_dragonfly-prod-msk-1_locals.tf
@@ -1,0 +1,10 @@
+locals {
+  aws_account_name = "dragonfly-prod"
+  aws_region       = "us-east-2"
+
+  arango_connector_plugin_name      = "kafka-connect-arangodb"
+  arango_connector_plugin_bucket    = "dragonfly-prod-binaries-repository"
+  arangodb_connector_logs_bucket    = "dragonfly-prod-kafka-connector-log-files"
+  arangodb_connector_plugin_version = "1.2.0"
+  arangodb_connector_plugin_jar     = "kafka-connect-arangodb-${local.arangodb_connector_plugin_version}.jar"
+}

--- a/aws_dragonfly-prod_us-east-2_msk_dragonfly-prod-msk-1_msk.tf
+++ b/aws_dragonfly-prod_us-east-2_msk_dragonfly-prod-msk-1_msk.tf
@@ -1,0 +1,154 @@
+resource "aws_msk_configuration" "configuration" {
+  kafka_versions = [var.kafka_version]
+  name           = "dragonfly-msk-prod-1"
+
+  server_properties = <<PROPERTIES
+auto.create.topics.enable = true
+PROPERTIES
+}
+
+resource "aws_msk_scram_secret_association" "msk_auth_credentials" {
+  cluster_arn = aws_msk_cluster.dragonfly_msk_1.arn
+  secret_arn_list = [
+    for s in aws_secretsmanager_secret.msk_auth_credentials : s.arn
+  ]
+
+  depends_on = [aws_secretsmanager_secret_version.msk_auth_credentials_1]
+}
+
+resource "aws_msk_cluster" "dragonfly_msk_1" {
+  cluster_name           = "dragonfly-msk-prod-1"
+  kafka_version          = var.kafka_version
+  number_of_broker_nodes = var.number_of_broker_nodes
+
+  // Broker configuration
+  broker_node_group_info {
+    instance_type = var.instance_type
+
+    client_subnets = data.aws_subnets.msk_subnets.ids
+
+    storage_info {
+      ebs_storage_info {
+        volume_size = 1000
+      }
+    }
+
+    // Turn on multi-vpc connectivity
+    connectivity_info {
+      vpc_connectivity {
+        client_authentication {
+          sasl {
+            scram = false
+            iam   = true
+          }
+        }
+      }
+    }
+
+    security_groups = [aws_security_group.dragonfly_msk_1.id]
+  }
+
+  // Encryption
+  encryption_info {
+    encryption_at_rest_kms_key_arn = aws_kms_key.encryption_key.arn
+
+    encryption_in_transit {
+      client_broker = "TLS"
+      in_cluster    = true
+    }
+  }
+
+  // Authentication
+  client_authentication {
+    sasl {
+      scram = true
+      iam   = true
+    }
+  }
+
+  // Cluster config
+  configuration_info {
+    arn      = aws_msk_configuration.configuration.arn
+    revision = aws_msk_configuration.configuration.latest_revision
+  }
+
+  // Monitoring && logging
+  open_monitoring {
+    prometheus {
+      jmx_exporter {
+        enabled_in_broker = true
+      }
+      node_exporter {
+        enabled_in_broker = true
+      }
+    }
+  }
+
+  enhanced_monitoring = "PER_TOPIC_PER_PARTITION"
+
+  logging_info {
+    broker_logs {
+      cloudwatch_logs {
+        enabled   = true
+        log_group = aws_cloudwatch_log_group.broker_logs.name
+      }
+    }
+  }
+}
+
+// Save brokers in vault
+resource "vault_generic_secret" "msk_brokers_sasl_scram" {
+  path = "secret/prod/msk/dragonfly-msk-1/brokers"
+
+  data_json = jsonencode({
+    brokers = aws_msk_cluster.dragonfly_msk_1.bootstrap_brokers_sasl_scram
+  })
+
+  provider = vault.dragonfly
+}
+
+resource "aws_msk_cluster_policy" "opensearch_ingestion_policy" {
+  cluster_arn = aws_msk_cluster.dragonfly_msk_1.arn
+
+  policy = jsonencode({
+    "Version" : "2012-10-17",
+    "Statement" : [
+      {
+        "Effect" : "Allow",
+        "Principal" : {
+          "Service" : "osis.amazonaws.com"
+        },
+        "Action" : [
+          "kafka:CreateVpcConnection",
+          "kafka:DescribeCluster",
+          "kafka:DescribeClusterV2"
+        ],
+        "Resource" : aws_msk_cluster.dragonfly_msk_1.arn
+      },
+      {
+        "Effect" : "Allow",
+        "Principal" : {
+          "Service" : "osis-pipelines.amazonaws.com"
+        },
+        "Action" : [
+          "kafka:CreateVpcConnection",
+          "kafka:GetBootstrapBrokers",
+          "kafka:DescribeCluster",
+          "kafka:DescribeClusterV2"
+        ],
+        "Resource" : aws_msk_cluster.dragonfly_msk_1.arn
+    }]
+  })
+}
+
+// Save brokers in vault
+resource "vault_generic_secret" "msk_brokers" {
+  path = "secret/prod/msk/${data.aws_region.current.name}/${aws_msk_cluster.dragonfly_msk_1.cluster_name}/brokers"
+
+  data_json = jsonencode({
+    brokers     = aws_msk_cluster.dragonfly_msk_1.bootstrap_brokers_sasl_scram
+    brokers-iam = aws_msk_cluster.dragonfly_msk_1.bootstrap_brokers_sasl_iam
+  })
+
+  provider = vault.dragonfly
+}

--- a/aws_dragonfly-prod_us-east-2_msk_dragonfly-prod-msk-1_outputs.tf
+++ b/aws_dragonfly-prod_us-east-2_msk_dragonfly-prod-msk-1_outputs.tf
@@ -1,0 +1,19 @@
+output "zookeeper_connect_string" {
+  value = aws_msk_cluster.dragonfly_msk_1.zookeeper_connect_string
+}
+
+output "bootstrap_brokers" {
+  value = aws_msk_cluster.dragonfly_msk_1.bootstrap_brokers
+}
+
+output "bootstrap_brokers_tls" {
+  value = aws_msk_cluster.dragonfly_msk_1.bootstrap_brokers_tls
+}
+
+output "bootstrap_brokers_sasl_iam" {
+  value = aws_msk_cluster.dragonfly_msk_1.bootstrap_brokers_sasl_iam
+}
+
+output "bootstrap_brokers_sasl_scram" {
+  value = aws_msk_cluster.dragonfly_msk_1.bootstrap_brokers_sasl_scram
+}

--- a/aws_dragonfly-prod_us-east-2_msk_dragonfly-prod-msk-1_providers.tf
+++ b/aws_dragonfly-prod_us-east-2_msk_dragonfly-prod-msk-1_providers.tf
@@ -1,0 +1,28 @@
+provider "aws" {
+  access_key = data.vault_generic_secret.aws_infra_credential.data["AWS_ACCESS_KEY_ID"]
+  secret_key = data.vault_generic_secret.aws_infra_credential.data["AWS_SECRET_ACCESS_KEY"]
+  region     = local.aws_region
+
+  default_tags {
+    tags = {
+      ApplicationName    = "dragonfly-msk-prod-1"
+      CiscoMailAlias     = "eti-sre-admins@cisco.com"
+      DataClassification = "Cisco Confidential"
+      DataTaxonomy       = "Cisco Operations Data"
+      Environment        = "Prod"
+      ResourceOwner      = "ETI SRE"
+    }
+  }
+}
+
+provider "vault" {
+  alias     = "eticloud"
+  address   = "https://keeper.cisco.com"
+  namespace = "eticloud"
+}
+
+provider "vault" {
+  alias     = "dragonfly"
+  address   = "https://keeper.cisco.com"
+  namespace = "eticloud/apps/dragonfly"
+}

--- a/aws_dragonfly-prod_us-east-2_msk_dragonfly-prod-msk-1_secretsmanager.tf
+++ b/aws_dragonfly-prod_us-east-2_msk_dragonfly-prod-msk-1_secretsmanager.tf
@@ -1,0 +1,47 @@
+// Generate random passwords
+resource "random_password" "password" {
+  for_each = var.kafka_clients
+
+  length  = 64
+  special = false
+}
+
+// Save secrets in Vault
+resource "vault_generic_secret" "msk_auth_credentials" {
+  for_each = var.kafka_clients
+
+  path = each.value.vault_path
+
+  data_json = jsonencode({
+    username = each.key
+    password = random_password.password[each.key].result
+  })
+
+  provider = vault.dragonfly
+}
+
+// Secrets for SASL/SCRAM authentication
+resource "aws_secretsmanager_secret" "msk_auth_credentials" {
+  for_each = var.kafka_clients
+
+  name        = "AmazonMSK_dragonfly-msk-1-${each.key}-auth"
+  description = each.value.description
+
+  kms_key_id = aws_kms_key.encryption_key.key_id
+}
+
+// Secret versions
+resource "aws_secretsmanager_secret_version" "msk_auth_credentials_1" {
+  for_each = var.kafka_clients
+
+  secret_id     = aws_secretsmanager_secret.msk_auth_credentials[each.key].id
+  secret_string = vault_generic_secret.msk_auth_credentials[each.key].data_json
+}
+
+// Secret policy
+resource "aws_secretsmanager_secret_policy" "msk_secret_policy" {
+  for_each = var.kafka_clients
+
+  secret_arn = aws_secretsmanager_secret.msk_auth_credentials[each.key].arn
+  policy     = data.aws_iam_policy_document.msk_secret_policy[each.key].json
+}

--- a/aws_dragonfly-prod_us-east-2_msk_dragonfly-prod-msk-1_securitygroup.tf
+++ b/aws_dragonfly-prod_us-east-2_msk_dragonfly-prod-msk-1_securitygroup.tf
@@ -1,0 +1,80 @@
+locals {
+  msk_ingress_rules = [
+    {
+      from_port : 9094,
+      to_port : 9094,
+      protocol : "tcp",
+      cidr_blocks : [
+        data.aws_vpc.msk_vpc.cidr_block,
+        data.aws_vpc.eks_vpc.cidr_block,
+      ],
+    },
+    {
+      from_port : 9096,
+      to_port : 9096,
+      protocol : "tcp",
+      cidr_blocks : [
+        data.aws_vpc.msk_vpc.cidr_block,
+        data.aws_vpc.eks_vpc.cidr_block,
+      ],
+    },
+    {
+      from_port : 9098,
+      to_port : 9098,
+      protocol : "tcp",
+      cidr_blocks : [
+        data.aws_vpc.msk_vpc.cidr_block,
+        data.aws_vpc.eks_vpc.cidr_block,
+      ],
+    },
+    {
+      from_port : 2181,
+      to_port : 2181,
+      protocol : "tcp",
+      cidr_blocks : [
+        data.aws_vpc.msk_vpc.cidr_block,
+      ],
+    },
+  ]
+
+  msk_egress_rules = [
+    {
+      from_port : 0,
+      to_port : 65535,
+      protocol : "tcp",
+      cidr_blocks : [
+        data.aws_vpc.msk_vpc.cidr_block,
+        data.aws_vpc.eks_vpc.cidr_block,
+      ],
+    },
+  ]
+}
+
+
+resource "aws_security_group" "dragonfly_msk_1" {
+  name        = "dragonfly-msk-prod-1-msk-default"
+  description = "dragonfly-msk-prod-1 MSK cluster default security group"
+  vpc_id      = data.aws_vpc.msk_vpc.id
+
+  dynamic "ingress" {
+    for_each = toset(local.msk_ingress_rules)
+
+    content {
+      from_port   = ingress.value.from_port
+      to_port     = ingress.value.to_port
+      protocol    = ingress.value.protocol
+      cidr_blocks = ingress.value.cidr_blocks
+    }
+  }
+
+  dynamic "egress" {
+    for_each = toset(local.msk_egress_rules)
+
+    content {
+      from_port   = egress.value.from_port
+      to_port     = egress.value.to_port
+      protocol    = egress.value.protocol
+      cidr_blocks = egress.value.cidr_blocks
+    }
+  }
+}

--- a/aws_dragonfly-prod_us-east-2_msk_dragonfly-prod-msk-1_variables.tf
+++ b/aws_dragonfly-prod_us-east-2_msk_dragonfly-prod-msk-1_variables.tf
@@ -1,0 +1,39 @@
+variable "kafka_version" {
+  description = "Kafka version to deploy"
+  type        = string
+  default     = "3.6.0"
+}
+
+variable "instance_type" {
+  description = "Instance type to use for Kafka brokers"
+  type        = string
+  default     = "kafka.m5.xlarge"
+}
+
+variable "number_of_broker_nodes" {
+  description = "Number of Kafka broker nodes to deploy"
+  type        = number
+  default     = 3
+}
+
+variable "kafka_clients" {
+  description = "Kafka clients to create"
+  type = map(object({
+    description = string
+    vault_path  = string
+  }))
+  default = {
+    "otel-collector" = {
+      description = "Auth credentials of otel-collector for dragonfly-msk-prod-1"
+      vault_path  = "secret/prod/msk/dragonfly-msk-1/kafka-clients/otel-collector"
+    },
+    "notification-service" = {
+      description = "Auth credentials of notification-service for dragonfly-msk-prod-1"
+      vault_path  = "secret/prod/msk/dragonfly-msk-1/kafka-clients/notification-service"
+    },
+    "opensearch-ingestion-service" = {
+      description = "Auth credentials of ingestion-service for dragonfly-msk-prod-1"
+      vault_path  = "secret/prod/msk/dragonfly-msk-1/kafka-clients/opensearch-ingestion-service"
+    },
+  }
+}

--- a/aws_dragonfly-prod_us-east-2_msk_dragonfly-prod-msk-1_versions.tf
+++ b/aws_dragonfly-prod_us-east-2_msk_dragonfly-prod-msk-1_versions.tf
@@ -1,0 +1,18 @@
+terraform {
+  required_version = ">= 1.3.6"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+    vault = {
+      source  = "hashicorp/vault"
+      version = "~> 3.0"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = "~> 3.0"
+    }
+  }
+}

--- a/aws_dragonfly-prod_us-east-2_os_dragonfly-prod-1-os_backend.tf
+++ b/aws_dragonfly-prod_us-east-2_os_dragonfly-prod-1-os_backend.tf
@@ -1,0 +1,7 @@
+terraform {
+  backend "s3" {
+    bucket = "eticloud-tf-state-prod"
+    key    = "terraform-state/aws-dragonfly-production/os/us-east-2/dragonfly-prod-1-os.tfstate"
+    region = "us-east-2"
+  }
+}

--- a/aws_dragonfly-prod_us-east-2_os_dragonfly-prod-1-os_cloudwatch.tf
+++ b/aws_dragonfly-prod_us-east-2_os_dragonfly-prod-1-os_cloudwatch.tf
@@ -1,0 +1,8 @@
+resource "aws_cloudwatch_log_group" "dragonfly_prod_1_os_logs" {
+  name = "dragonfly-prod-1-os-logs"
+}
+
+resource "aws_cloudwatch_log_resource_policy" "opensearch_log_publishing_policy" {
+  policy_document = data.aws_iam_policy_document.opensearch_log_publishing_policy.json
+  policy_name     = "opensearch-log-publishing-policy"
+}

--- a/aws_dragonfly-prod_us-east-2_os_dragonfly-prod-1-os_dependencies.tf
+++ b/aws_dragonfly-prod_us-east-2_os_dragonfly-prod-1-os_dependencies.tf
@@ -1,0 +1,45 @@
+data "vault_generic_secret" "aws_infra_credential" {
+  path     = "secret/infra/aws/${local.account_name}/terraform_admin"
+  provider = vault.eticloud
+}
+
+# OS account and region
+data "aws_caller_identity" "current" {} # data.aws_caller_identity.current.account_id
+data "aws_region" "current" {}          # data.aws_region.current.name
+
+data "aws_vpc" "database_vpc" {
+  filter {
+    name   = "tag:Name"
+    values = ["dragonfly-data-prod-1-vpc"]
+  }
+}
+
+data "aws_subnets" "db_subnets" {
+  filter {
+    name   = "vpc-id"
+    values = [data.aws_vpc.database_vpc.id]
+  }
+  filter {
+    name = "tag:Name"
+    values = [
+      "dragonfly-data-prod-1-vpc-db-${data.aws_region.current.name}*"
+    ]
+  }
+}
+
+data "aws_vpc" "compute_vpc" {
+  filter {
+    name   = "tag:Name"
+    values = ["dragonfly-compute-prod-1-vpc"]
+  }
+}
+
+data "aws_subnets" "compute_subnets" {
+  filter {
+    name   = "vpc-id"
+    values = [data.aws_vpc.compute_vpc.id]
+  }
+  tags = {
+    Tier = "Private"
+  }
+}

--- a/aws_dragonfly-prod_us-east-2_os_dragonfly-prod-1-os_iam.tf
+++ b/aws_dragonfly-prod_us-east-2_os_dragonfly-prod-1-os_iam.tf
@@ -1,0 +1,37 @@
+# resource "aws_iam_service_linked_role" "dragonfly_linked_role" {
+#   aws_service_name = "opensearchservice.amazonaws.com"
+# }
+
+data "aws_iam_policy_document" "dragonfly_admin_access_policy" {
+  statement {
+    sid = "admin"
+
+    effect = "Allow"
+
+    principals {
+      type        = "AWS"
+      identifiers = ["*"]
+    }
+
+    actions = ["es:*"]
+
+    resources = ["arn:aws:es:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:domain/${var.domain_name}/*"]
+  }
+}
+
+data "aws_iam_policy_document" "opensearch_log_publishing_policy" {
+  statement {
+    actions = [
+      "logs:CreateLogStream",
+      "logs:PutLogEvents",
+      "logs:PutLogEventsBatch",
+    ]
+
+    resources = ["arn:aws:logs:*"]
+
+    principals {
+      identifiers = ["opensearchservice.amazonaws.com"]
+      type        = "Service"
+    }
+  }
+}

--- a/aws_dragonfly-prod_us-east-2_os_dragonfly-prod-1-os_kms.tf
+++ b/aws_dragonfly-prod_us-east-2_os_dragonfly-prod-1-os_kms.tf
@@ -1,0 +1,3 @@
+resource "aws_kms_key" "encryption_key" {
+  description = "${var.domain_name} encryption key"
+}

--- a/aws_dragonfly-prod_us-east-2_os_dragonfly-prod-1-os_locals.tf
+++ b/aws_dragonfly-prod_us-east-2_os_dragonfly-prod-1-os_locals.tf
@@ -1,0 +1,3 @@
+locals {
+  account_name = "dragonfly-prod"
+}

--- a/aws_dragonfly-prod_us-east-2_os_dragonfly-prod-1-os_main.tf
+++ b/aws_dragonfly-prod_us-east-2_os_dragonfly-prod-1-os_main.tf
@@ -1,0 +1,101 @@
+resource "aws_opensearch_domain" "dragonfly_prod_1_os" {
+  depends_on = [
+    # aws_iam_service_linked_role.dragonfly_linked_role,
+    aws_cloudwatch_log_group.dragonfly_prod_1_os_logs,
+  ]
+
+  domain_name     = var.domain_name
+  engine_version  = var.engine_version
+  access_policies = null
+
+  cluster_config {
+    dedicated_master_enabled = true
+    dedicated_master_count   = 3
+    dedicated_master_type    = var.instance_type
+
+    instance_count = 12
+    instance_type  = var.instance_type
+
+    warm_enabled = true
+    warm_count   = 5
+    warm_type    = var.warm_instance_type
+
+    zone_awareness_enabled = true
+
+    zone_awareness_config {
+      availability_zone_count = 3
+    }
+
+    cold_storage_options {
+      enabled = true
+    }
+  }
+
+  vpc_options {
+    subnet_ids = data.aws_subnets.db_subnets.ids
+    security_group_ids = [
+      aws_security_group.dragonfly_prod_1_os.id
+    ]
+  }
+
+  advanced_security_options {
+    enabled                        = true
+    anonymous_auth_enabled         = false
+    internal_user_database_enabled = true
+
+    master_user_options {
+      master_user_name     = vault_generic_secret.os_auth_credentials.data["username"]
+      master_user_password = vault_generic_secret.os_auth_credentials.data["password"]
+    }
+  }
+
+  domain_endpoint_options {
+    enforce_https       = true
+    tls_security_policy = "Policy-Min-TLS-1-2-2019-07"
+
+    custom_endpoint_enabled = false
+  }
+
+  node_to_node_encryption {
+    enabled = true
+  }
+
+  encrypt_at_rest {
+    enabled    = true
+    kms_key_id = aws_kms_key.encryption_key.arn
+  }
+
+  ebs_options {
+    ebs_enabled = true
+    volume_type = "gp3"
+    volume_size = 1000
+    iops        = 3000
+    throughput  = 250
+  }
+
+  log_publishing_options {
+    log_type                 = "AUDIT_LOGS"
+    enabled                  = true
+    cloudwatch_log_group_arn = aws_cloudwatch_log_group.dragonfly_prod_1_os_logs.arn
+  }
+
+  auto_tune_options {
+    desired_state       = "ENABLED"
+    rollback_on_disable = "NO_ROLLBACK"
+  }
+
+
+  tags = {
+    DataClassification = "Cisco Restricted"
+    Environment        = "Prod"
+    ApplicationName    = var.domain_name
+    ResourceOwner      = "eti sre"
+    CiscoMailAlias     = "eti-sre-admins@cisco.com"
+    DataTaxonomy       = "Cisco Operations Data"
+  }
+}
+
+resource "aws_opensearch_domain_policy" "this" {
+  domain_name     = aws_opensearch_domain.dragonfly_prod_1_os.domain_name
+  access_policies = data.aws_iam_policy_document.dragonfly_admin_access_policy.json
+}

--- a/aws_dragonfly-prod_us-east-2_os_dragonfly-prod-1-os_master-user.tf
+++ b/aws_dragonfly-prod_us-east-2_os_dragonfly-prod-1-os_master-user.tf
@@ -1,0 +1,30 @@
+resource "random_password" "password" {
+  length  = 64
+  special = true
+}
+
+resource "vault_generic_secret" "os_auth_credentials" {
+  path = "secret/prod/os/${data.aws_region.current.name}/os-dragonfly-prod-1/master-user"
+
+  data_json = jsonencode({
+    username = var.os_master_user
+    password = random_password.password.result
+  })
+
+  provider = vault.dragonfly
+}
+
+resource "vault_generic_secret" "connection" {
+  path = "secret/prod/os/${data.aws_region.current.name}/os-dragonfly-prod-1/connection"
+  data_json = jsonencode({
+    username = var.os_master_user
+    password = random_password.password.result
+    endpoint = "https://${aws_opensearch_domain.dragonfly_prod_1_os.endpoint}"
+  })
+
+  provider = vault.dragonfly
+
+  depends_on = [
+    aws_opensearch_domain.dragonfly_prod_1_os
+  ]
+}

--- a/aws_dragonfly-prod_us-east-2_os_dragonfly-prod-1-os_outputs.tf
+++ b/aws_dragonfly-prod_us-east-2_os_dragonfly-prod-1-os_outputs.tf
@@ -1,0 +1,9 @@
+# OS endpoint
+output "opensearch_endpoint" {
+  value = aws_opensearch_domain.dragonfly_prod_1_os.endpoint
+}
+
+# OS dashboard endpoint
+output "opensearch_dashboard_endpoint" {
+  value = aws_opensearch_domain.dragonfly_prod_1_os.dashboard_endpoint
+}

--- a/aws_dragonfly-prod_us-east-2_os_dragonfly-prod-1-os_providers.tf
+++ b/aws_dragonfly-prod_us-east-2_os_dragonfly-prod-1-os_providers.tf
@@ -1,0 +1,28 @@
+provider "aws" {
+  access_key = data.vault_generic_secret.aws_infra_credential.data["AWS_ACCESS_KEY_ID"]
+  secret_key = data.vault_generic_secret.aws_infra_credential.data["AWS_SECRET_ACCESS_KEY"]
+  region     = "us-east-2"
+
+  default_tags {
+    tags = {
+      ApplicationName    = var.domain_name
+      CiscoMailAlias     = "eti-sre-admins@cisco.com"
+      DataClassification = "Cisco Confidential"
+      DataTaxonomy       = "Cisco Operations Data"
+      EnvironmentName    = "Prod"
+      ResourceOwner      = "ETI SRE"
+    }
+  }
+}
+
+provider "vault" {
+  alias     = "eticloud"
+  address   = "https://keeper.cisco.com"
+  namespace = "eticloud"
+}
+
+provider "vault" {
+  alias     = "dragonfly"
+  address   = "https://keeper.cisco.com"
+  namespace = "eticloud/apps/dragonfly"
+}

--- a/aws_dragonfly-prod_us-east-2_os_dragonfly-prod-1-os_securitygroups.tf
+++ b/aws_dragonfly-prod_us-east-2_os_dragonfly-prod-1-os_securitygroups.tf
@@ -1,0 +1,43 @@
+locals {
+  msk_ingress_rules = [
+    {
+      from_port : 443,
+      to_port : 443,
+      protocol : "tcp",
+      cidr_blocks : [
+        data.aws_vpc.compute_vpc.cidr_block,
+      ],
+    },
+  ]
+
+  msk_egress_rules = []
+}
+
+
+resource "aws_security_group" "dragonfly_prod_1_os" {
+  name        = "${var.domain_name}-default"
+  description = "${var.domain_name} opensearch cluster default security group"
+  vpc_id      = data.aws_vpc.database_vpc.id
+
+  dynamic "ingress" {
+    for_each = toset(local.msk_ingress_rules)
+
+    content {
+      from_port   = ingress.value.from_port
+      to_port     = ingress.value.to_port
+      protocol    = ingress.value.protocol
+      cidr_blocks = ingress.value.cidr_blocks
+    }
+  }
+
+  dynamic "egress" {
+    for_each = toset(local.msk_egress_rules)
+
+    content {
+      from_port   = egress.value.from_port
+      to_port     = egress.value.to_port
+      protocol    = egress.value.protocol
+      cidr_blocks = egress.value.cidr_blocks
+    }
+  }
+}

--- a/aws_dragonfly-prod_us-east-2_os_dragonfly-prod-1-os_variables.tf
+++ b/aws_dragonfly-prod_us-east-2_os_dragonfly-prod-1-os_variables.tf
@@ -1,0 +1,68 @@
+variable "cisco_cidrs" {
+  description = "Cisco network CIDRs"
+  default = [
+    "52.177.206.0/24",
+    "216.151.141.0/24",
+    "171.68.0.0/14",
+    "66.163.32.0/20",
+    "40.79.24.0/24",
+    "13.68.72.0/24",
+    "40.79.68.0/24",
+    "64.103.0.0/16",
+    "128.107.0.0/16",
+    "20.186.6.0/24",
+    "104.208.221.0/24",
+    "52.254.19.0/24",
+    "13.68.74.0/24",
+    "52.254.51.0/24",
+    "192.168.24.0/24",
+    "171.38.209.0/24",
+    "207.182.160.0/19",
+    "64.102.0.0/16",
+    "66.114.160.0/20",
+    "20.186.37.0/24",
+    "40.79.62.0/24",
+    "52.251.62.0/24",
+    "52.232.186.0/24",
+    "161.44.0.0/16",
+    "52.254.17.0/24",
+    "104.209.145.0/24",
+    "209.197.192.0/21",
+    "40.84.4.0/24",
+    "172.27.27.128/26",
+    "52.179.217.112/28",
+    "40.79.70.0/24",
+    "52.254.77.0/24",
+    "192.168.5.0/24",
+    "3.21.137.64/26",
+    "192.168.110.0/23",
+    "173.36.0.0/14",
+    "72.163.220.0/22",
+    "172.18.136.0/21"
+  ]
+}
+
+variable "domain_name" {
+  description = "Domain name for the Amazon OpenSearch Service domain"
+  default     = "os-dragonfly-prod-1"
+}
+
+variable "engine_version" {
+  description = "Engine version for the Amazon OpenSearch Service domain"
+  default     = "OpenSearch_2.11"
+}
+
+variable "instance_type" {
+  description = "Instance type to use for the Amazon OpenSearch Service domain"
+  default     = "r6g.large.search"
+}
+
+variable "os_master_user" {
+  description = "Username for the master user of the Amazon OpenSearch Service domain"
+  default     = "dragonfly-admin"
+}
+
+variable "warm_instance_type" {
+  description = "Warm instance type to use for the Amazon OpenSearch Service domain"
+  default     = "ultrawarm1.medium.search"
+}

--- a/aws_dragonfly-prod_us-east-2_os_dragonfly-prod-1-os_versions.tf
+++ b/aws_dragonfly-prod_us-east-2_os_dragonfly-prod-1-os_versions.tf
@@ -1,0 +1,18 @@
+terraform {
+  required_version = ">= 1.3.6"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+    vault = {
+      source  = "hashicorp/vault"
+      version = "~> 3.0"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = "~> 3.0"
+    }
+  }
+}

--- a/aws_dragonfly-prod_us-east-2_os_dragonfly-prod-1-osis_backend.tf
+++ b/aws_dragonfly-prod_us-east-2_os_dragonfly-prod-1-osis_backend.tf
@@ -1,0 +1,7 @@
+terraform {
+  backend "s3" {
+    bucket = "eticloud-tf-state-prod"
+    key    = "terraform-state/aws-dragonfly-production/os/us-east-2/dragonfly-prod-1-osis.tfstate"
+    region = "us-east-2"
+  }
+}

--- a/aws_dragonfly-prod_us-east-2_os_dragonfly-prod-1-osis_dependencies.tf
+++ b/aws_dragonfly-prod_us-east-2_os_dragonfly-prod-1-osis_dependencies.tf
@@ -1,0 +1,85 @@
+# AWS credentials
+data "vault_generic_secret" "aws_infra_credential" {
+  path     = "secret/infra/aws/dragonfly-prod/terraform_admin"
+  provider = vault.eticloud
+}
+
+# OS account and region
+data "aws_caller_identity" "current" {} # data.aws_caller_identity.current.account_id
+data "aws_region" "current" {}          # data.aws_region.current.name
+
+# OS domain
+data "aws_opensearch_domain" "dragonfly_prod_1_os" {
+  domain_name = var.domain_name
+}
+
+# MSK cluster
+data "aws_msk_cluster" "dragonfly_msk_1" {
+  cluster_name = var.msk_cluster_name
+}
+
+data "aws_iam_policy_document" "pipeline_opensearch" {
+  statement {
+    effect  = "Allow"
+    actions = ["es:DescribeDomain"]
+    resources = [
+      data.aws_opensearch_domain.dragonfly_prod_1_os.arn,
+    ]
+  }
+
+  statement {
+    effect = "Allow"
+    actions = [
+      "es:ESHttp*",
+    ]
+    resources = [
+      "${data.aws_opensearch_domain.dragonfly_prod_1_os.arn}/*",
+    ]
+  }
+}
+
+data "aws_iam_policy_document" "pipeline_kafka" {
+  statement {
+    effect  = "Allow"
+    actions = ["es:DescribeDomain"]
+    resources = [
+      data.aws_opensearch_domain.dragonfly_prod_1_os.arn,
+    ]
+  }
+
+  statement {
+    effect = "Allow"
+    actions = [
+      "kafka-cluster:Connect",
+      "kafka-cluster:AlterCluster",
+      "kafka-cluster:DescribeCluster",
+      "kafka:DescribeClusterV2",
+      "kafka:GetBootstrapBrokers",
+    ]
+    resources = [
+      data.aws_msk_cluster.dragonfly_msk_1.arn,
+    ]
+  }
+
+  statement {
+    effect = "Allow"
+    actions = [
+      "kafka-cluster:*Topic*",
+      "kafka-cluster:ReadData",
+    ]
+    resources = [
+      "arn:aws:kafka:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:topic/${var.msk_cluster_name}/*",
+    ]
+  }
+
+  statement {
+    effect = "Allow"
+    actions = [
+      "kafka-cluster:AlterGroup",
+      "kafka-cluster:DescribeGroup"
+    ]
+    resources = [
+      "arn:aws:kafka:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:group/${var.msk_cluster_name}/*",
+    ]
+  }
+}

--- a/aws_dragonfly-prod_us-east-2_os_dragonfly-prod-1-osis_iam.tf
+++ b/aws_dragonfly-prod_us-east-2_os_dragonfly-prod-1-osis_iam.tf
@@ -1,0 +1,49 @@
+module "pipeline_role" {
+  source  = "terraform-aws-modules/iam/aws//modules/iam-assumable-role"
+  version = "~> 5.0"
+
+  create_role = true
+
+  role_name        = "${var.domain_name}-pipeline-role"
+  role_description = "IAM Role to be assumed by Opensearch ingestion pipeline"
+
+  trusted_role_services = [
+    "osis-pipelines.amazonaws.com",
+  ]
+
+  role_requires_mfa       = false
+  custom_role_policy_arns = [
+    module.pipeline_opensearch_policy.arn,
+    module.pipeline_kafka_policy.arn,
+  ]
+
+  tags = var.tags
+}
+
+module "pipeline_opensearch_policy" {
+  source  = "terraform-aws-modules/iam/aws//modules/iam-policy"
+  version = "~> 5.0"
+
+  create_policy = true
+
+  name        = "${var.domain_name}-ingestion-policy"
+  path        = "/"
+  description = "IAM Policy for Opensearch ingestion"
+  policy      = data.aws_iam_policy_document.pipeline_opensearch.json
+
+  tags = var.tags
+}
+
+module "pipeline_kafka_policy" {
+  source  = "terraform-aws-modules/iam/aws//modules/iam-policy"
+  version = "~> 5.0"
+
+  create_policy = true
+
+  name        = "${var.domain_name}-kafka-consumer-policy"
+  path        = "/"
+  description = "IAM Policy for Kafka consumer"
+  policy      = data.aws_iam_policy_document.pipeline_kafka.json
+
+  tags = var.tags
+}

--- a/aws_dragonfly-prod_us-east-2_os_dragonfly-prod-1-osis_main.tf
+++ b/aws_dragonfly-prod_us-east-2_os_dragonfly-prod-1-osis_main.tf
@@ -1,0 +1,61 @@
+locals {
+  pipelines = {
+    "dragonfly-osis-pipeline-1" = {
+
+      topics = [
+        "monitoring",
+      ],
+      min_units = 1,
+      max_units = 10,
+      pipeline_template_file = "./pipeline-monitoring.yaml",
+    },
+    "dragonfly-osis-pipeline-2-ta" = {
+      topics = [
+        "threat",
+        "attack",
+      ]
+      min_units = 1,
+      max_units = 10,
+      pipeline_template_file = "./pipeline-threats-attacks.yaml",
+    },
+    "dragonfly-osis-pipeline-3-sa" = {
+      topics = [
+        "falco",
+      ]
+      min_units = 1,
+      max_units = 10,
+      pipeline_template_file = "./pipeline-sa.yaml",
+    },
+  }
+}
+
+resource "awscc_osis_pipeline" "ingestion_pipelines" {
+  for_each = local.pipelines
+
+  pipeline_name = each.key
+  pipeline_configuration_body = templatefile(
+    each.value.pipeline_template_file, {
+    region          = data.aws_region.current.name
+    sts_role_arn    = module.pipeline_role.iam_role_arn
+    opensearch_host = data.aws_opensearch_domain.dragonfly_prod_1_os.endpoint
+
+    msk_cluster_arn = data.aws_msk_cluster.dragonfly_msk_1.arn
+    kafka_topics    = each.value.topics
+  })
+
+  min_units = each.value.min_units
+  max_units = each.value.max_units
+
+  log_publishing_options = {
+    is_logging_enabled = true
+    cloudwatch_log_destination = {
+      log_group = aws_cloudwatch_log_group.dragonfly_prod_1_osis_log[each.key].name
+    }
+  }
+}
+
+resource "aws_cloudwatch_log_group" "dragonfly_prod_1_osis_log" {
+  for_each = local.pipelines
+
+  name = "/aws/vendedlogs/OpenSearchIngestion/${each.key}/audit-logs"
+}

--- a/aws_dragonfly-prod_us-east-2_os_dragonfly-prod-1-osis_outputs.tf
+++ b/aws_dragonfly-prod_us-east-2_os_dragonfly-prod-1-osis_outputs.tf
@@ -1,0 +1,3 @@
+output "opensearch_pipeline_role" {
+  value = module.pipeline_role.iam_role_arn
+}

--- a/aws_dragonfly-prod_us-east-2_os_dragonfly-prod-1-osis_providers.tf
+++ b/aws_dragonfly-prod_us-east-2_os_dragonfly-prod-1-osis_providers.tf
@@ -1,0 +1,35 @@
+provider "aws" {
+  access_key = data.vault_generic_secret.aws_infra_credential.data["AWS_ACCESS_KEY_ID"]
+  secret_key = data.vault_generic_secret.aws_infra_credential.data["AWS_SECRET_ACCESS_KEY"]
+  region     = "us-east-2"
+
+  default_tags {
+    tags = {
+      ApplicationName    = var.pipeline_name
+      CiscoMailAlias     = "eti-sre-admins@cisco.com"
+      DataClassification = "Cisco Confidential"
+      DataTaxonomy       = "Cisco Operations Data"
+      Environment        = "Prod"
+      ResourceOwner      = "ETI SRE"
+    }
+  }
+}
+
+provider "awscc" {
+  access_key = data.vault_generic_secret.aws_infra_credential.data["AWS_ACCESS_KEY_ID"]
+  secret_key = data.vault_generic_secret.aws_infra_credential.data["AWS_SECRET_ACCESS_KEY"]
+  region     = "us-east-2"
+}
+
+provider "vault" {
+  alias     = "eticloud"
+  address   = "https://keeper.cisco.com"
+  namespace = "eticloud"
+}
+
+provider "vault" {
+  alias     = "dragonfly"
+  address   = "https://keeper.cisco.com"
+  namespace = "eticloud/apps/dragonfly"
+}
+

--- a/aws_dragonfly-prod_us-east-2_os_dragonfly-prod-1-osis_variables.tf
+++ b/aws_dragonfly-prod_us-east-2_os_dragonfly-prod-1-osis_variables.tf
@@ -1,0 +1,30 @@
+variable "pipeline_name" {
+  description = "The name of the pipeline"
+  type        = string
+  default     = "osis-dragonfly-prod-1-kafka"
+}
+
+variable "domain_name" {
+  description = "The name of the domain"
+  type        = string
+  default     = "os-dragonfly-prod-1"
+}
+
+variable "msk_cluster_name" {
+  description = "The name of the MSK cluster"
+  type        = string
+  default     = "dragonfly-msk-prod-1"
+}
+
+variable "tags" {
+  description = "Tags to apply to all resources"
+  type        = map(string)
+  default = {
+    ApplicationName    = "osis-dragonfly-prod-1"
+    CiscoMailAlias     = "eti-sre-admins@cisco.com"
+    DataClassification = "Cisco Confidential"
+    DataTaxonomy       = "Cisco Operations Data"
+    Environment        = "Prod"
+    ResourceOwner      = "ETI SRE"
+  }
+}

--- a/aws_dragonfly-prod_us-east-2_os_dragonfly-prod-1-osis_versions.tf
+++ b/aws_dragonfly-prod_us-east-2_os_dragonfly-prod-1-osis_versions.tf
@@ -1,0 +1,19 @@
+terraform {
+  required_version = ">= 1.4"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 4.38"
+    }
+    awscc = {
+      source  = "hashicorp/awscc"
+      version = ">= 0.65.0"
+    }
+    vault = {
+      source  = "hashicorp/vault"
+      version = "~> 3.0"
+    }
+  }
+}
+

--- a/aws_dragonfly-prod_us-east-2_rds_dragonfly-prod-rds-1_aurora-postgres.tf
+++ b/aws_dragonfly-prod_us-east-2_rds_dragonfly-prod-rds-1_aurora-postgres.tf
@@ -1,0 +1,12 @@
+module "rds" {
+  source            = "git::https://github.com/cisco-eti/sre-tf-module-aws-aurora-postgres?ref=1.0.7"
+  vpc_name          = "dragonfly-data-prod-1-vpc"
+  database_name     = "dragonfly"
+  db_instance_type  = "db.r5.xlarge"
+  cluster_name      = "dragonfly-rds-prod-1"
+  db_engine_version = "13.12"
+  secret_path       = "secret/eticcprod/infra/aurora-pg/us-east-2/dragonfly-rds-prod-1"
+  db_allowed_cidrs = [
+    data.aws_vpc.eks_vpc.cidr_block,
+  ]
+}

--- a/aws_dragonfly-prod_us-east-2_rds_dragonfly-prod-rds-1_backend.tf
+++ b/aws_dragonfly-prod_us-east-2_rds_dragonfly-prod-rds-1_backend.tf
@@ -1,0 +1,7 @@
+terraform {
+  backend "s3" {
+    bucket = "eticloud-tf-state-prod"
+    key    = "terraform-state/aws-dragonfly-production/aurora-postgres/us-east-2/dragonfly-rds-prod-1.tfstate"
+    region = "us-east-2"
+  }
+}

--- a/aws_dragonfly-prod_us-east-2_rds_dragonfly-prod-rds-1_dependencies.tf
+++ b/aws_dragonfly-prod_us-east-2_rds_dragonfly-prod-rds-1_dependencies.tf
@@ -1,0 +1,12 @@
+data "vault_generic_secret" "aws_infra_credential" {
+  path     = "secret/infra/aws/dragonfly-prod/terraform_admin"
+  provider = vault.eticloud
+}
+
+data "aws_vpc" "eks_vpc" {
+  filter {
+    name   = "tag:Name"
+    values = ["dragonfly-compute-prod-1-vpc"]
+  }
+}
+

--- a/aws_dragonfly-prod_us-east-2_rds_dragonfly-prod-rds-1_providers.tf
+++ b/aws_dragonfly-prod_us-east-2_rds_dragonfly-prod-rds-1_providers.tf
@@ -1,0 +1,22 @@
+provider "vault" {
+  alias     = "eticloud"
+  address   = "https://keeper.cisco.com"
+  namespace = "eticloud"
+}
+
+provider "aws" {
+  access_key  = data.vault_generic_secret.aws_infra_credential.data["AWS_ACCESS_KEY_ID"]
+  secret_key  = data.vault_generic_secret.aws_infra_credential.data["AWS_SECRET_ACCESS_KEY"]
+  region      = "us-east-2"
+  max_retries = 3
+  default_tags {
+    tags = {
+      ApplicationName    = "dragonfly-rds-1"
+      CiscoMailAlias     = "eti-sre-admins@cisco.com"
+      DataClassification = "Cisco Confidential"
+      DataTaxonomy       = "Cisco Operations Data"
+      EnvironmentName    = "Prod"
+      ResourceOwner      = "ETI SRE"
+    }
+  }
+}

--- a/aws_dragonfly-prod_us-east-2_rds_dragonfly-prod-rds-1_versions.tf
+++ b/aws_dragonfly-prod_us-east-2_rds_dragonfly-prod-rds-1_versions.tf
@@ -1,0 +1,14 @@
+terraform {
+  required_version = ">= 1.3.6"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+    vault = {
+      source  = "hashicorp/vault"
+      version = "~> 3.0"
+    }
+  }
+}

--- a/aws_dragonfly-prod_us-east-2_redis_dragonfly-prod-redis-use2-1_main.tf
+++ b/aws_dragonfly-prod_us-east-2_redis_dragonfly-prod-redis-use2-1_main.tf
@@ -1,0 +1,99 @@
+terraform {
+  backend "s3" {
+    # This is the name of the backend S3 bucket.
+    bucket = "eticloud-tf-state-prod"
+    # This is the path to the Terraform state file in the backend S3 bucket.
+    key = "terraform-state/aws-dragonfly-production/us-east-2/redis/dragonfly-prod-redis-use2-1.tfstate"
+    # This is the region where the backend S3 bucket is located.
+    region = "us-east-2" # DO NOT CHANGE.
+  }
+}
+
+locals {
+  name              = "dragonfly-prod-use2-1"
+  eks_vpc_name      = "dragonfly-compute-prod-1-vpc"
+  data_vpc_name     = "dragonfly-data-prod-1-vpc"
+  region            = "us-east-2"
+  aws_account_name  = "dragonfly-prod"
+  node_type         = "cache.t2.small"
+  subnet_group_name = "dragonfly-prod-data-sg-use2-1"
+}
+
+provider "vault" {
+  alias     = "eticloud"
+  address   = "https://keeper.cisco.com"
+  namespace = "eticloud"
+}
+
+data "vault_generic_secret" "aws_infra_credential" {
+  provider = vault.eticloud
+  path     = "secret/infra/aws/${local.aws_account_name}/terraform_admin"
+}
+
+provider "aws" {
+  access_key = data.vault_generic_secret.aws_infra_credential.data["AWS_ACCESS_KEY_ID"]
+  secret_key = data.vault_generic_secret.aws_infra_credential.data["AWS_SECRET_ACCESS_KEY"]
+  region     = local.region
+}
+
+data "aws_vpc" "cluster_vpc" {
+  filter {
+    name   = "tag:Name"
+    values = [local.eks_vpc_name]
+  }
+}
+
+data "aws_vpc" "redis_vpc" {
+  filter {
+    name   = "tag:Name"
+    values = [local.data_vpc_name]
+  }
+}
+
+data "aws_subnets" "redis_subnets" {
+  filter {
+    name   = "vpc-id"
+    values = [data.aws_vpc.redis_vpc.id]
+  }
+  tags = {
+    Name = "*private*"
+  }
+}
+
+# Create a subnet group for the Elasticache service
+resource "aws_elasticache_subnet_group" "redis_subnet_group" {
+  name       = local.subnet_group_name
+  subnet_ids = data.aws_subnets.redis_subnets.ids
+}
+
+# Create a security group for the Elasticache service
+resource "aws_security_group" "redis_security_group" {
+  name   = local.subnet_group_name
+  vpc_id = data.aws_vpc.redis_vpc.id
+  ingress {
+    from_port   = 6379
+    to_port     = 6379
+    protocol    = "tcp"
+    cidr_blocks = [data.aws_vpc.cluster_vpc.cidr_block]
+  }
+}
+
+resource "aws_elasticache_replication_group" "dragonfly-prod-use2-1" {
+  replication_group_id = local.name
+  description          = "Redis cluster ElastiCache"
+  engine               = "redis"
+  engine_version       = "7.1"
+
+  node_type                  = local.node_type
+  port                       = 6379
+  parameter_group_name       = "default.redis7.cluster.on"
+  automatic_failover_enabled = true
+  at_rest_encryption_enabled = true
+  transit_encryption_enabled = true
+
+  num_node_groups         = 1
+  replicas_per_node_group = 1
+
+  subnet_group_name  = local.subnet_group_name
+  security_group_ids = [aws_security_group.redis_security_group.id]
+}

--- a/aws_dragonfly-prod_us-east-2_vpc-peering_dragonfly-prod-compute-to-data-peering-1_backend.tf
+++ b/aws_dragonfly-prod_us-east-2_vpc-peering_dragonfly-prod-compute-to-data-peering-1_backend.tf
@@ -1,0 +1,7 @@
+terraform {
+  backend "s3" {
+    bucket = "eticloud-tf-state-prod"
+    key    = "terraform-state/aws-dragonfly-production/vpc-peering/us-east-2/dragonfly-compute-to-data-prod-1/vpc-peering.tfstate"
+    region = "us-east-2"
+  }
+}

--- a/aws_dragonfly-prod_us-east-2_vpc-peering_dragonfly-prod-compute-to-data-peering-1_dependencies.tf
+++ b/aws_dragonfly-prod_us-east-2_vpc-peering_dragonfly-prod-compute-to-data-peering-1_dependencies.tf
@@ -1,0 +1,30 @@
+data "vault_generic_secret" "aws_infra_credential" {
+  path     = "secret/infra/aws/dragonfly-prod/terraform_admin"
+  provider = vault.eticloud
+}
+
+# Get the VPC IDs based on the names of the VPCs
+data "aws_vpc" "requestor_vpc" {
+  filter {
+    name   = "tag:ApplicationName"
+    values = ["dragonfly-compute-prod-1"]
+  }
+}
+
+data "aws_vpc" "acceptor_vpc" {
+  filter {
+    name   = "tag:ApplicationName"
+    values = ["dragonfly-data-prod-1"]
+  }
+}
+
+data "aws_route_tables" "requestor_vpc_rt" {
+  vpc_id = data.aws_vpc.requestor_vpc.id
+}
+
+data "aws_route_tables" "acceptor_vpc_rt" {
+  vpc_id = data.aws_vpc.acceptor_vpc.id
+}
+
+# Use this to get the account ID
+data "aws_caller_identity" "current" {}

--- a/aws_dragonfly-prod_us-east-2_vpc-peering_dragonfly-prod-compute-to-data-peering-1_provider.tf
+++ b/aws_dragonfly-prod_us-east-2_vpc-peering_dragonfly-prod-compute-to-data-peering-1_provider.tf
@@ -1,0 +1,14 @@
+provider "vault" {
+  alias     = "eticloud"
+  address   = "https://keeper.cisco.com"
+  namespace = "eticloud"
+}
+
+
+# By setting the AWS provider credentials via the data source above, we control in which account and region the resources get created.
+provider "aws" {
+  access_key  = data.vault_generic_secret.aws_infra_credential.data["AWS_ACCESS_KEY_ID"]
+  secret_key  = data.vault_generic_secret.aws_infra_credential.data["AWS_SECRET_ACCESS_KEY"]
+  region      = "us-east-2"
+  max_retries = 3
+}

--- a/aws_dragonfly-prod_us-east-2_vpc-peering_dragonfly-prod-compute-to-data-peering-1_securitygroups.tf
+++ b/aws_dragonfly-prod_us-east-2_vpc-peering_dragonfly-prod-compute-to-data-peering-1_securitygroups.tf
@@ -1,0 +1,31 @@
+# Security groups
+resource "aws_security_group" "compute_to_data" {
+  name        = "compute-vpc-1-to-data-vpc-1"
+  description = "Allows all communication into data-pvc from the compute-pvc"
+  vpc_id      = data.aws_vpc.acceptor_vpc.id
+}
+
+resource "aws_security_group" "data_to_compute" {
+  name        = "data-vpc-1-to-compute-vpc-1"
+  description = "Allows all communication into compute-pvc from the data-pvc"
+  vpc_id      = data.aws_vpc.requestor_vpc.id
+}
+
+# security group rules because the rules are going to reference the groups
+resource "aws_security_group_rule" "compute_to_data" {
+  type                     = "ingress"
+  from_port                = 0
+  to_port                  = 65535
+  protocol                 = "-1"
+  security_group_id        = aws_security_group.compute_to_data.id
+  source_security_group_id = aws_security_group.data_to_compute.id
+}
+
+resource "aws_security_group_rule" "data_to_compute" {
+  type                     = "ingress"
+  from_port                = 0
+  to_port                  = 65535
+  protocol                 = "-1"
+  security_group_id        = aws_security_group.data_to_compute.id
+  source_security_group_id = aws_security_group.compute_to_data.id
+}

--- a/aws_dragonfly-prod_us-east-2_vpc-peering_dragonfly-prod-compute-to-data-peering-1_versions.tf
+++ b/aws_dragonfly-prod_us-east-2_vpc-peering_dragonfly-prod-compute-to-data-peering-1_versions.tf
@@ -1,0 +1,14 @@
+terraform {
+  required_version = ">= 1.3.6"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+    vault = {
+      source  = "hashicorp/vault"
+      version = "~> 3.0"
+    }
+  }
+}

--- a/aws_dragonfly-prod_us-east-2_vpc-peering_dragonfly-prod-compute-to-data-peering-1_vpc-peering.tf
+++ b/aws_dragonfly-prod_us-east-2_vpc-peering_dragonfly-prod-compute-to-data-peering-1_vpc-peering.tf
@@ -1,0 +1,39 @@
+# VPC peering resources
+resource "aws_vpc_peering_connection" "data_to_compute" {
+  peer_owner_id = data.aws_caller_identity.current.account_id
+  peer_vpc_id   = data.aws_vpc.acceptor_vpc.id
+  vpc_id        = data.aws_vpc.requestor_vpc.id
+  auto_accept   = true
+
+  accepter {
+    allow_remote_vpc_dns_resolution = true
+  }
+
+  requester {
+    allow_remote_vpc_dns_resolution = true
+  }
+
+  tags = {
+    ApplicationName    = "dragonfly-compute-to-data-prod-1"
+    CiscoMailAlias     = "eti-sre-admins@cisco.com"
+    DataClassification = "Cisco Confidential"
+    DataTaxonomy       = "Cisco Operations Data"
+    EnvironmentName    = "Prod"
+    ResourceOwner      = "ETI SRE"
+  }
+}
+
+# VPC routing resources
+resource "aws_route" "compute_to_data" {
+  count                     = length(data.aws_route_tables.requestor_vpc_rt.ids)
+  route_table_id            = data.aws_route_tables.requestor_vpc_rt.ids[count.index]
+  destination_cidr_block    = data.aws_vpc.acceptor_vpc.cidr_block
+  vpc_peering_connection_id = aws_vpc_peering_connection.data_to_compute.id
+}
+
+resource "aws_route" "data_to_compute" {
+  count                     = length(data.aws_route_tables.acceptor_vpc_rt.ids)
+  route_table_id            = data.aws_route_tables.acceptor_vpc_rt.ids[count.index]
+  destination_cidr_block    = data.aws_vpc.requestor_vpc.cidr_block
+  vpc_peering_connection_id = aws_vpc_peering_connection.data_to_compute.id
+}

--- a/aws_dragonfly-prod_us-east-2_vpc_dragonfly-prod-compute-vpc-1_backend.tf
+++ b/aws_dragonfly-prod_us-east-2_vpc_dragonfly-prod-compute-vpc-1_backend.tf
@@ -1,0 +1,7 @@
+terraform {
+  backend "s3" {
+    bucket = "eticloud-tf-state-prod"
+    key    = "terraform-state/aws-dragonfly-production/vpc/us-east-2/dragonfly-compute-prod-1-vpc.tfstate"
+    region = "us-east-2"
+  }
+}

--- a/aws_dragonfly-prod_us-east-2_vpc_dragonfly-prod-compute-vpc-1_dependencies.tf
+++ b/aws_dragonfly-prod_us-east-2_vpc_dragonfly-prod-compute-vpc-1_dependencies.tf
@@ -1,0 +1,4 @@
+data "vault_generic_secret" "aws_infra_credential" {
+  path     = "secret/infra/aws/dragonfly-prod/terraform_admin"
+  provider = vault.eticloud
+}

--- a/aws_dragonfly-prod_us-east-2_vpc_dragonfly-prod-compute-vpc-1_provider.tf
+++ b/aws_dragonfly-prod_us-east-2_vpc_dragonfly-prod-compute-vpc-1_provider.tf
@@ -1,0 +1,22 @@
+provider "aws" {
+  access_key  = data.vault_generic_secret.aws_infra_credential.data["AWS_ACCESS_KEY_ID"]
+  secret_key  = data.vault_generic_secret.aws_infra_credential.data["AWS_SECRET_ACCESS_KEY"]
+  region      = "us-east-2"
+  max_retries = 3
+  default_tags {
+    tags = {
+      ApplicationName    = "dragonfly-compute-prod-1"
+      CiscoMailAlias     = "eti-sre-admins@cisco.com"
+      DataClassification = "Cisco Confidential"
+      DataTaxonomy       = "Cisco Operations Data"
+      EnvironmentName    = "Prod"
+      ResourceOwner      = "ETI SRE"
+    }
+  }
+}
+
+provider "vault" {
+  alias     = "eticloud_eticcprod"
+  address   = "https://keeper.cisco.com"
+  namespace = "eticloud/eticcprod"
+}

--- a/aws_dragonfly-prod_us-east-2_vpc_dragonfly-prod-compute-vpc-1_provider.tf
+++ b/aws_dragonfly-prod_us-east-2_vpc_dragonfly-prod-compute-vpc-1_provider.tf
@@ -16,7 +16,7 @@ provider "aws" {
 }
 
 provider "vault" {
-  alias     = "eticloud_eticcprod"
+  alias     = "eticloud"
   address   = "https://keeper.cisco.com"
-  namespace = "eticloud/eticcprod"
+  namespace = "eticloud"
 }

--- a/aws_dragonfly-prod_us-east-2_vpc_dragonfly-prod-compute-vpc-1_versions.tf
+++ b/aws_dragonfly-prod_us-east-2_vpc_dragonfly-prod-compute-vpc-1_versions.tf
@@ -1,0 +1,14 @@
+terraform {
+  required_version = ">= 1.3.6"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+    vault = {
+      source  = "hashicorp/vault"
+      version = "~> 3.0"
+    }
+  }
+}

--- a/aws_dragonfly-prod_us-east-2_vpc_dragonfly-prod-compute-vpc-1_vpc.tf
+++ b/aws_dragonfly-prod_us-east-2_vpc_dragonfly-prod-compute-vpc-1_vpc.tf
@@ -2,7 +2,7 @@ module "vpc" {
   source                          = "git::https://github.com/cisco-eti/sre-tf-module-aws-vpc?ref=2.0.6"
   region                          = "us-east-2"
   vpc_cidr                        = "10.10.0.0/16"
-  vpc_name                        = "dragonfly-compute-prod-1"
+  vpc_name                        = "dragonfly-compute-prod-1-vpc"
   cluster_name                    = "dragonfly-prod-1"
   create_database_subnet_group    = false
   create_elasticache_subnet_group = false

--- a/aws_dragonfly-prod_us-east-2_vpc_dragonfly-prod-compute-vpc-1_vpc.tf
+++ b/aws_dragonfly-prod_us-east-2_vpc_dragonfly-prod-compute-vpc-1_vpc.tf
@@ -2,7 +2,7 @@ module "vpc" {
   source                          = "git::https://github.com/cisco-eti/sre-tf-module-aws-vpc?ref=2.0.6"
   region                          = "us-east-2"
   vpc_cidr                        = "10.10.0.0/16"
-  vpc_name                        = "dragonfly-compute-prod-1-vpc"
+  vpc_name                        = "dragonfly-compute-prod-1"
   cluster_name                    = "dragonfly-prod-1"
   create_database_subnet_group    = false
   create_elasticache_subnet_group = false

--- a/aws_dragonfly-prod_us-east-2_vpc_dragonfly-prod-compute-vpc-1_vpc.tf
+++ b/aws_dragonfly-prod_us-east-2_vpc_dragonfly-prod-compute-vpc-1_vpc.tf
@@ -1,5 +1,5 @@
 module "vpc" {
-  source                          = "git::https://github.com/cisco-eti/sre-tf-module-aws-vpc?ref=2.0.4"
+  source                          = "git::https://github.com/cisco-eti/sre-tf-module-aws-vpc?ref=2.0.6"
   region                          = "us-east-2"
   vpc_cidr                        = "10.10.0.0/16"
   vpc_name                        = "dragonfly-compute-prod-1"

--- a/aws_dragonfly-prod_us-east-2_vpc_dragonfly-prod-compute-vpc-1_vpc.tf
+++ b/aws_dragonfly-prod_us-east-2_vpc_dragonfly-prod-compute-vpc-1_vpc.tf
@@ -1,5 +1,5 @@
 module "vpc" {
-  source                          = "git::https://wwwin-github.cisco.com/eti/sre-tf-module-aws-vpc?ref=2.0.4"
+  source                          = "git::https://github.com/cisco-eti/sre-tf-module-aws-vpc?ref=2.0.4"
   region                          = "us-east-2"
   vpc_cidr                        = "10.10.0.0/16"
   vpc_name                        = "dragonfly-compute-prod-1"

--- a/aws_dragonfly-prod_us-east-2_vpc_dragonfly-prod-compute-vpc-1_vpc.tf
+++ b/aws_dragonfly-prod_us-east-2_vpc_dragonfly-prod-compute-vpc-1_vpc.tf
@@ -1,0 +1,9 @@
+module "vpc" {
+  source                          = "git::https://wwwin-github.cisco.com/eti/sre-tf-module-aws-vpc?ref=2.0.4"
+  region                          = "us-east-2"
+  vpc_cidr                        = "10.10.0.0/16"
+  vpc_name                        = "dragonfly-compute-prod-1"
+  cluster_name                    = "dragonfly-prod-1"
+  create_database_subnet_group    = false
+  create_elasticache_subnet_group = false
+}

--- a/aws_dragonfly-prod_us-east-2_vpc_dragonfly-prod-data-vpc-1_backend.tf
+++ b/aws_dragonfly-prod_us-east-2_vpc_dragonfly-prod-data-vpc-1_backend.tf
@@ -1,0 +1,7 @@
+terraform {
+  backend "s3" {
+    bucket = "eticloud-tf-state-prod"
+    key    = "terraform-state/aws-dragonfly-production/vpc/us-east-2/dragonfly-data-prod-1-vpc.tfstate"
+    region = "us-east-2"
+  }
+}

--- a/aws_dragonfly-prod_us-east-2_vpc_dragonfly-prod-data-vpc-1_dependencies.tf
+++ b/aws_dragonfly-prod_us-east-2_vpc_dragonfly-prod-data-vpc-1_dependencies.tf
@@ -1,0 +1,4 @@
+data "vault_generic_secret" "aws_infra_credential" {
+  path     = "secret/infra/aws/dragonfly-prod/terraform_admin"
+  provider = vault.eticloud
+}

--- a/aws_dragonfly-prod_us-east-2_vpc_dragonfly-prod-data-vpc-1_provider.tf
+++ b/aws_dragonfly-prod_us-east-2_vpc_dragonfly-prod-data-vpc-1_provider.tf
@@ -1,0 +1,22 @@
+provider "aws" {
+  access_key  = data.vault_generic_secret.aws_infra_credential.data["AWS_ACCESS_KEY_ID"]
+  secret_key  = data.vault_generic_secret.aws_infra_credential.data["AWS_SECRET_ACCESS_KEY"]
+  region      = "us-east-2"
+  max_retries = 3
+  default_tags {
+    tags = {
+      ApplicationName    = "dragonfly-data-prod-1"
+      CiscoMailAlias     = "eti-sre-admins@cisco.com"
+      DataClassification = "Cisco Confidential"
+      DataTaxonomy       = "Cisco Operations Data"
+      EnvironmentName    = "Prod"
+      ResourceOwner      = "ETI SRE"
+    }
+  }
+}
+
+provider "vault" {
+  alias     = "eticloud"
+  address   = "https://keeper.cisco.com"
+  namespace = "eticloud"
+}

--- a/aws_dragonfly-prod_us-east-2_vpc_dragonfly-prod-data-vpc-1_versions.tf
+++ b/aws_dragonfly-prod_us-east-2_vpc_dragonfly-prod-data-vpc-1_versions.tf
@@ -1,0 +1,14 @@
+terraform {
+  required_version = ">= 1.3.6"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+    vault = {
+      source  = "hashicorp/vault"
+      version = "~> 3.0"
+    }
+  }
+}

--- a/aws_dragonfly-prod_us-east-2_vpc_dragonfly-prod-data-vpc-1_vpc.tf
+++ b/aws_dragonfly-prod_us-east-2_vpc_dragonfly-prod-data-vpc-1_vpc.tf
@@ -1,5 +1,5 @@
 module "vpc" {
-  source                          = "git::https://github.com/cisco-eti/sre-tf-module-aws-vpc?ref=2.0.4"
+  source                          = "git::https://github.com/cisco-eti/sre-tf-module-aws-vpc?ref=2.0.6"
   region                          = "us-east-2"
   vpc_cidr                        = "10.11.0.0/16"
   vpc_name                        = "dragonfly-data-prod-1"

--- a/aws_dragonfly-prod_us-east-2_vpc_dragonfly-prod-data-vpc-1_vpc.tf
+++ b/aws_dragonfly-prod_us-east-2_vpc_dragonfly-prod-data-vpc-1_vpc.tf
@@ -2,7 +2,7 @@ module "vpc" {
   source                          = "git::https://github.com/cisco-eti/sre-tf-module-aws-vpc?ref=2.0.6"
   region                          = "us-east-2"
   vpc_cidr                        = "10.11.0.0/16"
-  vpc_name                        = "dragonfly-data-prod-1-vpc"
+  vpc_name                        = "dragonfly-data-prod-1"
   cluster_name                    = "dragonfly-data-eks" # Not used
   create_database_subnet_group    = true
   create_elasticache_subnet_group = false

--- a/aws_dragonfly-prod_us-east-2_vpc_dragonfly-prod-data-vpc-1_vpc.tf
+++ b/aws_dragonfly-prod_us-east-2_vpc_dragonfly-prod-data-vpc-1_vpc.tf
@@ -1,0 +1,9 @@
+module "vpc" {
+  source                          = "git::https://github.cisco.com/cisco-eti/sre-tf-module-aws-vpc?ref=2.0.4"
+  region                          = "us-east-2"
+  vpc_cidr                        = "10.11.0.0/16"
+  vpc_name                        = "dragonfly-data-prod-1"
+  cluster_name                    = "dragonfly-data-eks" # Not used
+  create_database_subnet_group    = true
+  create_elasticache_subnet_group = false
+}

--- a/aws_dragonfly-prod_us-east-2_vpc_dragonfly-prod-data-vpc-1_vpc.tf
+++ b/aws_dragonfly-prod_us-east-2_vpc_dragonfly-prod-data-vpc-1_vpc.tf
@@ -1,5 +1,5 @@
 module "vpc" {
-  source                          = "git::https://github.cisco.com/cisco-eti/sre-tf-module-aws-vpc?ref=2.0.4"
+  source                          = "git::https://github.com/cisco-eti/sre-tf-module-aws-vpc?ref=2.0.4"
   region                          = "us-east-2"
   vpc_cidr                        = "10.11.0.0/16"
   vpc_name                        = "dragonfly-data-prod-1"

--- a/aws_dragonfly-prod_us-east-2_vpc_dragonfly-prod-data-vpc-1_vpc.tf
+++ b/aws_dragonfly-prod_us-east-2_vpc_dragonfly-prod-data-vpc-1_vpc.tf
@@ -2,7 +2,7 @@ module "vpc" {
   source                          = "git::https://github.com/cisco-eti/sre-tf-module-aws-vpc?ref=2.0.6"
   region                          = "us-east-2"
   vpc_cidr                        = "10.11.0.0/16"
-  vpc_name                        = "dragonfly-data-prod-1"
+  vpc_name                        = "dragonfly-data-prod-1-vpc"
   cluster_name                    = "dragonfly-data-eks" # Not used
   create_database_subnet_group    = true
   create_elasticache_subnet_group = false

--- a/aws_dragonfly-staging_eu-west-1_eks_dragonfly-staging-1-aws-alb-role_backend.tf
+++ b/aws_dragonfly-staging_eu-west-1_eks_dragonfly-staging-1-aws-alb-role_backend.tf
@@ -1,0 +1,7 @@
+terraform {
+  backend "s3" {
+    bucket = "eticloud-tf-state-nonprod"
+    key    = "terraform-state/aws-dragonfly-staging-1/eks/eu-west-1/eks-df-staging-1-aws-alb-role.tfstate"
+    region = "us-east-2"
+  }
+}

--- a/aws_dragonfly-staging_eu-west-1_eks_dragonfly-staging-1-aws-alb-role_eks-alb-controller-role.tf
+++ b/aws_dragonfly-staging_eu-west-1_eks_dragonfly-staging-1-aws-alb-role_eks-alb-controller-role.tf
@@ -1,0 +1,45 @@
+data "aws_caller_identity" "current_alb" {}
+
+data "aws_eks_cluster" "cluster_alb" {
+  name = local.cluster_name_alb
+}
+
+locals {
+  cluster_name_alb = "eks-df-staging-1"
+  account_id_alb   = data.aws_caller_identity.current_alb.account_id
+  oidc_id_alb      = trimprefix(data.aws_eks_cluster.cluster_alb.identity[0].oidc[0].issuer, "https://")
+}
+
+resource "aws_iam_policy" "aws_alb_controller_policy" {
+  name        = "${local.cluster_name_alb}-aws-alb-controller-policy"
+  description = "${local.cluster_name_alb} AWS ALB Controller Role IAM Policy"
+  policy      = file("./resources/eks-alb-controller-role-policy.json")
+}
+
+resource "aws_iam_role" "aws_alb_controller_role" {
+  name = "${local.cluster_name_alb}-aws-alb-controller-role"
+  assume_role_policy = jsonencode({
+    "Version" : "2012-10-17"
+    "Statement" : [
+      {
+        "Effect" : "Allow",
+        "Principal" : {
+          "Federated" : "arn:aws:iam::${local.account_id_alb}:oidc-provider/${local.oidc_id_alb}"
+        },
+        "Action" : "sts:AssumeRoleWithWebIdentity",
+        "Condition" : {
+          "StringEquals" : {
+            "${local.oidc_id_alb}:aud" : "sts.amazonaws.com",
+            "${local.oidc_id_alb}:sub" : "system:serviceaccount:kube-system:aws-load-balancer-controller"
+          }
+        }
+      }
+    ]
+  })
+  force_detach_policies = true
+}
+
+resource "aws_iam_role_policy_attachment" "aws_alb_controller_attachment" {
+  role       = aws_iam_role.aws_alb_controller_role.name
+  policy_arn = aws_iam_policy.aws_alb_controller_policy.arn
+}

--- a/aws_dragonfly-staging_eu-west-1_eks_dragonfly-staging-1-aws-alb-role_provider.tf
+++ b/aws_dragonfly-staging_eu-west-1_eks_dragonfly-staging-1-aws-alb-role_provider.tf
@@ -1,0 +1,28 @@
+provider "aws" {
+  access_key  = data.vault_generic_secret.aws_infra_credential.data["AWS_ACCESS_KEY_ID"]
+  secret_key  = data.vault_generic_secret.aws_infra_credential.data["AWS_SECRET_ACCESS_KEY"]
+  region      = "eu-west-1"
+  max_retries = 3
+  default_tags {
+    tags = {
+      DataClassification = "Cisco Restricted"
+      Environment        = "NonProd"
+      ApplicationName    = "eks-df-staging-1"
+      ResourceOwner      = "eti sre"
+      CiscoMailAlias     = "eti-sre-admins@cisco.com"
+      DataTaxonomy       = "Cisco Operations Data"
+    }
+  }
+}
+
+
+provider "vault" {
+  alias     = "eticloud"
+  address   = "https://keeper.cisco.com"
+  namespace = "eticloud"
+}
+
+data "vault_generic_secret" "aws_infra_credential" {
+  path     = "secret/infra/aws/dragonfly-staging/terraform_admin"
+  provider = vault.eticloud
+}

--- a/aws_dragonfly-staging_eu-west-1_eks_dragonfly-staging-1-aws-alb-role_versions.tf
+++ b/aws_dragonfly-staging_eu-west-1_eks_dragonfly-staging-1-aws-alb-role_versions.tf
@@ -1,0 +1,9 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 4.0"
+    }
+  }
+  required_version = ">= 1.3.6"
+}

--- a/aws_dragonfly-staging_eu-west-1_eks_dragonfly-staging-1-iam_backend.tf
+++ b/aws_dragonfly-staging_eu-west-1_eks_dragonfly-staging-1-iam_backend.tf
@@ -1,0 +1,7 @@
+terraform {
+  backend "s3" {
+    bucket = "eticloud-tf-state-nonprod"
+    key    = "terraform-state/aws/dragonfly-staging/eu-west-1/eks/eks-df-staging-1-iam.tfstate"
+    region = "us-east-2"
+  }
+}

--- a/aws_dragonfly-staging_eu-west-1_eks_dragonfly-staging-1-iam_dependencies.tf
+++ b/aws_dragonfly-staging_eu-west-1_eks_dragonfly-staging-1-iam_dependencies.tf
@@ -1,0 +1,48 @@
+data "vault_generic_secret" "aws_infra_credential" {
+  path     = "secret/infra/aws/${local.aws_account_name}/terraform_admin"
+  provider = vault.eticloud
+}
+
+// account information
+data "aws_caller_identity" "current" {}
+data "aws_region" "current" {}
+
+data "aws_vpc" "compute_vpc" {
+  filter {
+    name = "tag:Name"
+    values = [
+      local.vpc_id
+    ]
+  }
+}
+
+data "aws_subnets" "compute_subnets" {
+  filter {
+    name   = "vpc-id"
+    values = [data.aws_vpc.compute_vpc.id]
+  }
+  tags = {
+    Tier = "Private"
+  }
+}
+
+data "aws_msk_cluster" "dragonfly_msk_1" {
+  cluster_name = local.dragonfly_msk_cluster_name
+}
+
+// EKS
+data "aws_eks_cluster" "cluster" {
+  name = local.cluster_name
+}
+
+data "aws_s3_bucket" "mskconnect_custom_plugin_bucket" {
+  bucket = local.arango_connector_plugin_bucket
+}
+
+data "aws_s3_bucket" "mskconnect_logs_bucket" {
+  bucket = local.arangodb_connector_logs_bucket
+}
+
+data "aws_iam_role" "mskconnect_arangodb_execution_role" {
+  name = local.arangodb_connector_execution_role
+}

--- a/aws_dragonfly-staging_eu-west-1_eks_dragonfly-staging-1-iam_eks_developer_access.tf
+++ b/aws_dragonfly-staging_eu-west-1_eks_dragonfly-staging-1-iam_eks_developer_access.tf
@@ -1,0 +1,19 @@
+resource "aws_iam_policy" "developer_access" {
+  name        = "developer-access"
+  path        = "/"
+  description = "IAM Policy to allow developers EKS Access"
+  policy      = file("./resources/eks_developer_access-policy.json")
+}
+
+
+resource "aws_iam_role" "developer_access" {
+  name                  = "developer-access"
+  assume_role_policy    = file("./resources/saml_cloudsso-role-policy.json")
+  force_detach_policies = true
+}
+
+
+resource "aws_iam_role_policy_attachment" "developer_access" {
+  role       = aws_iam_role.developer_access.name
+  policy_arn = aws_iam_policy.developer_access.arn
+}

--- a/aws_dragonfly-staging_eu-west-1_eks_dragonfly-staging-1-iam_locals.tf
+++ b/aws_dragonfly-staging_eu-west-1_eks_dragonfly-staging-1-iam_locals.tf
@@ -1,0 +1,22 @@
+locals {
+  app_name         = "dragonfly-staging"
+  aws_account_name = "dragonfly-staging"
+  aws_region       = "eu-west-1"
+  account_id       = data.aws_caller_identity.current.account_id
+
+  vpc_id = "dragonfly-compute-staging-1-vpc"
+
+  cluster_name = "eks-df-staging-1"
+  oidc_id      = trimprefix(data.aws_eks_cluster.cluster.identity[0].oidc[0].issuer, "https://")
+
+  dragonfly_backend_namespace = "dragonfly-backend"
+  dragonfly_msk_cluster_name  = "dragonfly-staging-msk-1"
+
+  arango_connector_plugin_bucket    = "dragonfly-staging-binaries-repository"
+  arangodb_connector_logs_bucket    = "dragonfly-staging-kafka-connector-log-files"
+  arangodb_connector_execution_role = "kafka-connect-arangodb-role"
+
+  dragonfly_argo_service_account                = "${local.dragonfly_backend_namespace}:dragonfly-thrill-argo"
+  dragonfly_streaman_service_account            = "${local.dragonfly_backend_namespace}:dragonfly-streaman-service-account"
+  dragonfly_ml_inference_client_service_account = "${local.dragonfly_backend_namespace}:dragonfly-ml-inferenceclient-a-staging-app"
+}

--- a/aws_dragonfly-staging_eu-west-1_eks_dragonfly-staging-1-iam_outputs.tf
+++ b/aws_dragonfly-staging_eu-west-1_eks_dragonfly-staging-1-iam_outputs.tf
@@ -1,0 +1,12 @@
+# Role ID
+output "dragonfly_streaman_connector_role_id" {
+  value = aws_iam_role.dragonfly_streaman.arn
+}
+
+output "dragonfly_thrill_msk_role_id" {
+  value = aws_iam_role.dragonfly_thrill_msk_writer.arn
+}
+
+output "dragonfly_ml_inference_role_id" {
+  value = aws_iam_role.dragonfly_ml_inferenceclient.arn
+}

--- a/aws_dragonfly-staging_eu-west-1_eks_dragonfly-staging-1-iam_providers.tf
+++ b/aws_dragonfly-staging_eu-west-1_eks_dragonfly-staging-1-iam_providers.tf
@@ -1,0 +1,23 @@
+provider "vault" {
+  alias     = "eticloud"
+  address   = "https://keeper.cisco.com"
+  namespace = "eticloud"
+}
+
+provider "aws" {
+  access_key  = data.vault_generic_secret.aws_infra_credential.data["AWS_ACCESS_KEY_ID"]
+  secret_key  = data.vault_generic_secret.aws_infra_credential.data["AWS_SECRET_ACCESS_KEY"]
+  region      = local.aws_region
+  max_retries = 3
+
+  default_tags {
+    tags = {
+      ApplicationName    = local.app_name
+      CiscoMailAlias     = "eti-sre-admins@cisco.com"
+      DataClassification = "Cisco Confidential"
+      DataTaxonomy       = "Cisco Operations Data"
+      EnvironmentName    = "NonProd"
+      ResourceOwner      = "ETI SRE"
+    }
+  }
+}

--- a/aws_dragonfly-staging_eu-west-1_eks_dragonfly-staging-1-iam_role-ml-inference-client.tf
+++ b/aws_dragonfly-staging_eu-west-1_eks_dragonfly-staging-1-iam_role-ml-inference-client.tf
@@ -1,0 +1,81 @@
+resource "aws_iam_role" "dragonfly_ml_inferenceclient" {
+  name = "ml-inferenceclient-role"
+
+  assume_role_policy = jsonencode({
+    "Version" : "2012-10-17"
+    "Statement" : [
+      {
+        "Effect" : "Allow",
+        "Principal" : {
+          "Federated" : "arn:aws:iam::${local.account_id}:oidc-provider/${local.oidc_id}"
+        },
+        "Action" : "sts:AssumeRoleWithWebIdentity",
+        "Condition" : {
+          "StringEquals" : {
+            "${local.oidc_id}:aud" : "sts.amazonaws.com",
+            "${local.oidc_id}:sub" : "system:serviceaccount:${local.dragonfly_ml_inference_client_service_account}"
+          }
+        }
+      }
+    ]
+  })
+  force_detach_policies = true
+}
+
+data "aws_iam_policy_document" "dragonfly_ml_inferenceclient_policies" {
+  statement {
+    sid = "access"
+
+    actions = [
+      "kafka-cluster:Connect",
+    ]
+
+    resources = [
+      "arn:aws:kafka:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:cluster/${data.aws_msk_cluster.dragonfly_msk_1.cluster_name}/${data.aws_msk_cluster.dragonfly_msk_1.cluster_uuid}"
+    ]
+
+    effect = "Allow"
+  }
+
+  statement {
+    sid = "topic"
+
+    actions = [
+      "kafka-cluster:DescribeTopic",
+      "kafka-cluster:ReadData",
+    ]
+
+    resources = [
+      "arn:aws:kafka:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:topic/${data.aws_msk_cluster.dragonfly_msk_1.cluster_name}/${data.aws_msk_cluster.dragonfly_msk_1.cluster_uuid}/kg-node*",
+      "arn:aws:kafka:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:topic/${data.aws_msk_cluster.dragonfly_msk_1.cluster_name}/${data.aws_msk_cluster.dragonfly_msk_1.cluster_uuid}/kg-edge*",
+    ]
+
+    effect = "Allow"
+  }
+
+  statement {
+    sid = "groups"
+
+    actions = [
+      "kafka-cluster:AlterGroup",
+      "kafka-cluster:DescribeGroup",
+    ]
+
+    resources = [
+      "arn:aws:kafka:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:group/${data.aws_msk_cluster.dragonfly_msk_1.cluster_name}/${data.aws_msk_cluster.dragonfly_msk_1.cluster_uuid}/*",
+    ]
+
+    effect = "Allow"
+  }
+}
+
+resource "aws_iam_policy" "dragonfly_ml_inferenceclient_policies" {
+  name        = "dragonfly-ml-inferenceclient-policies"
+  description = "Policies for ml-inferececlient role on kg-node and kg-edge topics"
+  policy      = data.aws_iam_policy_document.dragonfly_ml_inferenceclient_policies.json
+}
+
+resource "aws_iam_role_policy_attachment" "dragonfly_ml_inferenceclient_policy_attachment" {
+  role       = aws_iam_role.dragonfly_ml_inferenceclient.name
+  policy_arn = aws_iam_policy.dragonfly_ml_inferenceclient_policies.arn
+}

--- a/aws_dragonfly-staging_eu-west-1_eks_dragonfly-staging-1-iam_role-streaman.tf
+++ b/aws_dragonfly-staging_eu-west-1_eks_dragonfly-staging-1-iam_role-streaman.tf
@@ -1,0 +1,110 @@
+resource "aws_iam_role" "dragonfly_streaman" {
+  name = "${local.cluster_name}-streaman-role"
+
+  assume_role_policy = jsonencode({
+    "Version" : "2012-10-17"
+    "Statement" : [
+      {
+        "Effect" : "Allow",
+        "Principal" : {
+          "Federated" : "arn:aws:iam::${local.account_id}:oidc-provider/${local.oidc_id}"
+        },
+        "Action" : "sts:AssumeRoleWithWebIdentity",
+        "Condition" : {
+          "StringEquals" : {
+            "${local.oidc_id}:aud" : "sts.amazonaws.com",
+            "${local.oidc_id}:sub" : "system:serviceaccount:${local.dragonfly_streaman_service_account}"
+          }
+        }
+      }
+    ]
+  })
+  force_detach_policies = true
+}
+
+data "aws_iam_policy_document" "dragonfly_streaman_kafka_policy" {
+  statement {
+    sid = "access"
+
+    actions = [
+      "kafka-cluster:Connect",
+      "kafka-cluster:AlterCluster",
+      "kafka-cluster:DescribeCluster",
+      "kafka:DescribeClusterV2",
+      "kafka:GetBootstrapBrokers",
+    ]
+
+    resources = [
+      "arn:aws:kafka:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:cluster/${data.aws_msk_cluster.dragonfly_msk_1.cluster_name}/${data.aws_msk_cluster.dragonfly_msk_1.cluster_uuid}"
+    ]
+  }
+
+  statement {
+    sid = "kafkawriter"
+
+    actions = [
+      "kafka-cluster:*Topic*",
+    ]
+
+    resources = [
+      "arn:aws:kafka:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:topic/${data.aws_msk_cluster.dragonfly_msk_1.cluster_name}/${data.aws_msk_cluster.dragonfly_msk_1.cluster_uuid}/kg-node*",
+      "arn:aws:kafka:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:topic/${data.aws_msk_cluster.dragonfly_msk_1.cluster_name}/${data.aws_msk_cluster.dragonfly_msk_1.cluster_uuid}/kg-edge*",
+    ]
+  }
+
+  statement {
+    sid = "kafkareader"
+
+    actions = [
+      "kafka-cluster:*Topic*",
+      "kafka-cluster:ReadData",
+    ]
+
+    resources = [
+      "arn:aws:kafka:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:topic/${data.aws_msk_cluster.dragonfly_msk_1.cluster_name}/${data.aws_msk_cluster.dragonfly_msk_1.id}/falco",
+      "arn:aws:kafka:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:topic/${data.aws_msk_cluster.dragonfly_msk_1.cluster_name}/${data.aws_msk_cluster.dragonfly_msk_1.id}/monitoring",
+    ]
+  }
+
+  statement {
+    sid = "kafkagroupreader"
+
+    actions = [
+      "kafka-cluster:AlterGroup",
+      "kafka-cluster:DescribeGroup",
+    ]
+
+    resources = [
+      "arn:aws:kafka:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:group/${data.aws_msk_cluster.dragonfly_msk_1.cluster_name}/${data.aws_msk_cluster.dragonfly_msk_1.id}/*",
+      "arn:aws:kafka:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:group/${data.aws_msk_cluster.dragonfly_msk_1.cluster_name}/${data.aws_msk_cluster.dragonfly_msk_1.id}/*",
+    ]
+  }
+}
+
+resource "aws_iam_policy" "dragonfly_streaman_kafka_policy" {
+  name        = "${local.cluster_name}-streaman-connector-writer-policy"
+  description = "Policies for streaman role"
+  policy      = data.aws_iam_policy_document.dragonfly_streaman_kafka_policy.json
+}
+
+resource "aws_iam_policy" "dragonfly_streaman_kafkconnect_policy" {
+  name        = "${local.cluster_name}-streaman-kafkaconnect-polic"
+  description = "${local.cluster_name} policy for streaman role"
+  policy = templatefile(
+    "${path.module}/resources/msk-connect-policy.json", {
+      kakfa_connect_arangodb_logs_bucket    = data.aws_s3_bucket.mskconnect_logs_bucket.arn
+      kakfa_connect_arangodb_execution_role = data.aws_iam_role.mskconnect_arangodb_execution_role.arn
+      dragonly_binaries_bucket              = data.aws_s3_bucket.mskconnect_custom_plugin_bucket.arn
+  })
+}
+
+resource "aws_iam_role_policy_attachment" "dragonfly_streaman_policy_attachment" {
+  for_each = {
+    kafka-policy         = aws_iam_policy.dragonfly_streaman_kafka_policy.arn,
+    kafka-connect-policy = aws_iam_policy.dragonfly_streaman_kafkconnect_policy.arn
+  }
+
+  role       = aws_iam_role.dragonfly_streaman.name
+  policy_arn = each.value
+}
+

--- a/aws_dragonfly-staging_eu-west-1_eks_dragonfly-staging-1-iam_role-thrill-msk-writer.tf
+++ b/aws_dragonfly-staging_eu-west-1_eks_dragonfly-staging-1-iam_role-thrill-msk-writer.tf
@@ -1,0 +1,66 @@
+resource "aws_iam_role" "dragonfly_thrill_msk_writer" {
+  name = "thrill-msk-writer-role"
+
+  assume_role_policy = jsonencode({
+    "Version" : "2012-10-17"
+    "Statement" : [
+      {
+        "Effect" : "Allow",
+        "Principal" : {
+          "Federated" : "arn:aws:iam::${local.account_id}:oidc-provider/${local.oidc_id}"
+        },
+        "Action" : "sts:AssumeRoleWithWebIdentity",
+        "Condition" : {
+          "StringEquals" : {
+            "${local.oidc_id}:aud" : "sts.amazonaws.com",
+            "${local.oidc_id}:sub" : "system:serviceaccount:${local.dragonfly_argo_service_account}"
+          }
+        }
+      }
+    ]
+  })
+  force_detach_policies = true
+}
+
+data "aws_iam_policy_document" "dragonfly_thrill_msk_writer_policies" {
+  statement {
+    sid = "access"
+
+    actions = [
+      "kafka-cluster:Connect",
+    ]
+
+    resources = [
+      "arn:aws:kafka:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:cluster/${data.aws_msk_cluster.dragonfly_msk_1.cluster_name}/${data.aws_msk_cluster.dragonfly_msk_1.cluster_uuid}"
+    ]
+
+    effect = "Allow"
+  }
+
+  statement {
+    sid = "topic"
+
+    actions = [
+      "kafka-cluster:DescribeTopic",
+      "kafka-cluster:WriteData",
+    ]
+
+    resources = [
+      "arn:aws:kafka:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:topic/${data.aws_msk_cluster.dragonfly_msk_1.cluster_name}/${data.aws_msk_cluster.dragonfly_msk_1.cluster_uuid}/threat",
+      "arn:aws:kafka:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:topic/${data.aws_msk_cluster.dragonfly_msk_1.cluster_name}/${data.aws_msk_cluster.dragonfly_msk_1.cluster_uuid}/attack",
+    ]
+
+    effect = "Allow"
+  }
+}
+
+resource "aws_iam_policy" "dragonfly_thrill_msk_writer_policies" {
+  name        = "dragonfly-thrill-msk-writer-policies"
+  description = "Policies for thrill MSK writer role on threat and attack topics"
+  policy      = data.aws_iam_policy_document.dragonfly_thrill_msk_writer_policies.json
+}
+
+resource "aws_iam_role_policy_attachment" "dragonfly_thrill_msk_writer_policy_attachment" {
+  role       = aws_iam_role.dragonfly_thrill_msk_writer.name
+  policy_arn = aws_iam_policy.dragonfly_thrill_msk_writer_policies.arn
+}

--- a/aws_dragonfly-staging_eu-west-1_eks_dragonfly-staging-1_dragonfly-staging-eks-karpenter-roles_karpenter-roles.tf
+++ b/aws_dragonfly-staging_eu-west-1_eks_dragonfly-staging-1_dragonfly-staging-eks-karpenter-roles_karpenter-roles.tf
@@ -1,0 +1,245 @@
+# Backend
+terraform {
+  backend "s3" {
+    bucket = "eticloud-tf-state-nonprod"
+    key    = "terraform-state/aws-dragonfly-staging/eks/eu-west-1/eks-df-staging-1-karpenter-roles.tfstate"
+    region = "us-east-2"
+  }
+  required_providers {
+    tls = {
+      source  = "hashicorp/tls"
+      version = "3.4.0"
+    }
+  }
+}
+
+# Infra AWS Provider
+provider "vault" {
+  address   = "https://keeper.cisco.com"
+  namespace = "eticloud"
+}
+
+data "vault_generic_secret" "aws_infra_credential" {
+  path = "secret/infra/aws/${local.account_name}/terraform_admin"
+}
+
+provider "aws" {
+  access_key  = data.vault_generic_secret.aws_infra_credential.data["AWS_ACCESS_KEY_ID"]
+  secret_key  = data.vault_generic_secret.aws_infra_credential.data["AWS_SECRET_ACCESS_KEY"]
+  region      = "eu-west-1"
+  max_retries = 3
+  default_tags {
+    tags = {
+      DataClassification = "Cisco Restricted"
+      Environment        = "NonProd"
+      ApplicationName    = local.eks_name
+      ResourceOwner      = "eti sre"
+      CiscoMailAlias     = "eti-sre-admins@cisco.com"
+      DataTaxonomy       = "Cisco Operations Data"
+    }
+  }
+}
+
+data "aws_caller_identity" "current" {}
+data "aws_eks_cluster" "cluster" {
+  name = local.eks_name
+}
+
+# locals
+locals {
+  account_id         = data.aws_caller_identity.current.account_id
+  account_name       = "dragonfly-staging"
+  oidc_id            = trimprefix(data.aws_eks_cluster.cluster.identity[0].oidc[0].issuer, "https://")
+  vpc_name           = "dragonfly-compute-staging-1-vpc"
+  eks_name           = "eks-df-staging-1"
+  aws_default_region = "eu-west-1"
+}
+
+resource "aws_iam_policy" "aws_karpenter_controller_policy" {
+  name        = "KarpenterControllerPolicy-${local.eks_name}"
+  description = "${local.eks_name} AWS Karpenter Controller Role IAM Policy"
+  policy = jsonencode({
+    "Version" : "2012-10-17",
+    "Statement" : [
+      {
+        "Action" : [
+          "ssm:GetParameter",
+          "ec2:DescribeImages",
+          "ec2:RunInstances",
+          "ec2:DescribeSubnets",
+          "ec2:DescribeSecurityGroups",
+          "ec2:DescribeLaunchTemplates",
+          "ec2:DescribeInstances",
+          "ec2:DescribeInstanceTypes",
+          "ec2:DescribeInstanceTypeOfferings",
+          "ec2:DescribeAvailabilityZones",
+          "ec2:DeleteLaunchTemplate",
+          "ec2:CreateTags",
+          "ec2:CreateLaunchTemplate",
+          "ec2:CreateFleet",
+          "ec2:DescribeSpotPriceHistory",
+          "pricing:GetProducts"
+        ],
+        "Effect" : "Allow",
+        "Resource" : "*",
+        "Sid" : "Karpenter"
+      },
+      {
+        "Action" : "ec2:TerminateInstances",
+        "Condition" : {
+          "StringLike" : {
+            "ec2:ResourceTag/karpenter.sh/nodepool" : "*"
+          }
+        },
+        "Effect" : "Allow",
+        "Resource" : "*",
+        "Sid" : "ConditionalEC2Termination"
+      },
+      {
+        "Effect" : "Allow",
+        "Action" : "iam:PassRole",
+        "Resource" : "arn:aws:iam::${local.account_id}:role/KarpenterNodeRole-${local.eks_name}",
+        "Sid" : "PassNodeIAMRole"
+      },
+      {
+        "Effect" : "Allow",
+        "Action" : "eks:DescribeCluster",
+        "Resource" : "arn:aws:eks:${local.aws_default_region}:${local.account_id}:cluster/${local.eks_name}",
+        "Sid" : "EKSClusterEndpointLookup"
+      },
+      {
+        "Sid" : "AllowScopedInstanceProfileCreationActions",
+        "Effect" : "Allow",
+        "Resource" : "*",
+        "Action" : [
+          "iam:CreateInstanceProfile"
+        ],
+        "Condition" : {
+          "StringEquals" : {
+            "aws:RequestTag/kubernetes.io/cluster/${local.eks_name}" : "owned",
+            "aws:RequestTag/topology.kubernetes.io/region" : "${local.aws_default_region}"
+          },
+          "StringLike" : {
+            "aws:RequestTag/karpenter.k8s.aws/ec2nodeclass" : "*"
+          }
+        }
+      },
+      {
+        "Sid" : "AllowScopedInstanceProfileTagActions",
+        "Effect" : "Allow",
+        "Resource" : "*",
+        "Action" : [
+          "iam:TagInstanceProfile"
+        ],
+        "Condition" : {
+          "StringEquals" : {
+            "aws:ResourceTag/kubernetes.io/cluster/${local.eks_name}" : "owned",
+            "aws:ResourceTag/topology.kubernetes.io/region" : "${local.aws_default_region}",
+            "aws:RequestTag/kubernetes.io/cluster/${local.eks_name}" : "owned",
+            "aws:RequestTag/topology.kubernetes.io/region" : "${local.aws_default_region}"
+          },
+          "StringLike" : {
+            "aws:ResourceTag/karpenter.k8s.aws/ec2nodeclass" : "*",
+            "aws:RequestTag/karpenter.k8s.aws/ec2nodeclass" : "*"
+          }
+        }
+      },
+      {
+        "Sid" : "AllowScopedInstanceProfileActions",
+        "Effect" : "Allow",
+        "Resource" : "*",
+        "Action" : [
+          "iam:AddRoleToInstanceProfile",
+          "iam:RemoveRoleFromInstanceProfile",
+          "iam:DeleteInstanceProfile"
+        ],
+        "Condition" : {
+          "StringEquals" : {
+            "aws:ResourceTag/kubernetes.io/cluster/${local.eks_name}" : "owned",
+            "aws:ResourceTag/topology.kubernetes.io/region" : "${local.aws_default_region}"
+          },
+          "StringLike" : {
+            "aws:ResourceTag/karpenter.k8s.aws/ec2nodeclass" : "*"
+          }
+        }
+      },
+      {
+        "Sid" : "AllowInstanceProfileReadActions",
+        "Effect" : "Allow",
+        "Resource" : "*",
+        "Action" : "iam:GetInstanceProfile"
+      }
+    ]
+
+  })
+}
+
+resource "aws_iam_role" "aws_karpenter_controller_role" {
+  name = "KarpenterControllerRole-${local.eks_name}"
+  assume_role_policy = jsonencode({
+    "Version" : "2012-10-17"
+    "Statement" : [
+      {
+        "Effect" : "Allow",
+        "Principal" : {
+          "Federated" : "arn:aws:iam::${local.account_id}:oidc-provider/${local.oidc_id}"
+        },
+        "Action" : "sts:AssumeRoleWithWebIdentity",
+        "Condition" : {
+          "StringEquals" : {
+            "${local.oidc_id}:aud" : "sts.amazonaws.com"
+          }
+        }
+      }
+    ]
+  })
+  force_detach_policies = true
+}
+
+
+resource "aws_iam_role" "aws_karpenter_node_role" {
+  name = "KarpenterNodeRole-${local.eks_name}"
+  assume_role_policy = jsonencode({
+    "Version" : "2012-10-17",
+    "Statement" : [
+      {
+        "Effect" : "Allow",
+        "Principal" : {
+          "Service" : "ec2.amazonaws.com"
+        },
+        "Action" : "sts:AssumeRole"
+      }
+    ]
+  })
+  force_detach_policies = true
+}
+
+resource "aws_iam_role_policy_attachment" "aws_karpenter_controller_attachment" {
+  role       = aws_iam_role.aws_karpenter_controller_role.name
+  policy_arn = aws_iam_policy.aws_karpenter_controller_policy.arn
+}
+
+resource "aws_iam_role_policy_attachment" "aws_karpenter_node_attachment_1" {
+  role       = aws_iam_role.aws_karpenter_node_role.name
+  policy_arn = "arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryReadOnly"
+}
+
+resource "aws_iam_role_policy_attachment" "aws_karpenter_node_attachment_2" {
+  role       = aws_iam_role.aws_karpenter_node_role.name
+  policy_arn = "arn:aws:iam::aws:policy/AmazonEKS_CNI_Policy"
+}
+
+resource "aws_iam_role_policy_attachment" "aws_karpenter_node_attachment_3" {
+  role       = aws_iam_role.aws_karpenter_node_role.name
+  policy_arn = "arn:aws:iam::aws:policy/AmazonEKSWorkerNodePolicy"
+}
+
+resource "aws_iam_role_policy_attachment" "aws_karpenter_node_attachment_4" {
+  role       = aws_iam_role.aws_karpenter_node_role.name
+  policy_arn = "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"
+}
+
+resource "aws_iam_role_policy_attachment" "aws_karpenter_node_attachment_5" {
+  role       = aws_iam_role.aws_karpenter_node_role.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonEBSCSIDriverPolicy"
+}

--- a/aws_dragonfly-staging_eu-west-1_eks_dragonfly-staging-1_eks.tf
+++ b/aws_dragonfly-staging_eu-west-1_eks_dragonfly-staging-1_eks.tf
@@ -1,0 +1,105 @@
+terraform {
+  backend "s3" {
+    bucket = "eticloud-tf-state-nonprod"
+    key    = "terraform-state/aws-dragonfly-staging/eks/eu-west-1/eks-df-staging-1.tfstate"
+    region = "us-east-2"
+  }
+}
+
+provider "aws" {
+  access_key = data.vault_generic_secret.aws_infra_credential.data["AWS_ACCESS_KEY_ID"]
+  secret_key = data.vault_generic_secret.aws_infra_credential.data["AWS_SECRET_ACCESS_KEY"]
+  region     = "eu-west-1"
+  default_tags {
+    tags = {
+      ApplicationName    = "eks-df-staging-1"
+      CiscoMailAlias     = "eti-sre-admins@cisco.com"
+      DataClassification = "Cisco Confidential"
+      DataTaxonomy       = "Cisco Operations Data"
+      Environment        = "NonProd"
+      ResourceOwner      = "ETI SRE"
+    }
+  }
+}
+
+provider "vault" {
+  address   = "https://keeper.cisco.com"
+  namespace = "eticloud"
+  alias     = "eticloud"
+}
+
+data "vault_generic_secret" "aws_infra_credential" {
+  path = "secret/infra/aws/dragonfly-staging/terraform_admin"
+}
+
+data "aws_caller_identity" "current" {}
+
+module "eks" {
+  source          = "git::https://github.com/cisco-eti/sre-tf-module-aws-eks?ref=2.0.1"
+  cluster_name    = "eks-df-staging-1"
+  cluster_version = "1.27" # don't roll back!
+  cluster_os      = "AmazonLinux2"
+  vpc_name        = "dragonfly-compute-staging-1-vpc"
+
+  # Private Node group options
+  create_private_nodegroup            = true            # Defaults to true. Must be true for any of the below to be set by the module,
+  private_node_group_desired_capacity = 5               # The desired number of worker nodes. Once this is set, the number of desired instances must be manually modified.
+  private_node_group_min_capacity     = 5               # The minimum number of worker nodes.
+  private_node_group_max_capacity     = 10              # The maximium number of worker nodes.
+  private_node_group_instance_type    = ["m5a.2xlarge"] # The instance type for the worker nodes.
+
+  # Public Node group options
+  create_public_nodegroup            = false          # Defaults to false. Must be true for any of the below to be set by the module,
+  public_node_group_desired_capacity = 0              # The desired number of worker nodes. Once this is set, the number of desired instances must be manually modified.
+  public_node_group_min_capacity     = 0              # The minimum number of worker nodes.
+  public_node_group_max_capacity     = 0              # The maximium number of worker nodes.
+  public_node_group_instance_type    = ["m5a.xlarge"] # The instance type for the worker nodes.
+
+  # aws-auth configmap
+  create_aws_auth_configmap = false
+  manage_aws_auth_configmap = false # Set to false in SRE module
+
+  aws_auth_additional_roles = [
+    {
+      rolearn  = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/admin"
+      username = "admin"
+      groups   = ["system:masters"]
+    },
+    {
+      rolearn  = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/devops",
+      username = "devops",
+      groups   = ["system:masters"]
+    },
+    { # Role for karpenter
+      rolearn  = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/KarpenterNodeRole-eks-df-staging-1",
+      username = "system:node:{{EC2PrivateDNSName}}",
+      groups   = ["system:bootstrappers", "system:nodes"]
+    }
+  ]
+
+  cluster_addons = {
+    coredns = {
+      addon_version = "v1.10.1-eksbuild.4"
+    }
+    kube-proxy = {
+      addon_version = "v1.27.6-eksbuild.2"
+    }
+    vpc-cni = {
+      addon_version = "v1.15.1-eksbuild.1"
+      configuration_values = jsonencode({
+        env = {
+          # Reference docs https://docs.aws.amazon.com/eks/latest/userguide/cni-increase-ip-addresses.html
+          ENABLE_PREFIX_DELEGATION = "false"
+          WARM_PREFIX_TARGET       = "0"
+        }
+      })
+    }
+    aws-ebs-csi-driver = {
+      addon_version = "v1.23.1-eksbuild.1"
+    }
+  }
+
+  providers = {
+    vault = vault.eticloud
+  }
+}

--- a/aws_dragonfly-staging_eu-west-1_msk_dragonfly-staging-msk-1_backend.tf
+++ b/aws_dragonfly-staging_eu-west-1_msk_dragonfly-staging-msk-1_backend.tf
@@ -1,0 +1,7 @@
+terraform {
+  backend "s3" {
+    bucket = "eticloud-tf-state-nonprod"
+    key    = "terraform-state/aws-dragonfly-staging/msk/eu-west-1/dragonfly-staging-msk-1.tfstate"
+    region = "us-east-2"
+  }
+}

--- a/aws_dragonfly-staging_eu-west-1_msk_dragonfly-staging-msk-1_cloudwatch.tf
+++ b/aws_dragonfly-staging_eu-west-1_msk_dragonfly-staging-msk-1_cloudwatch.tf
@@ -1,0 +1,3 @@
+resource "aws_cloudwatch_log_group" "broker_logs" {
+  name = "dragonfly-staging-msk-1-broker-logs"
+}

--- a/aws_dragonfly-staging_eu-west-1_msk_dragonfly-staging-msk-1_dependencies.tf
+++ b/aws_dragonfly-staging_eu-west-1_msk_dragonfly-staging-msk-1_dependencies.tf
@@ -1,0 +1,65 @@
+data "vault_generic_secret" "aws_infra_credential" {
+  path     = "secret/infra/aws/${local.aws_account_name}/terraform_admin"
+  provider = vault.eticloud
+}
+
+data "aws_caller_identity" "current" {}
+data "aws_region" "current" {}
+
+data "vault_generic_secret" "msk_auth_credentials" {
+  for_each = var.kafka_clients
+
+  path     = each.value.vault_path
+  provider = vault.dragonfly
+}
+
+data "aws_iam_policy_document" "msk_secret_policy" {
+  for_each = var.kafka_clients
+
+  statement {
+    sid    = "AWSKafkaResourcePolicy"
+    effect = "Allow"
+
+    principals {
+      type        = "Service"
+      identifiers = ["kafka.amazonaws.com"]
+    }
+
+    actions   = ["secretsmanager:getSecretValue"]
+    resources = [aws_secretsmanager_secret.msk_auth_credentials[each.key].arn]
+  }
+}
+
+data "aws_vpc" "eks_vpc" {
+  filter {
+    name   = "tag:Name"
+    values = ["dragonfly-compute-staging-1-vpc"]
+  }
+}
+
+data "aws_vpc" "msk_vpc" {
+  filter {
+    name   = "tag:Name"
+    values = ["dragonfly-data-staging-1-vpc"]
+  }
+}
+
+data "aws_subnets" "eks_subnets" {
+  filter {
+    name   = "vpc-id"
+    values = [data.aws_vpc.eks_vpc.id]
+  }
+  tags = {
+    Tier = "Private"
+  }
+}
+
+data "aws_subnets" "msk_subnets" {
+  filter {
+    name   = "vpc-id"
+    values = [data.aws_vpc.msk_vpc.id]
+  }
+  tags = {
+    Tier = "Private"
+  }
+}

--- a/aws_dragonfly-staging_eu-west-1_msk_dragonfly-staging-msk-1_kafka-connect.tf
+++ b/aws_dragonfly-staging_eu-west-1_msk_dragonfly-staging-msk-1_kafka-connect.tf
@@ -1,0 +1,117 @@
+resource "aws_iam_role" "connector_role" {
+  name = "${local.connector_name}-role"
+
+  assume_role_policy = jsonencode({
+    "Version" : "2012-10-17"
+    "Statement" : [
+      {
+        "Effect" = "Allow",
+        "Principal" : {
+          "Service" = "kafkaconnect.amazonaws.com"
+        },
+        "Action" = "sts:AssumeRole",
+      }
+    ]
+  })
+  force_detach_policies = true
+}
+
+data "aws_iam_policy_document" "connector_role_policy" {
+  statement {
+    actions = [
+      "kafka-cluster:Connect",
+      "kafka-cluster:AlterCluster",
+      "kafka-cluster:DescribeCluster",
+      "kafka:DescribeClusterV2",
+      "kafka:GetBootstrapBrokers"
+    ]
+
+    resources = [
+      "${aws_msk_cluster.dragonfly-msk-1.arn}:connector/*"
+    ]
+
+    effect = "Allow"
+  }
+
+  statement {
+    actions = [
+      "kafka-cluster:*Topic*",
+      "kafka-cluster:ReadData"
+    ]
+
+    resources = [
+      "arn:aws:kafka:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:topic/${aws_msk_cluster.dragonfly-msk-1.cluster_name}/${aws_msk_cluster.dragonfly-msk-1.cluster_uuid}/*"
+    ]
+
+    effect = "Allow"
+  }
+
+  statement {
+    actions = [
+      "kafka-cluster:CreateTopic",
+      "kafka-cluster:WriteData",
+      "kafka-cluster:ReadData",
+      "kafka-cluster:DescribeTopic"
+    ]
+
+    resources = [
+      "arn:aws:kafka:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:topic/${aws_msk_cluster.dragonfly-msk-1.cluster_name}/${aws_msk_cluster.dragonfly-msk-1.cluster_uuid}/__amazon_msk_connect_*"
+    ]
+
+    effect = "Allow"
+  }
+
+  statement {
+    actions = [
+      "kafka-cluster:AlterGroup",
+      "kafka-cluster:DescribeGroup"
+    ]
+
+    resources = [
+      "arn:aws:kafka:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:group/${aws_msk_cluster.dragonfly-msk-1.cluster_name}/${aws_msk_cluster.dragonfly-msk-1.cluster_uuid}/*",
+      # "arn:aws:kafka:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:group/${aws_msk_cluster.dragonfly-msk-1.cluster_name}/${aws_msk_cluster.dragonfly-msk-1.cluster_uuid}/__amazon_msk_connect_*",
+      # "arn:aws:kafka:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:group/${aws_msk_cluster.dragonfly-msk-1.cluster_name}/${aws_msk_cluster.dragonfly-msk-1.cluster_uuid}/connect-*"
+    ]
+
+    effect = "Allow"
+  }
+
+  statement {
+    actions = [
+      "logs:CreateLogDelivery",
+      "logs:GetLogDelivery",
+      "logs:DescribeLogDelivery",
+      "logs:DeleteLogDelivery",
+      "logs:ListLogDeliveries"
+    ]
+
+    resources = [
+      "*"
+    ]
+
+    effect = "Allow"
+  }
+
+  statement {
+    actions = [
+      "s3:PutObject"
+    ]
+
+    resources = [
+      "arn:aws:s3:::${local.connector_name}-logs/*"
+    ]
+
+    effect = "Allow"
+  }
+}
+
+resource "aws_iam_policy" "connector_role_policy" {
+  name        = "${local.connector_name}-role-policy"
+  description = "Policies for msk connector"
+  policy      = data.aws_iam_policy_document.connector_role_policy.json
+}
+
+resource "aws_iam_role_policy_attachment" "dragonfly_msk_connector_role_policy_attachment" {
+  role       = aws_iam_role.connector_role.name
+  policy_arn = aws_iam_policy.connector_role_policy.arn
+}

--- a/aws_dragonfly-staging_eu-west-1_msk_dragonfly-staging-msk-1_kms.tf
+++ b/aws_dragonfly-staging_eu-west-1_msk_dragonfly-staging-msk-1_kms.tf
@@ -1,0 +1,3 @@
+resource "aws_kms_key" "encryption_key" {
+  description = "dragonfly-staging-msk-1 MSK cluster encryption key"
+}

--- a/aws_dragonfly-staging_eu-west-1_msk_dragonfly-staging-msk-1_locals.tf
+++ b/aws_dragonfly-staging_eu-west-1_msk_dragonfly-staging-msk-1_locals.tf
@@ -1,0 +1,5 @@
+locals {
+  aws_account_name = "dragonfly-staging"
+
+  connector_name = "kafka-connect-arangodb"
+}

--- a/aws_dragonfly-staging_eu-west-1_msk_dragonfly-staging-msk-1_msk.tf
+++ b/aws_dragonfly-staging_eu-west-1_msk_dragonfly-staging-msk-1_msk.tf
@@ -1,0 +1,143 @@
+resource "aws_msk_configuration" "configuration" {
+  kafka_versions = [var.kafka_version]
+  name           = "dragonfly-staging-msk-1"
+
+  server_properties = <<PROPERTIES
+auto.create.topics.enable = true
+PROPERTIES
+}
+
+resource "aws_msk_scram_secret_association" "msk_auth_credentials" {
+  cluster_arn = aws_msk_cluster.dragonfly-msk-1.arn
+  secret_arn_list = [
+    for s in aws_secretsmanager_secret.msk_auth_credentials : s.arn
+  ]
+
+  depends_on = [aws_secretsmanager_secret_version.msk_auth_credentials_1]
+}
+
+resource "aws_msk_cluster" "dragonfly-msk-1" {
+  cluster_name           = "dragonfly-staging-msk-1"
+  kafka_version          = var.kafka_version
+  number_of_broker_nodes = var.number_of_broker_nodes
+
+  // Broker configuration
+  broker_node_group_info {
+    instance_type = var.instance_type
+
+    client_subnets = data.aws_subnets.msk_subnets.ids
+
+    storage_info {
+      ebs_storage_info {
+        volume_size = 1000
+      }
+    }
+
+    // Turn on multi-vpc connectivity
+    connectivity_info {
+      vpc_connectivity {
+        client_authentication {
+          sasl {
+            scram = false
+            iam   = true
+          }
+        }
+      }
+    }
+
+    security_groups = [aws_security_group.dragonfly-msk-1.id]
+  }
+
+  // Encryption
+  encryption_info {
+    encryption_at_rest_kms_key_arn = aws_kms_key.encryption_key.arn
+
+    encryption_in_transit {
+      client_broker = "TLS"
+      in_cluster    = true
+    }
+  }
+
+  // Authentication
+  client_authentication {
+    sasl {
+      scram = true
+      iam   = true
+    }
+  }
+
+  // Cluster config
+  configuration_info {
+    arn      = aws_msk_configuration.configuration.arn
+    revision = aws_msk_configuration.configuration.latest_revision
+  }
+
+  // Monitoring && logging
+  open_monitoring {
+    prometheus {
+      jmx_exporter {
+        enabled_in_broker = true
+      }
+      node_exporter {
+        enabled_in_broker = true
+      }
+    }
+  }
+
+  enhanced_monitoring = "PER_TOPIC_PER_PARTITION"
+
+  logging_info {
+    broker_logs {
+      cloudwatch_logs {
+        enabled   = true
+        log_group = aws_cloudwatch_log_group.broker_logs.name
+      }
+    }
+  }
+}
+
+resource "aws_msk_cluster_policy" "opensearch_ingestion_policy" {
+  cluster_arn = aws_msk_cluster.dragonfly-msk-1.arn
+
+  policy = jsonencode({
+    "Version" : "2012-10-17",
+    "Statement" : [
+      {
+        "Effect" : "Allow",
+        "Principal" : {
+          "Service" : "osis.amazonaws.com"
+        },
+        "Action" : [
+          "kafka:CreateVpcConnection",
+          "kafka:DescribeCluster",
+          "kafka:DescribeClusterV2"
+        ],
+        "Resource" : aws_msk_cluster.dragonfly-msk-1.arn
+      },
+      {
+        "Effect" : "Allow",
+        "Principal" : {
+          "Service" : "osis-pipelines.amazonaws.com"
+        },
+        "Action" : [
+          "kafka:CreateVpcConnection",
+          "kafka:GetBootstrapBrokers",
+          "kafka:DescribeCluster",
+          "kafka:DescribeClusterV2"
+        ],
+        "Resource" : aws_msk_cluster.dragonfly-msk-1.arn
+    }]
+  })
+}
+
+// Save brokers in vault
+resource "vault_generic_secret" "msk_brokers" {
+  path = "secret/staging/msk/dragonfly-msk-1/brokers"
+
+  data_json = jsonencode({
+    brokers     = aws_msk_cluster.dragonfly-msk-1.bootstrap_brokers_sasl_scram
+    brokers-iam = aws_msk_cluster.dragonfly-msk-1.bootstrap_brokers_sasl_iam
+  })
+
+  provider = vault.dragonfly
+}

--- a/aws_dragonfly-staging_eu-west-1_msk_dragonfly-staging-msk-1_outputs.tf
+++ b/aws_dragonfly-staging_eu-west-1_msk_dragonfly-staging-msk-1_outputs.tf
@@ -1,0 +1,11 @@
+output "zookeeper_connect_string" {
+  value = aws_msk_cluster.dragonfly-msk-1.zookeeper_connect_string
+}
+
+output "bootstrap_brokers" {
+  value = aws_msk_cluster.dragonfly-msk-1.bootstrap_brokers
+}
+
+output "bootstrap_brokers_tls" {
+  value = aws_msk_cluster.dragonfly-msk-1.bootstrap_brokers_tls
+}

--- a/aws_dragonfly-staging_eu-west-1_msk_dragonfly-staging-msk-1_providers.tf
+++ b/aws_dragonfly-staging_eu-west-1_msk_dragonfly-staging-msk-1_providers.tf
@@ -1,0 +1,28 @@
+provider "aws" {
+  access_key = data.vault_generic_secret.aws_infra_credential.data["AWS_ACCESS_KEY_ID"]
+  secret_key = data.vault_generic_secret.aws_infra_credential.data["AWS_SECRET_ACCESS_KEY"]
+  region     = "eu-west-1"
+
+  default_tags {
+    tags = {
+      ApplicationName    = "dragonfly-staging-msk-1"
+      CiscoMailAlias     = "eti-sre-admins@cisco.com"
+      DataClassification = "Cisco Confidential"
+      DataTaxonomy       = "Cisco Operations Data"
+      Environment        = "NonProd"
+      ResourceOwner      = "ETI SRE"
+    }
+  }
+}
+
+provider "vault" {
+  alias     = "eticloud"
+  address   = "https://keeper.cisco.com"
+  namespace = "eticloud"
+}
+
+provider "vault" {
+  alias     = "dragonfly"
+  address   = "https://keeper.cisco.com"
+  namespace = "eticloud/apps/dragonfly"
+}

--- a/aws_dragonfly-staging_eu-west-1_msk_dragonfly-staging-msk-1_secretsmanager.tf
+++ b/aws_dragonfly-staging_eu-west-1_msk_dragonfly-staging-msk-1_secretsmanager.tf
@@ -1,0 +1,25 @@
+// Secrets for SASL/SCRAM authentication
+resource "aws_secretsmanager_secret" "msk_auth_credentials" {
+  for_each = var.kafka_clients
+
+  name        = "AmazonMSK_dragonfly-staging-msk-1-${each.key}-auth"
+  description = each.value.description
+
+  kms_key_id = aws_kms_key.encryption_key.key_id
+}
+
+// Secret versions
+resource "aws_secretsmanager_secret_version" "msk_auth_credentials_1" {
+  for_each = var.kafka_clients
+
+  secret_id     = aws_secretsmanager_secret.msk_auth_credentials[each.key].id
+  secret_string = data.vault_generic_secret.msk_auth_credentials[each.key].data_json
+}
+
+// Secret policy
+resource "aws_secretsmanager_secret_policy" "msk_secret_policy" {
+  for_each = var.kafka_clients
+
+  secret_arn = aws_secretsmanager_secret.msk_auth_credentials[each.key].arn
+  policy     = data.aws_iam_policy_document.msk_secret_policy[each.key].json
+}

--- a/aws_dragonfly-staging_eu-west-1_msk_dragonfly-staging-msk-1_securitygroup.tf
+++ b/aws_dragonfly-staging_eu-west-1_msk_dragonfly-staging-msk-1_securitygroup.tf
@@ -1,0 +1,80 @@
+locals {
+  msk_ingress_rules = [
+    {
+      from_port : 9094,
+      to_port : 9094,
+      protocol : "tcp",
+      cidr_blocks : [
+        data.aws_vpc.msk_vpc.cidr_block,
+        data.aws_vpc.eks_vpc.cidr_block,
+      ],
+    },
+    {
+      from_port : 9096,
+      to_port : 9096,
+      protocol : "tcp",
+      cidr_blocks : [
+        data.aws_vpc.msk_vpc.cidr_block,
+        data.aws_vpc.eks_vpc.cidr_block,
+      ],
+    },
+    {
+      from_port : 9098,
+      to_port : 9098,
+      protocol : "tcp",
+      cidr_blocks : [
+        data.aws_vpc.msk_vpc.cidr_block,
+        data.aws_vpc.eks_vpc.cidr_block,
+      ],
+    },
+    {
+      from_port : 2181,
+      to_port : 2181,
+      protocol : "tcp",
+      cidr_blocks : [
+        data.aws_vpc.msk_vpc.cidr_block,
+      ],
+    },
+  ]
+
+  msk_egress_rules = [
+    {
+      from_port : 0,
+      to_port : 65535,
+      protocol : "tcp",
+      cidr_blocks : [
+        data.aws_vpc.msk_vpc.cidr_block,
+        data.aws_vpc.eks_vpc.cidr_block,
+      ],
+    },
+  ]
+}
+
+
+resource "aws_security_group" "dragonfly-msk-1" {
+  name        = "dragonfly-staging-msk-1-msk-default"
+  description = "dragonfly-staging-msk-1 MSK cluster default security group"
+  vpc_id      = data.aws_vpc.msk_vpc.id
+
+  dynamic "ingress" {
+    for_each = toset(local.msk_ingress_rules)
+
+    content {
+      from_port   = ingress.value.from_port
+      to_port     = ingress.value.to_port
+      protocol    = ingress.value.protocol
+      cidr_blocks = ingress.value.cidr_blocks
+    }
+  }
+
+  dynamic "egress" {
+    for_each = toset(local.msk_egress_rules)
+
+    content {
+      from_port   = egress.value.from_port
+      to_port     = egress.value.to_port
+      protocol    = egress.value.protocol
+      cidr_blocks = egress.value.cidr_blocks
+    }
+  }
+}

--- a/aws_dragonfly-staging_eu-west-1_msk_dragonfly-staging-msk-1_variables.tf
+++ b/aws_dragonfly-staging_eu-west-1_msk_dragonfly-staging-msk-1_variables.tf
@@ -1,0 +1,39 @@
+variable "kafka_version" {
+  description = "Kafka version to deploy"
+  type        = string
+  default     = "3.6.0"
+}
+
+variable "instance_type" {
+  description = "Instance type to use for Kafka brokers"
+  type        = string
+  default     = "kafka.m5.large"
+}
+
+variable "number_of_broker_nodes" {
+  description = "Number of Kafka broker nodes to deploy"
+  type        = number
+  default     = 3
+}
+
+variable "kafka_clients" {
+  description = "Kafka clients to create"
+  type = map(object({
+    description = string
+    vault_path  = string
+  }))
+  default = {
+    "otel-collector" = {
+      description = "Auth credentials of otel-collector for dragonfly-msk-1"
+      vault_path  = "secret/staging/msk/dragonfly-msk-1/kafka-clients/otel-collector"
+    },
+    "notification-service" = {
+      description = "Auth credentials of notification-service for dragonfly-msk-1"
+      vault_path  = "secret/staging/msk/dragonfly-msk-1/kafka-clients/notification-service"
+    },
+    "opensearch-ingestion-service" = {
+      description = "Auth credentials of ingestion-service for dragonfly-msk-1"
+      vault_path  = "secret/staging/msk/dragonfly-msk-1/kafka-clients/opensearch-ingestion-service"
+    },
+  }
+}

--- a/aws_dragonfly-staging_eu-west-1_msk_dragonfly-staging-msk-1_versions.tf
+++ b/aws_dragonfly-staging_eu-west-1_msk_dragonfly-staging-msk-1_versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.3.6"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+}

--- a/aws_dragonfly-staging_eu-west-1_os_dragonfly-staging-1-os_backend.tf
+++ b/aws_dragonfly-staging_eu-west-1_os_dragonfly-staging-1-os_backend.tf
@@ -1,0 +1,7 @@
+terraform {
+  backend "s3" {
+    bucket = "eticloud-tf-state-nonprod"
+    key    = "terraform-state/aws-dragonfly-staging/os/eu-west-1/dragonfly-staging-1-os.tfstate"
+    region = "us-east-2"
+  }
+}

--- a/aws_dragonfly-staging_eu-west-1_os_dragonfly-staging-1-os_cloudwatch.tf
+++ b/aws_dragonfly-staging_eu-west-1_os_dragonfly-staging-1-os_cloudwatch.tf
@@ -1,0 +1,8 @@
+resource "aws_cloudwatch_log_group" "dragonfly_staging_1_os_logs" {
+  name = "dragonfly-staging-1-os-logs"
+}
+
+resource "aws_cloudwatch_log_resource_policy" "opensearch_log_publishing_policy" {
+  policy_document = data.aws_iam_policy_document.opensearch_log_publishing_policy.json
+  policy_name     = "opensearch-log-publishing-policy"
+}

--- a/aws_dragonfly-staging_eu-west-1_os_dragonfly-staging-1-os_dependencies.tf
+++ b/aws_dragonfly-staging_eu-west-1_os_dragonfly-staging-1-os_dependencies.tf
@@ -1,0 +1,49 @@
+data "vault_generic_secret" "aws_infra_credential" {
+  path     = "secret/infra/aws/${local.aws_account_name}/terraform_admin"
+  provider = vault.eticloud
+}
+
+# OS account and region
+data "aws_caller_identity" "current" {} # data.aws_caller_identity.current.account_id
+data "aws_region" "current" {}          # data.aws_region.current.name
+
+data "aws_vpc" "database_vpc" {
+  filter {
+    name = "tag:Name"
+    values = [
+      local.data_vpc_name
+    ]
+  }
+}
+
+data "aws_subnets" "db_subnets" {
+  filter {
+    name   = "vpc-id"
+    values = [data.aws_vpc.database_vpc.id]
+  }
+  filter {
+    name = "tag:Name"
+    values = [
+      "dragonfly-data-staging-1-vpc-db-${data.aws_region.current.name}*"
+    ]
+  }
+}
+
+data "aws_vpc" "compute_vpc" {
+  filter {
+    name = "tag:Name"
+    values = [
+      local.eks_vpc_name
+    ]
+  }
+}
+
+data "aws_subnets" "compute_subnets" {
+  filter {
+    name   = "vpc-id"
+    values = [data.aws_vpc.compute_vpc.id]
+  }
+  tags = {
+    Tier = "Private"
+  }
+}

--- a/aws_dragonfly-staging_eu-west-1_os_dragonfly-staging-1-os_iam.tf
+++ b/aws_dragonfly-staging_eu-west-1_os_dragonfly-staging-1-os_iam.tf
@@ -1,0 +1,37 @@
+# resource "aws_iam_service_linked_role" "dragonfly_linked_role" {
+#   aws_service_name = "opensearchservice.amazonaws.com"
+# }
+
+data "aws_iam_policy_document" "dragonfly_admin_access_policy" {
+  statement {
+    sid = "admin"
+
+    effect = "Allow"
+
+    principals {
+      type        = "AWS"
+      identifiers = ["*"]
+    }
+
+    actions = ["es:*"]
+
+    resources = ["arn:aws:es:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:domain/${var.domain_name}/*"]
+  }
+}
+
+data "aws_iam_policy_document" "opensearch_log_publishing_policy" {
+  statement {
+    actions = [
+      "logs:CreateLogStream",
+      "logs:PutLogEvents",
+      "logs:PutLogEventsBatch",
+    ]
+
+    resources = ["arn:aws:logs:*"]
+
+    principals {
+      identifiers = ["opensearchservice.amazonaws.com"]
+      type        = "Service"
+    }
+  }
+}

--- a/aws_dragonfly-staging_eu-west-1_os_dragonfly-staging-1-os_kms.tf
+++ b/aws_dragonfly-staging_eu-west-1_os_dragonfly-staging-1-os_kms.tf
@@ -1,0 +1,3 @@
+resource "aws_kms_key" "encryption_key" {
+  description = "${var.domain_name} encryption key"
+}

--- a/aws_dragonfly-staging_eu-west-1_os_dragonfly-staging-1-os_locals.tf
+++ b/aws_dragonfly-staging_eu-west-1_os_dragonfly-staging-1-os_locals.tf
@@ -1,0 +1,6 @@
+locals {
+  eks_vpc_name     = "dragonfly-compute-staging-1-vpc"
+  data_vpc_name    = "dragonfly-data-staging-1-vpc"
+  region           = "eu-west-1"
+  aws_account_name = "dragonfly-staging"
+}

--- a/aws_dragonfly-staging_eu-west-1_os_dragonfly-staging-1-os_main.tf
+++ b/aws_dragonfly-staging_eu-west-1_os_dragonfly-staging-1-os_main.tf
@@ -1,0 +1,101 @@
+resource "aws_opensearch_domain" "dragonfly_staging_1_os" {
+  depends_on = [
+    # aws_iam_service_linked_role.dragonfly_linked_role,
+    aws_cloudwatch_log_group.dragonfly_staging_1_os_logs,
+  ]
+
+  domain_name     = var.domain_name
+  engine_version  = var.engine_version
+  access_policies = null
+
+  cluster_config {
+    dedicated_master_enabled = true
+    dedicated_master_count   = 3
+    dedicated_master_type    = var.instance_type
+
+    instance_count = 3
+    instance_type  = var.instance_type
+
+    warm_enabled = true
+    warm_count   = 3
+    warm_type    = var.warm_instance_type
+
+    zone_awareness_enabled = true
+
+    zone_awareness_config {
+      availability_zone_count = 3
+    }
+
+    cold_storage_options {
+      enabled = true
+    }
+  }
+
+  vpc_options {
+    subnet_ids = data.aws_subnets.db_subnets.ids
+    security_group_ids = [
+      aws_security_group.dragonfly_staging_1_os.id
+    ]
+  }
+
+  advanced_security_options {
+    enabled                        = true
+    anonymous_auth_enabled         = false
+    internal_user_database_enabled = true
+
+    master_user_options {
+      master_user_name     = vault_generic_secret.os_auth_credentials.data["username"]
+      master_user_password = vault_generic_secret.os_auth_credentials.data["password"]
+    }
+  }
+
+  domain_endpoint_options {
+    enforce_https       = true
+    tls_security_policy = "Policy-Min-TLS-1-2-2019-07"
+
+    custom_endpoint_enabled = false
+  }
+
+  node_to_node_encryption {
+    enabled = true
+  }
+
+  encrypt_at_rest {
+    enabled    = true
+    kms_key_id = aws_kms_key.encryption_key.arn
+  }
+
+  ebs_options {
+    ebs_enabled = true
+    volume_type = "gp3"
+    volume_size = 1000
+    iops        = 3000
+    throughput  = 250
+  }
+
+  log_publishing_options {
+    log_type                 = "AUDIT_LOGS"
+    enabled                  = true
+    cloudwatch_log_group_arn = aws_cloudwatch_log_group.dragonfly_staging_1_os_logs.arn
+  }
+
+  auto_tune_options {
+    desired_state       = "ENABLED"
+    rollback_on_disable = "NO_ROLLBACK"
+  }
+
+
+  tags = {
+    DataClassification = "Cisco Restricted"
+    Environment        = "NonProd"
+    ApplicationName    = var.domain_name
+    ResourceOwner      = "eti sre"
+    CiscoMailAlias     = "eti-sre-admins@cisco.com"
+    DataTaxonomy       = "Cisco Operations Data"
+  }
+}
+
+resource "aws_opensearch_domain_policy" "this" {
+  domain_name     = aws_opensearch_domain.dragonfly_staging_1_os.domain_name
+  access_policies = data.aws_iam_policy_document.dragonfly_admin_access_policy.json
+}

--- a/aws_dragonfly-staging_eu-west-1_os_dragonfly-staging-1-os_master-user.tf
+++ b/aws_dragonfly-staging_eu-west-1_os_dragonfly-staging-1-os_master-user.tf
@@ -1,0 +1,30 @@
+resource "random_password" "password" {
+  length  = 64
+  special = true
+}
+
+resource "vault_generic_secret" "os_auth_credentials" {
+  path = "secret/staging/os/eu-west-1/dragonfly-staging-1-os/master-user"
+
+  data_json = jsonencode({
+    username = var.os_master_user
+    password = random_password.password.result
+  })
+
+  provider = vault.dragonfly
+}
+
+resource "vault_generic_secret" "connection" {
+  path = "secret/staging/os/eu-west-1/dragonfly-staging-1-os/connection"
+  data_json = jsonencode({
+    username = var.os_master_user
+    password = random_password.password.result
+    endpoint = "https://${aws_opensearch_domain.dragonfly_staging_1_os.endpoint}"
+  })
+
+  provider = vault.dragonfly
+
+  depends_on = [
+    aws_opensearch_domain.dragonfly_staging_1_os
+  ]
+}

--- a/aws_dragonfly-staging_eu-west-1_os_dragonfly-staging-1-os_outputs.tf
+++ b/aws_dragonfly-staging_eu-west-1_os_dragonfly-staging-1-os_outputs.tf
@@ -1,0 +1,9 @@
+# OS endpoint
+output "opensearch_endpoint" {
+  value = aws_opensearch_domain.dragonfly_staging_1_os.endpoint
+}
+
+# OS dashboard endpoint
+output "opensearch_dashboard_endpoint" {
+  value = aws_opensearch_domain.dragonfly_staging_1_os.dashboard_endpoint
+}

--- a/aws_dragonfly-staging_eu-west-1_os_dragonfly-staging-1-os_providers.tf
+++ b/aws_dragonfly-staging_eu-west-1_os_dragonfly-staging-1-os_providers.tf
@@ -1,0 +1,28 @@
+provider "aws" {
+  access_key = data.vault_generic_secret.aws_infra_credential.data["AWS_ACCESS_KEY_ID"]
+  secret_key = data.vault_generic_secret.aws_infra_credential.data["AWS_SECRET_ACCESS_KEY"]
+  region     = "eu-west-1"
+
+  default_tags {
+    tags = {
+      ApplicationName    = var.domain_name
+      CiscoMailAlias     = "eti-sre-admins@cisco.com"
+      DataClassification = "Cisco Confidential"
+      DataTaxonomy       = "Cisco Operations Data"
+      EnvironmentName    = "NonProd"
+      ResourceOwner      = "ETI SRE"
+    }
+  }
+}
+
+provider "vault" {
+  alias     = "eticloud"
+  address   = "https://keeper.cisco.com"
+  namespace = "eticloud"
+}
+
+provider "vault" {
+  alias     = "dragonfly"
+  address   = "https://keeper.cisco.com"
+  namespace = "eticloud/apps/dragonfly"
+}

--- a/aws_dragonfly-staging_eu-west-1_os_dragonfly-staging-1-os_securitygroups.tf
+++ b/aws_dragonfly-staging_eu-west-1_os_dragonfly-staging-1-os_securitygroups.tf
@@ -1,0 +1,43 @@
+locals {
+  msk_ingress_rules = [
+    {
+      from_port : 443,
+      to_port : 443,
+      protocol : "tcp",
+      cidr_blocks : [
+        data.aws_vpc.compute_vpc.cidr_block,
+      ],
+    },
+  ]
+
+  msk_egress_rules = []
+}
+
+
+resource "aws_security_group" "dragonfly_staging_1_os" {
+  name        = "${var.domain_name}-default"
+  description = "${var.domain_name} opensearch cluster default security group"
+  vpc_id      = data.aws_vpc.database_vpc.id
+
+  dynamic "ingress" {
+    for_each = toset(local.msk_ingress_rules)
+
+    content {
+      from_port   = ingress.value.from_port
+      to_port     = ingress.value.to_port
+      protocol    = ingress.value.protocol
+      cidr_blocks = ingress.value.cidr_blocks
+    }
+  }
+
+  dynamic "egress" {
+    for_each = toset(local.msk_egress_rules)
+
+    content {
+      from_port   = egress.value.from_port
+      to_port     = egress.value.to_port
+      protocol    = egress.value.protocol
+      cidr_blocks = egress.value.cidr_blocks
+    }
+  }
+}

--- a/aws_dragonfly-staging_eu-west-1_os_dragonfly-staging-1-os_variables.tf
+++ b/aws_dragonfly-staging_eu-west-1_os_dragonfly-staging-1-os_variables.tf
@@ -1,0 +1,68 @@
+variable "cisco_cidrs" {
+  description = "Cisco network CIDRs"
+  default = [
+    "52.177.206.0/24",
+    "216.151.141.0/24",
+    "171.68.0.0/14",
+    "66.163.32.0/20",
+    "40.79.24.0/24",
+    "13.68.72.0/24",
+    "40.79.68.0/24",
+    "64.103.0.0/16",
+    "128.107.0.0/16",
+    "20.186.6.0/24",
+    "104.208.221.0/24",
+    "52.254.19.0/24",
+    "13.68.74.0/24",
+    "52.254.51.0/24",
+    "192.168.24.0/24",
+    "171.38.209.0/24",
+    "207.182.160.0/19",
+    "64.102.0.0/16",
+    "66.114.160.0/20",
+    "20.186.37.0/24",
+    "40.79.62.0/24",
+    "52.251.62.0/24",
+    "52.232.186.0/24",
+    "161.44.0.0/16",
+    "52.254.17.0/24",
+    "104.209.145.0/24",
+    "209.197.192.0/21",
+    "40.84.4.0/24",
+    "172.27.27.128/26",
+    "52.179.217.112/28",
+    "40.79.70.0/24",
+    "52.254.77.0/24",
+    "192.168.5.0/24",
+    "3.21.137.64/26",
+    "192.168.110.0/23",
+    "173.36.0.0/14",
+    "72.163.220.0/22",
+    "172.18.136.0/21"
+  ]
+}
+
+variable "domain_name" {
+  description = "Domain name for the Amazon OpenSearch Service domain"
+  default     = "dragonfly-staging-1-os"
+}
+
+variable "engine_version" {
+  description = "Engine version for the Amazon OpenSearch Service domain"
+  default     = "OpenSearch_2.11"
+}
+
+variable "instance_type" {
+  description = "Instance type to use for the Amazon OpenSearch Service domain"
+  default     = "r6g.large.search"
+}
+
+variable "os_master_user" {
+  description = "Username for the master user of the Amazon OpenSearch Service domain"
+  default     = "dragonfly-admin"
+}
+
+variable "warm_instance_type" {
+  description = "Warm instance type to use for the Amazon OpenSearch Service domain"
+  default     = "ultrawarm1.medium.search"
+}

--- a/aws_dragonfly-staging_eu-west-1_os_dragonfly-staging-1-os_versions.tf
+++ b/aws_dragonfly-staging_eu-west-1_os_dragonfly-staging-1-os_versions.tf
@@ -1,0 +1,18 @@
+terraform {
+  required_version = ">= 1.3.6"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+    vault = {
+      source  = "hashicorp/vault"
+      version = "~> 3.0"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = "~> 3.0"
+    }
+  }
+}

--- a/aws_dragonfly-staging_eu-west-1_os_dragonfly-staging-1-osis_backend.tf
+++ b/aws_dragonfly-staging_eu-west-1_os_dragonfly-staging-1-osis_backend.tf
@@ -1,0 +1,7 @@
+terraform {
+  backend "s3" {
+    bucket = "eticloud-tf-state-nonprod"
+    key    = "terraform-state/aws-dragonfly-staging/os/eu-west-1/dragonfly-staging-1-osis.tfstate"
+    region = "us-east-2"
+  }
+}

--- a/aws_dragonfly-staging_eu-west-1_os_dragonfly-staging-1-osis_dependencies.tf
+++ b/aws_dragonfly-staging_eu-west-1_os_dragonfly-staging-1-osis_dependencies.tf
@@ -1,0 +1,85 @@
+# AWS credentials
+data "vault_generic_secret" "aws_infra_credential" {
+  path     = "secret/infra/aws/dragonfly-staging/terraform_admin"
+  provider = vault.eticloud
+}
+
+# OS account and region
+data "aws_caller_identity" "current" {} # data.aws_caller_identity.current.account_id
+data "aws_region" "current" {}          # data.aws_region.current.name
+
+# OS domain
+data "aws_opensearch_domain" "dragonfly_staging_1_os" {
+  domain_name = var.domain_name
+}
+
+# MSK cluster
+data "aws_msk_cluster" "dragonfly_msk_1" {
+  cluster_name = var.msk_cluster_name
+}
+
+data "aws_iam_policy_document" "pipeline_opensearch" {
+  statement {
+    effect  = "Allow"
+    actions = ["es:DescribeDomain"]
+    resources = [
+      data.aws_opensearch_domain.dragonfly_staging_1_os.arn,
+    ]
+  }
+
+  statement {
+    effect = "Allow"
+    actions = [
+      "es:ESHttp*",
+    ]
+    resources = [
+      "${data.aws_opensearch_domain.dragonfly_staging_1_os.arn}/*",
+    ]
+  }
+}
+
+data "aws_iam_policy_document" "pipeline_kafka" {
+  statement {
+    effect  = "Allow"
+    actions = ["es:DescribeDomain"]
+    resources = [
+      data.aws_opensearch_domain.dragonfly_staging_1_os.arn,
+    ]
+  }
+
+  statement {
+    effect = "Allow"
+    actions = [
+      "kafka-cluster:Connect",
+      "kafka-cluster:AlterCluster",
+      "kafka-cluster:DescribeCluster",
+      "kafka:DescribeClusterV2",
+      "kafka:GetBootstrapBrokers",
+    ]
+    resources = [
+      data.aws_msk_cluster.dragonfly_msk_1.arn,
+    ]
+  }
+
+  statement {
+    effect = "Allow"
+    actions = [
+      "kafka-cluster:*Topic*",
+      "kafka-cluster:ReadData",
+    ]
+    resources = [
+      "arn:aws:kafka:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:topic/${var.msk_cluster_name}/*",
+    ]
+  }
+
+  statement {
+    effect = "Allow"
+    actions = [
+      "kafka-cluster:AlterGroup",
+      "kafka-cluster:DescribeGroup"
+    ]
+    resources = [
+      "arn:aws:kafka:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:group/${var.msk_cluster_name}/*",
+    ]
+  }
+}

--- a/aws_dragonfly-staging_eu-west-1_os_dragonfly-staging-1-osis_iam.tf
+++ b/aws_dragonfly-staging_eu-west-1_os_dragonfly-staging-1-osis_iam.tf
@@ -1,0 +1,49 @@
+module "pipeline_role" {
+  source  = "terraform-aws-modules/iam/aws//modules/iam-assumable-role"
+  version = "~> 5.0"
+
+  create_role = true
+
+  role_name        = "${var.domain_name}-pipeline-role"
+  role_description = "IAM Role to be assumed by Opensearch ingestion pipeline"
+
+  trusted_role_services = [
+    "osis-pipelines.amazonaws.com",
+  ]
+
+  role_requires_mfa       = false
+  custom_role_policy_arns = [
+    module.pipeline_opensearch_policy.arn,
+    module.pipeline_kafka_policy.arn,
+  ]
+
+  tags = var.tags
+}
+
+module "pipeline_opensearch_policy" {
+  source  = "terraform-aws-modules/iam/aws//modules/iam-policy"
+  version = "~> 5.0"
+
+  create_policy = true
+
+  name        = "${var.domain_name}-ingestion-policy"
+  path        = "/"
+  description = "IAM Policy for Opensearch ingestion"
+  policy      = data.aws_iam_policy_document.pipeline_opensearch.json
+
+  tags = var.tags
+}
+
+module "pipeline_kafka_policy" {
+  source  = "terraform-aws-modules/iam/aws//modules/iam-policy"
+  version = "~> 5.0"
+
+  create_policy = true
+
+  name        = "${var.domain_name}-kafka-consumer-policy"
+  path        = "/"
+  description = "IAM Policy for Kafka consumer"
+  policy      = data.aws_iam_policy_document.pipeline_kafka.json
+
+  tags = var.tags
+}

--- a/aws_dragonfly-staging_eu-west-1_os_dragonfly-staging-1-osis_main.tf
+++ b/aws_dragonfly-staging_eu-west-1_os_dragonfly-staging-1-osis_main.tf
@@ -1,0 +1,60 @@
+locals {
+  pipelines = {
+    "dragonfly-osis-pipeline-1" = {
+      topics = [
+        "monitoring",
+      ],
+      min_units              = 1,
+      max_units              = 4,
+      pipeline_template_file = "./pipeline-monitoring.yaml",
+    },
+    "dragonfly-osis-pipeline-2" = {
+      topics = [
+        "threat",
+        "attack",
+      ]
+      min_units              = 1,
+      max_units              = 4,
+      pipeline_template_file = "./pipeline-threats-attacks.yaml",
+    },
+    "dragonfly-osis-pipeline-3" = {
+      topics = [
+        "falco",
+      ]
+      min_units              = 1,
+      max_units              = 4,
+      pipeline_template_file = "./pipeline-sa.yaml",
+    },
+  }
+}
+
+resource "awscc_osis_pipeline" "ingestion_pipeline" {
+  for_each = local.pipelines
+
+  pipeline_name = each.key
+  pipeline_configuration_body = templatefile(
+    each.value.pipeline_template_file, {
+    region          = data.aws_region.current.name
+    sts_role_arn    = module.pipeline_role.iam_role_arn
+    opensearch_host = data.aws_opensearch_domain.dragonfly_staging_1_os.endpoint
+
+    msk_cluster_arn = data.aws_msk_cluster.dragonfly_msk_1.arn
+    kafka_topics    = each.value.topics
+  })
+
+  min_units = each.value.min_units
+  max_units = each.value.max_units
+
+  log_publishing_options = {
+    is_logging_enabled = true
+    cloudwatch_log_destination = {
+      log_group = aws_cloudwatch_log_group.dragonfly_staging_1_osis_logs[each.key].name
+    }
+  }
+}
+
+resource "aws_cloudwatch_log_group" "dragonfly_staging_1_osis_logs" {
+  for_each = local.pipelines
+
+  name = "/aws/vendedlogs/OpenSearchIngestion/${each.key}/audit-logs"
+}

--- a/aws_dragonfly-staging_eu-west-1_os_dragonfly-staging-1-osis_outputs.tf
+++ b/aws_dragonfly-staging_eu-west-1_os_dragonfly-staging-1-osis_outputs.tf
@@ -1,0 +1,3 @@
+output "opensearch_pipeline_role" {
+  value = module.pipeline_role.iam_role_arn
+}

--- a/aws_dragonfly-staging_eu-west-1_os_dragonfly-staging-1-osis_providers.tf
+++ b/aws_dragonfly-staging_eu-west-1_os_dragonfly-staging-1-osis_providers.tf
@@ -1,0 +1,35 @@
+provider "aws" {
+  access_key = data.vault_generic_secret.aws_infra_credential.data["AWS_ACCESS_KEY_ID"]
+  secret_key = data.vault_generic_secret.aws_infra_credential.data["AWS_SECRET_ACCESS_KEY"]
+  region     = "eu-west-1"
+
+  default_tags {
+    tags = {
+      ApplicationName    = "osis-dragonfly-staging-1"
+      CiscoMailAlias     = "eti-sre-admins@cisco.com"
+      DataClassification = "Cisco Confidential"
+      DataTaxonomy       = "Cisco Operations Data"
+      Environment        = "NonProd"
+      ResourceOwner      = "ETI SRE"
+    }
+  }
+}
+
+provider "awscc" {
+  access_key = data.vault_generic_secret.aws_infra_credential.data["AWS_ACCESS_KEY_ID"]
+  secret_key = data.vault_generic_secret.aws_infra_credential.data["AWS_SECRET_ACCESS_KEY"]
+  region     = "eu-west-1"
+}
+
+provider "vault" {
+  alias     = "eticloud"
+  address   = "https://keeper.cisco.com"
+  namespace = "eticloud"
+}
+
+provider "vault" {
+  alias     = "dragonfly"
+  address   = "https://keeper.cisco.com"
+  namespace = "eticloud/apps/dragonfly"
+}
+

--- a/aws_dragonfly-staging_eu-west-1_os_dragonfly-staging-1-osis_variables.tf
+++ b/aws_dragonfly-staging_eu-west-1_os_dragonfly-staging-1-osis_variables.tf
@@ -1,0 +1,24 @@
+variable "domain_name" {
+  description = "The name of the domain"
+  type        = string
+  default     = "dragonfly-staging-1-os"
+}
+
+variable "msk_cluster_name" {
+  description = "The name of the MSK cluster"
+  type        = string
+  default     = "dragonfly-staging-msk-1"
+}
+
+variable "tags" {
+  description = "Tags to apply to all resources"
+  type        = map(string)
+  default = {
+    ApplicationName    = "osis-dragonfly-staging-1"
+    CiscoMailAlias     = "eti-sre-admins@cisco.com"
+    DataClassification = "Cisco Confidential"
+    DataTaxonomy       = "Cisco Operations Data"
+    Environment        = "NonProd"
+    ResourceOwner      = "ETI SRE"
+  }
+}

--- a/aws_dragonfly-staging_eu-west-1_os_dragonfly-staging-1-osis_versions.tf
+++ b/aws_dragonfly-staging_eu-west-1_os_dragonfly-staging-1-osis_versions.tf
@@ -1,0 +1,19 @@
+terraform {
+  required_version = ">= 1.4"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 4.38"
+    }
+    awscc = {
+      source  = "hashicorp/awscc"
+      version = ">= 0.65.0"
+    }
+    vault = {
+      source  = "hashicorp/vault"
+      version = "~> 3.0"
+    }
+  }
+}
+

--- a/aws_dragonfly-staging_eu-west-1_rds_dragonfly-staging-rds-1_aurora-postgres.tf
+++ b/aws_dragonfly-staging_eu-west-1_rds_dragonfly-staging-rds-1_aurora-postgres.tf
@@ -1,0 +1,13 @@
+module "rds" {
+  source            = "git::https://github.com/cisco-eti/sre-tf-module-aws-aurora-postgres?ref=1.0.7"
+  vpc_name          = "dragonfly-data-staging-1-vpc"
+  database_name     = "dragonflywheel"
+  db_instance_type  = "db.r5.xlarge"
+  db_engine_version = "13.12"
+  secret_path       = "secret/eticcprod/infra/aurora-pg/eu-west-1/rds-dragonfly-staging-1"
+  cluster_name      = "rds-dragonfly-staging-1"
+  db_allowed_cidrs = [
+    data.aws_vpc.msk_vpc.cidr_block,
+    data.aws_vpc.eks_vpc.cidr_block,
+  ]
+}

--- a/aws_dragonfly-staging_eu-west-1_rds_dragonfly-staging-rds-1_backend.tf
+++ b/aws_dragonfly-staging_eu-west-1_rds_dragonfly-staging-rds-1_backend.tf
@@ -1,0 +1,7 @@
+terraform {
+  backend "s3" {
+    bucket = "eticloud-tf-state-nonprod"
+    key    = "terraform-state/aws-dragonfly-staging/aurora-postgres/eu-west-1/rds-dragonfly-staging-1.tfstate"
+    region = "us-east-2"
+  }
+}

--- a/aws_dragonfly-staging_eu-west-1_rds_dragonfly-staging-rds-1_dependencies.tf
+++ b/aws_dragonfly-staging_eu-west-1_rds_dragonfly-staging-rds-1_dependencies.tf
@@ -1,0 +1,38 @@
+data "vault_generic_secret" "aws_infra_credential" {
+  path     = "secret/infra/aws/dragonfly-staging/terraform_admin"
+  provider = vault.eticloud
+}
+
+data "aws_vpc" "eks_vpc" {
+  filter {
+    name   = "tag:Name"
+    values = ["dragonfly-compute-staging-1-vpc"]
+  }
+}
+
+data "aws_vpc" "msk_vpc" {
+  filter {
+    name   = "tag:Name"
+    values = ["dragonfly-data-staging-1-vpc"]
+  }
+}
+
+data "aws_subnets" "eks_subnets" {
+  filter {
+    name   = "vpc-id"
+    values = [data.aws_vpc.eks_vpc.id]
+  }
+  tags = {
+    Tier = "Private"
+  }
+}
+
+data "aws_subnets" "msk_subnets" {
+  filter {
+    name   = "vpc-id"
+    values = [data.aws_vpc.msk_vpc.id]
+  }
+  tags = {
+    Tier = "Private"
+  }
+}

--- a/aws_dragonfly-staging_eu-west-1_rds_dragonfly-staging-rds-1_providers.tf
+++ b/aws_dragonfly-staging_eu-west-1_rds_dragonfly-staging-rds-1_providers.tf
@@ -1,0 +1,22 @@
+provider "vault" {
+  alias     = "eticloud"
+  address   = "https://keeper.cisco.com"
+  namespace = "eticloud"
+}
+
+provider "aws" {
+  access_key  = data.vault_generic_secret.aws_infra_credential.data["AWS_ACCESS_KEY_ID"]
+  secret_key  = data.vault_generic_secret.aws_infra_credential.data["AWS_SECRET_ACCESS_KEY"]
+  region      = "eu-west-1"
+  max_retries = 3
+  default_tags {
+    tags = {
+      ApplicationName    = "rds-dragonfly-staging-1"
+      CiscoMailAlias     = "eti-sre-admins@cisco.com"
+      DataClassification = "Cisco Confidential"
+      DataTaxonomy       = "Cisco Operations Data"
+      Environment        = "NonProd"
+      ResourceOwner      = "ETI SRE"
+    }
+  }
+}

--- a/aws_dragonfly-staging_eu-west-1_rds_dragonfly-staging-rds-1_versions.tf
+++ b/aws_dragonfly-staging_eu-west-1_rds_dragonfly-staging-rds-1_versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.3.6"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 4.0"
+    }
+  }
+}

--- a/aws_dragonfly-staging_eu-west-1_redis_dragonfly-staging-redis-euw1-1_main.tf
+++ b/aws_dragonfly-staging_eu-west-1_redis_dragonfly-staging-redis-euw1-1_main.tf
@@ -1,0 +1,99 @@
+terraform {
+  backend "s3" {
+    # This is the name of the backend S3 bucket.
+    bucket = "eticloud-tf-state-nonprod"
+    # This is the path to the Terraform state file in the backend S3 bucket.
+    key = "terraform-state/aws/aws-dragonfly-staging-1/eu-west-1/redis/dragonfly-staging-redis-euw1-1.tfstate"
+    # This is the region where the backend S3 bucket is located.
+    region = "us-east-2" # DO NOT CHANGE.
+  }
+}
+
+locals {
+  name              = "dragonfly-staging-euw1-1"
+  eks_vpc_name      = "dragonfly-compute-staging-1-vpc"
+  data_vpc_name     = "dragonfly-data-staging-1-vpc"
+  region            = "eu-west-1"
+  aws_account_name  = "dragonfly-staging"
+  node_type         = "cache.t2.small"
+  subnet_group_name = "dragonfly-staging-data-sg-euw1-1"
+}
+
+provider "vault" {
+  alias     = "eticloud"
+  address   = "https://keeper.cisco.com"
+  namespace = "eticloud"
+}
+
+data "vault_generic_secret" "aws_infra_credential" {
+  provider = vault.eticloud
+  path     = "secret/infra/aws/${local.aws_account_name}/terraform_admin"
+}
+
+provider "aws" {
+  access_key = data.vault_generic_secret.aws_infra_credential.data["AWS_ACCESS_KEY_ID"]
+  secret_key = data.vault_generic_secret.aws_infra_credential.data["AWS_SECRET_ACCESS_KEY"]
+  region     = local.region
+}
+
+data "aws_vpc" "cluster_vpc" {
+  filter {
+    name   = "tag:Name"
+    values = [local.eks_vpc_name]
+  }
+}
+
+data "aws_vpc" "redis_vpc" {
+  filter {
+    name   = "tag:Name"
+    values = [local.data_vpc_name]
+  }
+}
+
+data "aws_subnets" "redis_subnets" {
+  filter {
+    name   = "vpc-id"
+    values = [data.aws_vpc.redis_vpc.id]
+  }
+  tags = {
+    Name = "*private*"
+  }
+}
+
+# Create a subnet group for the Elasticache service
+resource "aws_elasticache_subnet_group" "redis_subnet_group" {
+  name       = local.subnet_group_name
+  subnet_ids = data.aws_subnets.redis_subnets.ids
+}
+
+# Create a security group for the Elasticache service
+resource "aws_security_group" "redis_security_group" {
+  name   = local.subnet_group_name
+  vpc_id = data.aws_vpc.redis_vpc.id
+  ingress {
+    from_port   = 6379
+    to_port     = 6379
+    protocol    = "tcp"
+    cidr_blocks = [data.aws_vpc.cluster_vpc.cidr_block]
+  }
+}
+
+resource "aws_elasticache_replication_group" "dragonfly-dev-euw1-1" {
+  replication_group_id = local.name
+  description          = "Redis cluster ElastiCache"
+  engine               = "redis"
+  engine_version       = "7.1"
+
+  node_type                  = local.node_type
+  port                       = 6379
+  parameter_group_name       = "default.redis7.cluster.on"
+  automatic_failover_enabled = true
+  at_rest_encryption_enabled = true
+  transit_encryption_enabled = true
+
+  num_node_groups         = 1
+  replicas_per_node_group = 1
+
+  subnet_group_name  = local.subnet_group_name
+  security_group_ids = [aws_security_group.redis_security_group.id]
+}

--- a/aws_dragonfly-staging_eu-west-1_vpc-peering_dragonfly-staging-compute-to-data-peering-1_vpc-peering.tf
+++ b/aws_dragonfly-staging_eu-west-1_vpc-peering_dragonfly-staging-compute-to-data-peering-1_vpc-peering.tf
@@ -1,0 +1,126 @@
+terraform {
+  backend "s3" {
+    bucket = "eticloud-tf-state-nonprod"
+    key    = "terraform-state/aws-dragonfly-staging/vpc-peering/eu-west-1/dragonfly-staging-compute-1-to-data-1-vpc-peering-1/vpc-peering.tfstate"
+    region = "us-east-2"
+  }
+}
+
+provider "vault" {
+  alias     = "eticloud"
+  address   = "https://keeper.cisco.com"
+  namespace = "eticloud"
+}
+
+data "vault_generic_secret" "aws_infra_credential" {
+  path     = "secret/infra/aws/dragonfly-staging/terraform_admins"
+  provider = vault.eticloud
+}
+
+# Get the VPC IDs based on the names of the VPCs
+data "aws_vpc" "requestor_vpc" {
+  filter {
+    name   = "tag:ApplicationName"
+    values = ["dragonfly-compute-staging-1-vpc"]
+  }
+}
+
+data "aws_vpc" "acceptor_vpc" {
+  filter {
+    name   = "tag:ApplicationName"
+    values = ["dragonfly-data-staging-1-vpc"]
+  }
+}
+
+data "aws_route_tables" "requestor_vpc_rt" {
+  vpc_id = data.aws_vpc.requestor_vpc.id
+}
+
+data "aws_route_tables" "acceptor_vpc_rt" {
+  vpc_id = data.aws_vpc.acceptor_vpc.id
+}
+
+# Use this to get the account ID
+data "aws_caller_identity" "current" {}
+
+
+# By setting the AWS provider credentials via the data source above, we control in which account and region the resources get created.
+provider "aws" {
+  access_key  = data.vault_generic_secret.aws_infra_credential.data["AWS_ACCESS_KEY_ID"]
+  secret_key  = data.vault_generic_secret.aws_infra_credential.data["AWS_SECRET_ACCESS_KEY"]
+  region      = "eu-west-1"
+  max_retries = 3
+}
+
+# VPC peering resources
+resource "aws_vpc_peering_connection" "data_to_compute" {
+  peer_owner_id = data.aws_caller_identity.current.account_id
+  peer_vpc_id   = data.aws_vpc.acceptor_vpc.id
+  vpc_id        = data.aws_vpc.requestor_vpc.id
+  auto_accept   = true
+
+  accepter {
+    allow_remote_vpc_dns_resolution = true
+  }
+
+  requester {
+    allow_remote_vpc_dns_resolution = true
+  }
+
+  tags = {
+    Name               = "VPC Peering between dragonfly-staging-compute-vpc-1 and dragonfly-staging-data-vpc-1"
+    ApplicationName    = "nonprod-dragonfly-staging-compute-data-peering"
+    CiscoMailAlias     = "eti-sre@cisco.com"
+    DataClassification = "Cisco Confidential"
+    DataTaxonomy       = "Cisco Operations Data"
+    Environment        = "NonProd"
+    ResourceOwner      = "ETI SRE"
+  }
+}
+
+# VPC routing resources
+resource "aws_route" "compute_to_data" {
+  count                     = length(data.aws_route_tables.requestor_vpc_rt.ids)
+  route_table_id            = data.aws_route_tables.requestor_vpc_rt.ids[count.index]
+  destination_cidr_block    = data.aws_vpc.acceptor_vpc.cidr_block
+  vpc_peering_connection_id = aws_vpc_peering_connection.data_to_compute.id
+}
+
+resource "aws_route" "data_to_compute" {
+  count                     = length(data.aws_route_tables.acceptor_vpc_rt.ids)
+  route_table_id            = data.aws_route_tables.acceptor_vpc_rt.ids[count.index]
+  destination_cidr_block    = data.aws_vpc.requestor_vpc.cidr_block
+  vpc_peering_connection_id = aws_vpc_peering_connection.data_to_compute.id
+}
+
+# Security groups
+resource "aws_security_group" "compute_to_data" {
+  name        = "compute-vpc-1-to-data-vpc-1"
+  description = "Allows all communication into data-vpc-1 from the compute-vpc-1"
+  vpc_id      = data.aws_vpc.acceptor_vpc.id
+}
+
+resource "aws_security_group" "data_to_compute" {
+  name        = "data-vpc-1-to-compute-vpc-1"
+  description = "Allows all communication into compute-vpc-1 from the data-vpc-1"
+  vpc_id      = data.aws_vpc.requestor_vpc.id
+}
+
+# security group rules because the rules are going to reference the groups
+resource "aws_security_group_rule" "compute_to_data" {
+  type                     = "ingress"
+  from_port                = 0
+  to_port                  = 65535
+  protocol                 = "-1"
+  security_group_id        = aws_security_group.compute_to_data.id
+  source_security_group_id = aws_security_group.data_to_compute.id
+}
+
+resource "aws_security_group_rule" "data_to_compute" {
+  type                     = "ingress"
+  from_port                = 0
+  to_port                  = 65535
+  protocol                 = "-1"
+  security_group_id        = aws_security_group.data_to_compute.id
+  source_security_group_id = aws_security_group.compute_to_data.id
+}

--- a/aws_dragonfly-staging_eu-west-1_vpc-peering_dragonfly-staging-compute-to-data-peering-1_vpc-peering.tf
+++ b/aws_dragonfly-staging_eu-west-1_vpc-peering_dragonfly-staging-compute-to-data-peering-1_vpc-peering.tf
@@ -13,7 +13,7 @@ provider "vault" {
 }
 
 data "vault_generic_secret" "aws_infra_credential" {
-  path     = "secret/infra/aws/dragonfly-staging/terraform_admins"
+  path     = "secret/infra/aws/dragonfly-staging/terraform_admin"
   provider = vault.eticloud
 }
 

--- a/aws_dragonfly-staging_eu-west-1_vpc_dragonfly-staging-compute-vpc-1_vpc.tf
+++ b/aws_dragonfly-staging_eu-west-1_vpc_dragonfly-staging-compute-vpc-1_vpc.tf
@@ -38,7 +38,7 @@ module "vpc" {
   source                          = "git::https://github.com/cisco-eti/sre-tf-module-aws-vpc?ref=2.0.6"
   region                          = "eu-west-1"
   vpc_cidr                        = "10.10.0.0/16"
-  vpc_name                        = "dragonfly-compute-staging-1-vpc"
+  vpc_name                        = "dragonfly-compute-staging-1"
   cluster_name                    = "eks-df-staging-1"
   create_database_subnet_group    = false
   create_elasticache_subnet_group = false

--- a/aws_dragonfly-staging_eu-west-1_vpc_dragonfly-staging-compute-vpc-1_vpc.tf
+++ b/aws_dragonfly-staging_eu-west-1_vpc_dragonfly-staging-compute-vpc-1_vpc.tf
@@ -35,7 +35,7 @@ data "vault_generic_secret" "aws_infra_credential" {
 }
 
 module "vpc" {
-  source                          = "git::https://github.cisco.com/cisco-eti/sre-tf-module-aws-vpc?ref=2.0.4"
+  source                          = "git::https://github.com/cisco-eti/sre-tf-module-aws-vpc?ref=2.0.4"
   region                          = "eu-west-1"
   vpc_cidr                        = "10.10.0.0/16"
   vpc_name                        = "dragonfly-compute-staging-1"

--- a/aws_dragonfly-staging_eu-west-1_vpc_dragonfly-staging-compute-vpc-1_vpc.tf
+++ b/aws_dragonfly-staging_eu-west-1_vpc_dragonfly-staging-compute-vpc-1_vpc.tf
@@ -38,7 +38,7 @@ module "vpc" {
   source                          = "git::https://github.com/cisco-eti/sre-tf-module-aws-vpc?ref=2.0.6"
   region                          = "eu-west-1"
   vpc_cidr                        = "10.10.0.0/16"
-  vpc_name                        = "dragonfly-compute-staging-1"
+  vpc_name                        = "dragonfly-compute-staging-1-vpc"
   cluster_name                    = "eks-df-staging-1"
   create_database_subnet_group    = false
   create_elasticache_subnet_group = false

--- a/aws_dragonfly-staging_eu-west-1_vpc_dragonfly-staging-compute-vpc-1_vpc.tf
+++ b/aws_dragonfly-staging_eu-west-1_vpc_dragonfly-staging-compute-vpc-1_vpc.tf
@@ -1,0 +1,45 @@
+terraform {
+  backend "s3" {
+    bucket = "eticloud-tf-state-nonprod"
+    key    = "terraform-state/aws-dragonfly-staging/vpc/eu-west-1/dragonfly-staging-compute-vpc-1.tfstate"
+    region = "us-east-2"
+  }
+}
+
+provider "aws" {
+  access_key  = data.vault_generic_secret.aws_infra_credential.data["AWS_ACCESS_KEY_ID"]
+  secret_key  = data.vault_generic_secret.aws_infra_credential.data["AWS_SECRET_ACCESS_KEY"]
+  region      = "eu-west-1"
+  max_retries = 3
+  default_tags {
+    tags = {
+      ApplicationName    = "dragonfly-compute-staging-1-vpc"
+      CiscoMailAlias     = "eti-sre-admins@cisco.com"
+      DataClassification = "Cisco Confidential"
+      DataTaxonomy       = "Cisco Operations Data"
+      Environment        = "NonProd"
+      ResourceOwner      = "ETI SRE"
+    }
+  }
+}
+
+provider "vault" {
+  alias     = "eticloud"
+  address   = "https://keeper.cisco.com"
+  namespace = "eticloud"
+}
+
+data "vault_generic_secret" "aws_infra_credential" {
+  path     = "secret/infra/aws/dragonfly-staging/terraform_admin"
+  provider = vault.eticloud
+}
+
+module "vpc" {
+  source                          = "git::https://github.cisco.com/cisco-eti/sre-tf-module-aws-vpc?ref=2.0.4"
+  region                          = "eu-west-1"
+  vpc_cidr                        = "10.10.0.0/16"
+  vpc_name                        = "dragonfly-compute-staging-1"
+  cluster_name                    = "eks-df-staging-1"
+  create_database_subnet_group    = false
+  create_elasticache_subnet_group = false
+}

--- a/aws_dragonfly-staging_eu-west-1_vpc_dragonfly-staging-compute-vpc-1_vpc.tf
+++ b/aws_dragonfly-staging_eu-west-1_vpc_dragonfly-staging-compute-vpc-1_vpc.tf
@@ -35,7 +35,7 @@ data "vault_generic_secret" "aws_infra_credential" {
 }
 
 module "vpc" {
-  source                          = "git::https://github.com/cisco-eti/sre-tf-module-aws-vpc?ref=2.0.4"
+  source                          = "git::https://github.com/cisco-eti/sre-tf-module-aws-vpc?ref=2.0.6"
   region                          = "eu-west-1"
   vpc_cidr                        = "10.10.0.0/16"
   vpc_name                        = "dragonfly-compute-staging-1"

--- a/aws_dragonfly-staging_eu-west-1_vpc_dragonfly-staging-data-vpc-1_vpc.tf
+++ b/aws_dragonfly-staging_eu-west-1_vpc_dragonfly-staging-data-vpc-1_vpc.tf
@@ -38,7 +38,7 @@ module "vpc" {
   source                          = "git::https://github.com/cisco-eti/sre-tf-module-aws-vpc?ref=2.0.6"
   region                          = "eu-west-1"
   vpc_cidr                        = "10.11.0.0/16"
-  vpc_name                        = "dragonfly-data-staging-1-vpc"
+  vpc_name                        = "dragonfly-data-staging-1"
   cluster_name                    = "eks-df-staging-1"
   create_database_subnet_group    = true
   create_elasticache_subnet_group = false

--- a/aws_dragonfly-staging_eu-west-1_vpc_dragonfly-staging-data-vpc-1_vpc.tf
+++ b/aws_dragonfly-staging_eu-west-1_vpc_dragonfly-staging-data-vpc-1_vpc.tf
@@ -35,7 +35,7 @@ data "vault_generic_secret" "aws_infra_credential" {
 }
 
 module "vpc" {
-  source                          = "git::https://github.cisco.com/cisco-eti/sre-tf-module-aws-vpc?ref=2.0.4"
+  source                          = "git::https://github.com/cisco-eti/sre-tf-module-aws-vpc?ref=2.0.4"
   region                          = "eu-west-1"
   vpc_cidr                        = "10.11.0.0/16"
   vpc_name                        = "dragonfly-data-staging-1"

--- a/aws_dragonfly-staging_eu-west-1_vpc_dragonfly-staging-data-vpc-1_vpc.tf
+++ b/aws_dragonfly-staging_eu-west-1_vpc_dragonfly-staging-data-vpc-1_vpc.tf
@@ -1,0 +1,45 @@
+terraform {
+  backend "s3" {
+    bucket = "eticloud-tf-state-nonprod"
+    key    = "terraform-state/aws-dragonfly-staging/vpc/eu-west-1/dragonfly-staging-data-vpc-1.tfstate"
+    region = "us-east-2"
+  }
+}
+
+provider "aws" {
+  access_key  = data.vault_generic_secret.aws_infra_credential.data["AWS_ACCESS_KEY_ID"]
+  secret_key  = data.vault_generic_secret.aws_infra_credential.data["AWS_SECRET_ACCESS_KEY"]
+  region      = "eu-west-1"
+  max_retries = 3
+  default_tags {
+    tags = {
+      ApplicationName    = "dragonfly-data-staging-1-vpc"
+      CiscoMailAlias     = "eti-sre-admins@cisco.com"
+      DataClassification = "Cisco Confidential"
+      DataTaxonomy       = "Cisco Operations Data"
+      Environment        = "NonProd"
+      ResourceOwner      = "ETI SRE"
+    }
+  }
+}
+
+provider "vault" {
+  alias     = "eticloud"
+  address   = "https://keeper.cisco.com"
+  namespace = "eticloud"
+}
+
+data "vault_generic_secret" "aws_infra_credential" {
+  path     = "secret/infra/aws/dragonfly-staging/terraform_admin"
+  provider = vault.eticloud
+}
+
+module "vpc" {
+  source                          = "git::https://github.cisco.com/cisco-eti/sre-tf-module-aws-vpc?ref=2.0.4"
+  region                          = "eu-west-1"
+  vpc_cidr                        = "10.11.0.0/16"
+  vpc_name                        = "dragonfly-data-staging-1"
+  cluster_name                    = "eks-df-staging-1"
+  create_database_subnet_group    = true
+  create_elasticache_subnet_group = false
+}

--- a/aws_dragonfly-staging_eu-west-1_vpc_dragonfly-staging-data-vpc-1_vpc.tf
+++ b/aws_dragonfly-staging_eu-west-1_vpc_dragonfly-staging-data-vpc-1_vpc.tf
@@ -35,7 +35,7 @@ data "vault_generic_secret" "aws_infra_credential" {
 }
 
 module "vpc" {
-  source                          = "git::https://github.com/cisco-eti/sre-tf-module-aws-vpc?ref=2.0.4"
+  source                          = "git::https://github.com/cisco-eti/sre-tf-module-aws-vpc?ref=2.0.6"
   region                          = "eu-west-1"
   vpc_cidr                        = "10.11.0.0/16"
   vpc_name                        = "dragonfly-data-staging-1"

--- a/aws_dragonfly-staging_eu-west-1_vpc_dragonfly-staging-data-vpc-1_vpc.tf
+++ b/aws_dragonfly-staging_eu-west-1_vpc_dragonfly-staging-data-vpc-1_vpc.tf
@@ -38,7 +38,7 @@ module "vpc" {
   source                          = "git::https://github.com/cisco-eti/sre-tf-module-aws-vpc?ref=2.0.6"
   region                          = "eu-west-1"
   vpc_cidr                        = "10.11.0.0/16"
-  vpc_name                        = "dragonfly-data-staging-1"
+  vpc_name                        = "dragonfly-data-staging-1-vpc"
   cluster_name                    = "eks-df-staging-1"
   create_database_subnet_group    = true
   create_elasticache_subnet_group = false


### PR DESCRIPTION
## Migration of VPCs from [sre-tf-infra](https://wwwin-github.cisco.com/eti/sre-tf-infra)

### Description/Justification

This PR is part of the effort of moving the tf configuration of aws managed infra from [sre-tf-infra](https://wwwin-github.cisco.com/eti/sre-tf-infra) to this repo.


### If the (atlantis) plan is destroying resources, reason for deletion  

No apply should be run as part of this PR.

### Additional details

- [x] `terraform fmt` was applied
- [ ] All atlantis plans can be applied
- [ ] (For reviewers) I have verified the resource changes
