### PR TITLE
feat(documentdb): bootstrap cluster in vowel-genai-dev for Prompt intel

### DIFF
--- a/aws_outshift-common-dev_us-east-2_documentdb_pi-dev-use2-documentdb-1_documentdb.tf
+++ b/aws_outshift-common-dev_us-east-2_documentdb_pi-dev-use2-documentdb-1_documentdb.tf
@@ -3,22 +3,22 @@ terraform {
     # This is the name of the backend S3 bucket.
     bucket = "eticloud-tf-state-nonprod" # UPDATE ME.
     # This is the path to the Terraform state file in the backend S3 bucket.
-    key = "terraform-state/aws/outshift-common-dev/us-east-2/documentdb/pi-dev-use2-documentdb-1.tfstate" # UPDATE ME.
+    key = "terraform-state/awsvowel-genai-dev/us-east-2/documentdb/pi-dev-use2-documentdb-1.tfstate" # UPDATE ME.
     # This is the region where the backend S3 bucket is located.
     region = "us-east-2" # DO NOT CHANGE.
   }
 }
 
-module "documentdb_cluster" {
+module "ppu_dev_documentdb_cluster" {
   source            = "git::https://github.com/cisco-eti/sre-tf-module-aws-documentdb?ref=develop"
-  account_name      = "outshift-common-dev"
+  account_name      = "vowel-genai-dev"  # id 961088030672
   application_name  = "pi-dev-use2-documentdb-1"
   environment       = "dev"
   engine_version    = "5.0.0"
   master_username   = "pi"
-  instances         = 2
-  instance_class    = "db.r6g.large"
-  vpc_data_name     = "venture-data-vpc-name"
+  instances         = 3
+  instance_class    = "db.r6g.xlarge"
+  vpc_data_name     = "motf-dev-use2-data"
   vpc_eks_name      = "venture-eks-vpc-name"
   venture_namespace = "ppu"
 }

--- a/aws_outshift-common-dev_us-east-2_documentdb_pi-dev-use2-documentdb-1_documentdb.tf
+++ b/aws_outshift-common-dev_us-east-2_documentdb_pi-dev-use2-documentdb-1_documentdb.tf
@@ -1,0 +1,24 @@
+terraform {
+  backend "s3" {
+    # This is the name of the backend S3 bucket.
+    bucket = "eticloud-tf-state-nonprod" # UPDATE ME.
+    # This is the path to the Terraform state file in the backend S3 bucket.
+    key = "terraform-state/aws/outshift-common-dev/us-east-2/documentdb/pi-dev-use2-documentdb-1.tfstate" # UPDATE ME.
+    # This is the region where the backend S3 bucket is located.
+    region = "us-east-2" # DO NOT CHANGE.
+  }
+}
+
+module "documentdb_cluster" {
+  source            = "git::https://github.com/cisco-eti/sre-tf-module-aws-documentdb?ref=develop"
+  account_name      = "outshift-common-dev"
+  application_name  = "pi-dev-use2-documentdb-1"
+  environment       = "dev"
+  engine_version    = "5.0.0"
+  master_username   = "pi"
+  instances         = 2
+  instance_class    = "db.r6g.large"
+  vpc_data_name     = "venture-data-vpc-name"
+  vpc_eks_name      = "venture-eks-vpc-name"
+  venture_namespace = "ppu"
+}

--- a/aws_outshift-common-dev_us-east-2_documentdb_pi-dev-use2-documentdb-1_documentdb.tf
+++ b/aws_outshift-common-dev_us-east-2_documentdb_pi-dev-use2-documentdb-1_documentdb.tf
@@ -3,7 +3,7 @@ terraform {
     # This is the name of the backend S3 bucket.
     bucket = "eticloud-tf-state-nonprod" # UPDATE ME.
     # This is the path to the Terraform state file in the backend S3 bucket.
-    key = "terraform-state/awsvowel-genai-dev/us-east-2/documentdb/pi-dev-use2-documentdb-1.tfstate" # UPDATE ME.
+    key = "terraform-state/vowel-genai-dev/us-east-2/documentdb/pi-dev-use2-documentdb-1.tfstate" # UPDATE ME.
     # This is the region where the backend S3 bucket is located.
     region = "us-east-2" # DO NOT CHANGE.
   }

--- a/aws_outshift-common-dev_us-east-2_documentdb_pi-dev-use2-documentdb-1_documentdb.tf
+++ b/aws_outshift-common-dev_us-east-2_documentdb_pi-dev-use2-documentdb-1_documentdb.tf
@@ -18,7 +18,7 @@ module "ppu_dev_documentdb_cluster" {
   master_username   = "pi"
   instances         = 3
   instance_class    = "db.r6g.xlarge"
-  vpc_data_name     = "motf-dev-use2-data"
-  vpc_eks_name      = "venture-eks-vpc-name"
+  vpc_data_name     = "motf-e2e-use2-data"
+  vpc_eks_name      = "pi-dev-use2-1"
   venture_namespace = "ppu"
 }

--- a/aws_outshift-common-dev_us-east-2_vpc-peering_pi-dev-use2-1-motf-e2e-use2-data-peering_vpc-peering.tf
+++ b/aws_outshift-common-dev_us-east-2_vpc-peering_pi-dev-use2-1-motf-e2e-use2-data-peering_vpc-peering.tf
@@ -6,7 +6,7 @@ terraform {
   }
 }
 
-module "vpc_peering_primary_to_primary"{
+module "vpc_peering_pi_dev_motf_e2e_data"{
   source             = "git::https://github.com/cisco-eti/sre-tf-module-multi-region-vpc-peering.git?ref=1.1.0"
   aws_accounts_to_regions = {
     "vowel-genai-dev" = {

--- a/aws_outshift-common-dev_us-east-2_vpc-peering_pi-dev-use2-1-motf-e2e-use2-data-peering_vpc-peering.tf
+++ b/aws_outshift-common-dev_us-east-2_vpc-peering_pi-dev-use2-1-motf-e2e-use2-data-peering_vpc-peering.tf
@@ -1,0 +1,19 @@
+terraform {
+  backend "s3" {
+    bucket = "eticloud-tf-state-nonprod"
+    key    = "terraform-state/vpc-peering/us-east-2/pi-dev-use2-1-motf-e2e-use2-data.tfstate"
+    region = "us-east-2"
+  }
+}
+
+module "vpc_peering_primary_to_primary"{
+  source             = "git::https://github.com/cisco-eti/sre-tf-module-multi-region-vpc-peering.git?ref=1.1.0"
+  aws_accounts_to_regions = {
+    "vowel-genai-dev" = {
+      account_name = "vowel-genai-dev"
+      region       = "us-east-2"
+    }
+  }
+  accepter_vpc_name  = "pi-dev-use2-1"
+  requester_vpc_name = "motf-e2e-use2-data"
+}

--- a/aws_vowel-genai-dev_us-east-2_documentdb_pi-dev-use2-documentdb-1_documentdb.tf
+++ b/aws_vowel-genai-dev_us-east-2_documentdb_pi-dev-use2-documentdb-1_documentdb.tf
@@ -18,4 +18,5 @@ module "ppu_dev_documentdb_cluster" {
   vpc_data_name     = "motf-e2e-use2-data"
   vpc_eks_name      = "pi-dev-use2-1"
   venture_namespace = "ppu"
+  secret_path       = "secret/dev/ppu-backend-perf"
 }

--- a/aws_vowel-genai-dev_us-east-2_documentdb_pi-dev-use2-documentdb-1_documentdb.tf
+++ b/aws_vowel-genai-dev_us-east-2_documentdb_pi-dev-use2-documentdb-1_documentdb.tf
@@ -1,0 +1,21 @@
+terraform {
+  backend "s3" {
+    bucket = "eticloud-tf-state-nonprod"
+    key    = "terraform-state/vowel-genai-dev/us-east-2/documentdb/pi-dev-use2-documentdb-1.tfstate"
+    region = "us-east-2"
+  }
+}
+
+module "ppu_dev_documentdb_cluster" {
+  source            = "git::https://github.com/cisco-eti/sre-tf-module-aws-documentdb?ref=develop"
+  account_name      = "vowel-genai-dev" # id 961088030672
+  application_name  = "pi-dev-use2-documentdb-1"
+  environment       = "dev"
+  engine_version    = "5.0.0"
+  master_username   = "pi"
+  instances         = 3
+  instance_class    = "db.r6g.xlarge"
+  vpc_data_name     = "motf-e2e-use2-data"
+  vpc_eks_name      = "pi-dev-use2-1"
+  venture_namespace = "ppu"
+}

--- a/aws_vowel-genai-dev_us-east-2_vpc-peering_pi-dev-use2-1-motf-e2e-use2-data-peering_vpc-peering.tf
+++ b/aws_vowel-genai-dev_us-east-2_vpc-peering_pi-dev-use2-1-motf-e2e-use2-data-peering_vpc-peering.tf
@@ -1,0 +1,20 @@
+terraform {
+  backend "s3" {
+    bucket = "eticloud-tf-state-nonprod"
+    key    = "terraform-state/vpc-peering/us-east-2/pi-dev-use2-1-motf-e2e-use2-data.tfstate"
+    region = "us-east-2"
+  }
+}
+
+# peering between pi-dev-use2-1 EKS and motf-e2e-use2-data where DocumentDB will be bootstrapped
+module "vpc_peering_pi_dev_motf_e2e_data" {
+  source = "git::https://github.com/cisco-eti/sre-tf-module-multi-region-vpc-peering.git?ref=1.1.0"
+  aws_accounts_to_regions = {
+    "vowel-genai-dev" = {
+      account_name = "vowel-genai-dev"
+      region       = "us-east-2"
+    }
+  }
+  accepter_vpc_name  = "pi-dev-use2-1"
+  requester_vpc_name = "motf-e2e-use2-data"
+}

--- a/aws_vowel-genai-dev_us-east-2_vpc-peering_pi-dev-use2-1-motf-e2e-use2-data-peering_vpc-peering.tf
+++ b/aws_vowel-genai-dev_us-east-2_vpc-peering_pi-dev-use2-1-motf-e2e-use2-data-peering_vpc-peering.tf
@@ -10,7 +10,7 @@ terraform {
 module "vpc_peering_pi_dev_motf_e2e_data" {
   source = "git::https://github.com/cisco-eti/sre-tf-module-multi-region-vpc-peering.git?ref=1.1.0"
   aws_accounts_to_regions = {
-    "vowel-genai-dev" = {
+    "common" = {
       account_name = "vowel-genai-dev"
       region       = "us-east-2"
     }


### PR DESCRIPTION
https://cisco-eti.atlassian.net/browse/OPENSD-351

This will use a terraform module: https://github.com/cisco-eti/sre-tf-module-aws-documentdb/tree/develop

1. This creates VPC peering connections between an EKS VPC and a Data one where this DocumentDB cluster will be hosted
2. Bootstraps a new DocumentDB cluster, there's already a Mongo instance running in Kubernetes for other purposes. This one will be for perf test.