### PR TITLE
chore(dragonfly-prod): reduce the number of opensearch nodes from 12 to 6

### DIFF
--- a/aws_dragonfly-prod_us-east-2_os_dragonfly-prod-1-os_main.tf
+++ b/aws_dragonfly-prod_us-east-2_os_dragonfly-prod-1-os_main.tf
@@ -13,7 +13,7 @@ resource "aws_opensearch_domain" "dragonfly_prod_1_os" {
     dedicated_master_count   = 3
     dedicated_master_type    = var.instance_type
 
-    instance_count = 12
+    instance_count = 6
     instance_type  = var.instance_type
 
     warm_enabled = true


### PR DESCRIPTION
## Reduce opensearch data nodes from 12 to 6

### Description/Justification

Opensearch cluster is currently over provisioned. We can reduce the number of nodes from 12 to 6.

### If the (atlantis) plan is destroying resources, reason for deletion  

We are resizing the opensearch clustere but we are not destroying resource.

### Additional details

- [x] `terraform fmt` was applied
- [x] All atlantis plans can be applied
- [ ] (For reviewers) I have verified the resource changes
