### PR TITLE
chore(dragonfly-prod): bump msk storage volume size

### DIFF
--- a/aws_dragonfly-prod_us-east-2_msk_dragonfly-prod-msk-1_msk.tf
+++ b/aws_dragonfly-prod_us-east-2_msk_dragonfly-prod-msk-1_msk.tf
@@ -30,6 +30,10 @@ resource "aws_msk_cluster" "dragonfly_msk_1" {
     storage_info {
       ebs_storage_info {
         volume_size = 1500
+
+        provisioned_throughput {
+          enabled = false
+        }
       }
     }
 

--- a/aws_dragonfly-prod_us-east-2_msk_dragonfly-prod-msk-1_msk.tf
+++ b/aws_dragonfly-prod_us-east-2_msk_dragonfly-prod-msk-1_msk.tf
@@ -29,7 +29,7 @@ resource "aws_msk_cluster" "dragonfly_msk_1" {
 
     storage_info {
       ebs_storage_info {
-        volume_size = 1000
+        volume_size = 1500
       }
     }
 


### PR DESCRIPTION
## Fixes/Implements
Fixes high disk usage alert on `dragonfly-msk-prod-1`
[INC-31](https://cisco-eti.atlassian.net/browse/INC-31)

Change already applied manually. This is just a follow-up in TF.

### Additional details

- [x] `terraform fmt` was applied
- [ ] All atlantis plans can be applied
- [ ] (For reviewers) I have verified the resource changes


[INC-31]: https://cisco-eti.atlassian.net/browse/INC-31?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ