### PR TITLE
feat(vpc-peering): add new peering with vowel-dev-1 EKS

### DIFF
--- a/aws_vowel-genai-dev_us-west-2_vpc_peering_compute-to-data_vpc-peering.tf
+++ b/aws_vowel-genai-dev_us-west-2_vpc_peering_compute-to-data_vpc-peering.tf
@@ -18,7 +18,7 @@ module "vpc_peering_us-east_2_eks_us_west_2_data" {
 module "vpc_peering_vowel_dev_1_eks_us_west_2_data" {
   source             = "git::https://github.com/cisco-eti/sre-tf-module-vpc-peering.git?ref=latest"
   aws_account_name   = "vowel-genai-dev"
-  accepter_vpc_name  = "vowel-dev-1-vpc"  # where the vowel-dev-1 EKS cluster lives
+  accepter_vpc_name  = "vowel-dev-1-vpc" # where the vowel-dev-1 EKS cluster lives
   requester_vpc_name = "motf-dev-usw2-data"
   accepter_region    = "us-east-2"
   requester_region   = "us-west-2"

--- a/aws_vowel-genai-dev_us-west-2_vpc_peering_compute-to-data_vpc-peering.tf
+++ b/aws_vowel-genai-dev_us-west-2_vpc_peering_compute-to-data_vpc-peering.tf
@@ -14,3 +14,12 @@ module "vpc_peering_us-east_2_eks_us_west_2_data" {
   accepter_region    = "us-east-2"
   requester_region   = "us-west-2"
 }
+
+module "vpc_peering_vowel_dev_1_eks_us_west_2_data" {
+  source             = "git::https://github.com/cisco-eti/sre-tf-module-vpc-peering.git?ref=latest"
+  aws_account_name   = "vowel-genai-dev"
+  accepter_vpc_name  = "vowel-dev-1-vpc"  # where the vowel-dev-1 EKS cluster lives
+  requester_vpc_name = "motf-dev-usw2-data"
+  accepter_region    = "us-east-2"
+  requester_region   = "us-west-2"
+}


### PR DESCRIPTION
## Fixes/Implements # (JIRA issue if applicable)  

RDS global disaster recovery testing with `vowel-dev-1` EKS cluster. A new secondary RDS cluster will be added in an existing VPC in `us-west-2` instead of creating a brand new VPC.

### Description/Justification

(Why is this change needed? Which team might need it? etc...)  

Today's DR test.

### If the (atlantis) plan is destroying resources, reason for deletion  

N/A

### Additional details

- [x] `terraform fmt` was applied
- [x] All atlantis plans can be applied
- [ ] (For reviewers) I have verified the resource changes
