### PR TITLE
feat(dragonfly/osis): move to daily indexing rotation for SA

### DIFF
--- a/aws_dragonfly-dev_eu-west-1_os_dragonfly-dev-1-osis_main.tf
+++ b/aws_dragonfly-dev_eu-west-1_os_dragonfly-dev-1-osis_main.tf
@@ -25,7 +25,7 @@ locals {
       min_units              = 1,
       max_units              = 4,
       pipeline_template_file = "./pipeline-sa.yaml",
-    },
+    }
   }
 }
 

--- a/aws_dragonfly-prod_us-east-2_os_dragonfly-prod-1-osis_main.tf
+++ b/aws_dragonfly-prod_us-east-2_os_dragonfly-prod-1-osis_main.tf
@@ -25,7 +25,7 @@ locals {
       min_units = 1,
       max_units = 10,
       pipeline_template_file = "./pipeline-sa.yaml",
-    },
+    }
   }
 }
 

--- a/aws_dragonfly-staging_eu-west-1_os_dragonfly-staging-1-osis_main.tf
+++ b/aws_dragonfly-staging_eu-west-1_os_dragonfly-staging-1-osis_main.tf
@@ -24,7 +24,7 @@ locals {
       min_units              = 1,
       max_units              = 4,
       pipeline_template_file = "./pipeline-sa.yaml",
-    },
+    }
   }
 }
 


### PR DESCRIPTION
## Use daily rotation strategy for suspicious acrivities indexes in opensearch

### Description/Justification

As suspicious activities volume is increasing, we are moving to a rotation strategy of 1 day in place of 1 month.

### Additional details

- [x] `terraform fmt` was applied
- [x] All atlantis plans can be applied
- [ ] (For reviewers) I have verified the resource changes
