### PR TITLE
fix(rosey-logs): k8s serviceAccount was wrong again

### DIFF
--- a/aws_cnapp-prod_rosey-logs_iam.tf
+++ b/aws_cnapp-prod_rosey-logs_iam.tf
@@ -49,7 +49,7 @@ resource "aws_iam_role" "rosey_logs" {
         Condition = {
           StringEquals = {
             "oidc.eks.${each.value.region}.amazonaws.com/id/${each.value.oidc_provider_id}:aud" = "sts.amazonaws.com"
-            "oidc.eks.${each.value.region}.amazonaws.com/id/${each.value.oidc_provider_id}:sub" = "system:serviceaccount:opentelemetry-exporter:${each.value.name}-opentelemetry-collector"
+            "oidc.eks.${each.value.region}.amazonaws.com/id/${each.value.oidc_provider_id}:sub" = "system:serviceaccount:${local.application_name}:${each.value.name}-${local.application_name}"
           }
         }
       }

--- a/aws_cnapp-prod_rosey-logs_locals.tf
+++ b/aws_cnapp-prod_rosey-logs_locals.tf
@@ -1,6 +1,7 @@
 locals {
-  account_id   = data.aws_caller_identity.current.account_id
-  account_name = "cnapp-prod"
+  account_id       = data.aws_caller_identity.current.account_id
+  account_name     = "cnapp-prod"
+  application_name = "opentelemetry-exporter"
   # EKS clsuter region and OIDC provider id
   clusters = {
     "cnapp-prod-us" = {


### PR DESCRIPTION
https://cisco-eti.atlassian.net/browse/SRE-7888

One day I'll manage to write this correctly. k8s namespace and serviceAccount are actually named `opentelemetry-exporter` not `collector`.