### PR TITLE
chore: deploy df event manager role on prod euc1 and use2

### DIFF
--- a/aws_dragonfly-prod_iam_dragonfly-event-manager-role-euc1_backend.tf
+++ b/aws_dragonfly-prod_iam_dragonfly-event-manager-role-euc1_backend.tf
@@ -1,0 +1,7 @@
+terraform {
+  backend "s3" {
+    bucket = "eticloud-tf-state-prod"
+    key    = "terraform-state/aws/dragonfly-prod/iam/dragonfly-event-manager-euc1.tfstate"
+    region = "us-east-2"
+  }
+}

--- a/aws_dragonfly-prod_iam_dragonfly-event-manager-role-euc1_dependencies.tf
+++ b/aws_dragonfly-prod_iam_dragonfly-event-manager-role-euc1_dependencies.tf
@@ -1,0 +1,10 @@
+data aws_caller_identity current {}
+data aws_region current {}
+
+data "aws_eks_cluster" "cluster" {
+  name = local.cluster_name
+}
+
+data "aws_msk_cluster" "dragonfly_msk_1" {
+  cluster_name = local.dragonfly_msk_cluster_name
+}

--- a/aws_dragonfly-prod_iam_dragonfly-event-manager-role-euc1_locals.tf
+++ b/aws_dragonfly-prod_iam_dragonfly-event-manager-role-euc1_locals.tf
@@ -1,0 +1,14 @@
+locals {
+  aws_account        = "dragonfly-prod"
+  role_name          = "dragonfly-event-manager-role-euc1"
+  role_description   = "IAM Role for dragonfly-event-manager"
+
+  dragonfly_msk_cluster_name = "dragonfly-msk-prod-eu1"
+
+  # AWS EKS Cluster
+  cluster_name = "dragonfly-prod-euc1-1"
+  oidc_id      = trimprefix(data.aws_eks_cluster.cluster.identity[0].oidc[0].issuer, "https://")
+
+  dragonfly_backend_namespace = "dragonfly-backend"
+  service_account             = "${local.dragonfly_backend_namespace}:dragonfly-event-manager-service-account"
+}

--- a/aws_dragonfly-prod_iam_dragonfly-event-manager-role-euc1_output.tf
+++ b/aws_dragonfly-prod_iam_dragonfly-event-manager-role-euc1_output.tf
@@ -1,0 +1,3 @@
+output "role_arn" {
+  value = aws_iam_role.role.arn
+}

--- a/aws_dragonfly-prod_iam_dragonfly-event-manager-role-euc1_providers.tf
+++ b/aws_dragonfly-prod_iam_dragonfly-event-manager-role-euc1_providers.tf
@@ -1,0 +1,39 @@
+terraform {
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+  }
+}
+
+provider "vault" {
+  address   = "https://keeper.cisco.com"
+  namespace = "eticloud"
+}
+
+data "vault_generic_secret" "aws_infra_credential" {
+  path = "secret/infra/aws/${local.aws_account}/terraform_admin"
+}
+
+variable "AWS_INFRA_REGION" {
+  description = "AWS Region"
+  default     = "eu-central-1"
+}
+
+provider "aws" {
+  access_key  = data.vault_generic_secret.aws_infra_credential.data["AWS_ACCESS_KEY_ID"]
+  secret_key  = data.vault_generic_secret.aws_infra_credential.data["AWS_SECRET_ACCESS_KEY"]
+  region      = var.AWS_INFRA_REGION
+  max_retries = 3
+
+  default_tags {
+    tags = {
+      ApplicationName    = "dragonfly"
+      CiscoMailAlias     = "eti-sre-admins@cisco.com"
+      DataClassification = "Cisco Confidential"
+      DataTaxonomy       = "Cisco Operations Data"
+      Environment        = "Prod"
+      ResourceOwner      = "ETI SRE"
+    }
+  }
+}

--- a/aws_dragonfly-prod_iam_dragonfly-event-manager-role-euc1_role.tf
+++ b/aws_dragonfly-prod_iam_dragonfly-event-manager-role-euc1_role.tf
@@ -1,0 +1,107 @@
+data "aws_iam_policy_document" "assume_role_policy" {
+  statement {
+    effect = "Allow"
+    principals {
+      type = "Federated"
+      identifiers = [
+        "arn:aws:iam::${data.aws_caller_identity.current.account_id}:oidc-provider/${local.oidc_id}",
+      ]
+    }
+    actions = ["sts:AssumeRoleWithWebIdentity"]
+    condition {
+      test     = "StringEquals"
+      values = ["sts.amazonaws.com"]
+      variable = "${local.oidc_id}:aud"
+    }
+    condition {
+      test     = "StringEquals"
+      values = ["system:serviceaccount:${local.service_account}"]
+      variable = "${local.oidc_id}:sub"
+    }
+  }
+}
+
+data "aws_iam_policy_document" "policy" {
+  statement {
+    sid = "access"
+
+    actions = [
+      "kafka-cluster:Connect",
+    ]
+
+    resources = [
+      "arn:aws:kafka:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:cluster/${data.aws_msk_cluster.dragonfly_msk_1.cluster_name}/${data.aws_msk_cluster.dragonfly_msk_1.cluster_uuid}"
+    ]
+
+    effect = "Allow"
+  }
+
+  statement {
+    sid = "topic"
+
+    actions = [
+      "kafka-cluster:DescribeTopic",
+      "kafka-cluster:ReadData",
+    ]
+
+    resources = [
+      "arn:aws:kafka:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:topic/${data.aws_msk_cluster.dragonfly_msk_1.cluster_name}/${data.aws_msk_cluster.dragonfly_msk_1.cluster_uuid}/monitoring*",
+      "arn:aws:kafka:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:topic/${data.aws_msk_cluster.dragonfly_msk_1.cluster_name}/${data.aws_msk_cluster.dragonfly_msk_1.cluster_uuid}/falco*",
+      "arn:aws:kafka:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:topic/${data.aws_msk_cluster.dragonfly_msk_1.cluster_name}/${data.aws_msk_cluster.dragonfly_msk_1.cluster_uuid}/threat*",
+      "arn:aws:kafka:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:topic/${data.aws_msk_cluster.dragonfly_msk_1.cluster_name}/${data.aws_msk_cluster.dragonfly_msk_1.cluster_uuid}/attack*",
+    ]
+
+    effect = "Allow"
+  }
+
+  statement {
+    sid = "groups"
+
+    actions = [
+      "kafka-cluster:AlterGroup",
+      "kafka-cluster:DescribeGroup",
+    ]
+
+    resources = [
+      "arn:aws:kafka:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:group/${data.aws_msk_cluster.dragonfly_msk_1.cluster_name}/${data.aws_msk_cluster.dragonfly_msk_1.cluster_uuid}/event-manager",
+    ]
+
+    effect = "Allow"
+  }
+}
+
+resource "aws_iam_role" "role" {
+  name        = local.role_name
+  description = local.role_description
+
+  assume_role_policy = data.aws_iam_policy_document.assume_role_policy.json
+  inline_policy {
+    name   = "kserve-inference-policy"
+    policy = data.aws_iam_policy_document.policy.json
+  }
+
+  managed_policy_arns = []
+}
+
+data "aws_iam_policy_document" "sqs_policy" {
+  statement {
+    sid = "PortshiftSQSAccess"
+
+    actions = [
+      "sqs:*"
+    ]
+    resources = [
+      "arn:aws:sqs:eu-central-1:975854676552:queue-eventsForwarderTopic-lightspin"
+    ]
+  }
+}
+resource "aws_iam_policy" "portshift_sqs_policy" {
+  name        = "${local.cluster_name}-streaman-portshift-sqs"
+  description = "${local.cluster_name} policy for event manager role"
+  policy      = data.aws_iam_policy_document.sqs_policy.json
+}
+
+resource "aws_iam_role_policy_attachment" "dragonfly_event_manager_sqs_policy_attachment" {
+  role       = aws_iam_role.role.name
+  policy_arn = aws_iam_policy.portshift_sqs_policy.arn
+}

--- a/aws_dragonfly-prod_iam_dragonfly-event-manager-role-use2_backend.tf
+++ b/aws_dragonfly-prod_iam_dragonfly-event-manager-role-use2_backend.tf
@@ -1,0 +1,7 @@
+terraform {
+  backend "s3" {
+    bucket = "eticloud-tf-state-prod"
+    key    = "terraform-state/aws/dragonfly-prod/iam/dragonfly-event-manager-use2.tfstate"
+    region = "us-east-2"
+  }
+}

--- a/aws_dragonfly-prod_iam_dragonfly-event-manager-role-use2_dependencies.tf
+++ b/aws_dragonfly-prod_iam_dragonfly-event-manager-role-use2_dependencies.tf
@@ -1,0 +1,10 @@
+data aws_caller_identity current {}
+data aws_region current {}
+
+data "aws_eks_cluster" "cluster" {
+  name = local.cluster_name
+}
+
+data "aws_msk_cluster" "dragonfly_msk_1" {
+  cluster_name = local.dragonfly_msk_cluster_name
+}

--- a/aws_dragonfly-prod_iam_dragonfly-event-manager-role-use2_locals.tf
+++ b/aws_dragonfly-prod_iam_dragonfly-event-manager-role-use2_locals.tf
@@ -1,0 +1,14 @@
+locals {
+  aws_account        = "dragonfly-prod"
+  role_name          = "dragonfly-event-manager-role-use2"
+  role_description   = "IAM Role for dragonfly-event-manager"
+
+  dragonfly_msk_cluster_name = "dragonfly-msk-prod-1"
+
+  # AWS EKS Cluster
+  cluster_name = "dragonfly-prod-1"
+  oidc_id      = trimprefix(data.aws_eks_cluster.cluster.identity[0].oidc[0].issuer, "https://")
+
+  dragonfly_backend_namespace = "dragonfly-backend"
+  service_account             = "${local.dragonfly_backend_namespace}:dragonfly-event-manager-service-account"
+}

--- a/aws_dragonfly-prod_iam_dragonfly-event-manager-role-use2_output.tf
+++ b/aws_dragonfly-prod_iam_dragonfly-event-manager-role-use2_output.tf
@@ -1,0 +1,3 @@
+output "role_arn" {
+  value = aws_iam_role.role.arn
+}

--- a/aws_dragonfly-prod_iam_dragonfly-event-manager-role-use2_providers.tf
+++ b/aws_dragonfly-prod_iam_dragonfly-event-manager-role-use2_providers.tf
@@ -1,0 +1,39 @@
+terraform {
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+  }
+}
+
+provider "vault" {
+  address   = "https://keeper.cisco.com"
+  namespace = "eticloud"
+}
+
+data "vault_generic_secret" "aws_infra_credential" {
+  path = "secret/infra/aws/${local.aws_account}/terraform_admin"
+}
+
+variable "AWS_INFRA_REGION" {
+  description = "AWS Region"
+  default     = "us-east-2"
+}
+
+provider "aws" {
+  access_key  = data.vault_generic_secret.aws_infra_credential.data["AWS_ACCESS_KEY_ID"]
+  secret_key  = data.vault_generic_secret.aws_infra_credential.data["AWS_SECRET_ACCESS_KEY"]
+  region      = var.AWS_INFRA_REGION
+  max_retries = 3
+
+  default_tags {
+    tags = {
+      ApplicationName    = "dragonfly"
+      CiscoMailAlias     = "eti-sre-admins@cisco.com"
+      DataClassification = "Cisco Confidential"
+      DataTaxonomy       = "Cisco Operations Data"
+      Environment        = "Prod"
+      ResourceOwner      = "ETI SRE"
+    }
+  }
+}

--- a/aws_dragonfly-prod_iam_dragonfly-event-manager-role-use2_role.tf
+++ b/aws_dragonfly-prod_iam_dragonfly-event-manager-role-use2_role.tf
@@ -1,0 +1,107 @@
+data "aws_iam_policy_document" "assume_role_policy" {
+  statement {
+    effect = "Allow"
+    principals {
+      type = "Federated"
+      identifiers = [
+        "arn:aws:iam::${data.aws_caller_identity.current.account_id}:oidc-provider/${local.oidc_id}",
+      ]
+    }
+    actions = ["sts:AssumeRoleWithWebIdentity"]
+    condition {
+      test     = "StringEquals"
+      values = ["sts.amazonaws.com"]
+      variable = "${local.oidc_id}:aud"
+    }
+    condition {
+      test     = "StringEquals"
+      values = ["system:serviceaccount:${local.service_account}"]
+      variable = "${local.oidc_id}:sub"
+    }
+  }
+}
+
+data "aws_iam_policy_document" "policy" {
+  statement {
+    sid = "access"
+
+    actions = [
+      "kafka-cluster:Connect",
+    ]
+
+    resources = [
+      "arn:aws:kafka:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:cluster/${data.aws_msk_cluster.dragonfly_msk_1.cluster_name}/${data.aws_msk_cluster.dragonfly_msk_1.cluster_uuid}"
+    ]
+
+    effect = "Allow"
+  }
+
+  statement {
+    sid = "topic"
+
+    actions = [
+      "kafka-cluster:DescribeTopic",
+      "kafka-cluster:ReadData",
+    ]
+
+    resources = [
+      "arn:aws:kafka:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:topic/${data.aws_msk_cluster.dragonfly_msk_1.cluster_name}/${data.aws_msk_cluster.dragonfly_msk_1.cluster_uuid}/monitoring*",
+      "arn:aws:kafka:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:topic/${data.aws_msk_cluster.dragonfly_msk_1.cluster_name}/${data.aws_msk_cluster.dragonfly_msk_1.cluster_uuid}/falco*",
+      "arn:aws:kafka:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:topic/${data.aws_msk_cluster.dragonfly_msk_1.cluster_name}/${data.aws_msk_cluster.dragonfly_msk_1.cluster_uuid}/threat*",
+      "arn:aws:kafka:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:topic/${data.aws_msk_cluster.dragonfly_msk_1.cluster_name}/${data.aws_msk_cluster.dragonfly_msk_1.cluster_uuid}/attack*",
+    ]
+
+    effect = "Allow"
+  }
+
+  statement {
+    sid = "groups"
+
+    actions = [
+      "kafka-cluster:AlterGroup",
+      "kafka-cluster:DescribeGroup",
+    ]
+
+    resources = [
+      "arn:aws:kafka:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:group/${data.aws_msk_cluster.dragonfly_msk_1.cluster_name}/${data.aws_msk_cluster.dragonfly_msk_1.cluster_uuid}/event-manager",
+    ]
+
+    effect = "Allow"
+  }
+}
+
+resource "aws_iam_role" "role" {
+  name        = local.role_name
+  description = local.role_description
+
+  assume_role_policy = data.aws_iam_policy_document.assume_role_policy.json
+  inline_policy {
+    name   = "kserve-inference-policy"
+    policy = data.aws_iam_policy_document.policy.json
+  }
+
+  managed_policy_arns = []
+}
+
+data "aws_iam_policy_document" "sqs_policy" {
+  statement {
+    sid = "PortshiftSQSAccess"
+
+    actions = [
+      "sqs:*"
+    ]
+    resources = [
+      "arn:aws:sqs:us-east-1:975854676552:queue-eventsForwarderTopic-lightspin"
+    ]
+  }
+}
+resource "aws_iam_policy" "portshift_sqs_policy" {
+  name        = "${local.cluster_name}-streaman-portshift-sqs"
+  description = "${local.cluster_name} policy for event manager role"
+  policy      = data.aws_iam_policy_document.sqs_policy.json
+}
+
+resource "aws_iam_role_policy_attachment" "dragonfly_event_manager_sqs_policy_attachment" {
+  role       = aws_iam_role.role.name
+  policy_arn = aws_iam_policy.portshift_sqs_policy.arn
+}

--- a/aws_dragonfly-prod_iam_dragonfly-event-manager-role_backend.tf
+++ b/aws_dragonfly-prod_iam_dragonfly-event-manager-role_backend.tf
@@ -1,0 +1,7 @@
+terraform {
+  backend "s3" {
+    bucket = "eticloud-tf-state-prod"
+    key    = "terraform-state/aws/dragonfly-prod/iam/dragonfly-event-manager-euc1.tfstate"
+    region = "us-east-2"
+  }
+}

--- a/aws_dragonfly-prod_iam_dragonfly-event-manager-role_dependencies.tf
+++ b/aws_dragonfly-prod_iam_dragonfly-event-manager-role_dependencies.tf
@@ -1,0 +1,10 @@
+data aws_caller_identity current {}
+data aws_region current {}
+
+data "aws_eks_cluster" "cluster" {
+  name = local.cluster_name
+}
+
+data "aws_msk_cluster" "dragonfly_msk_1" {
+  cluster_name = local.dragonfly_msk_cluster_name
+}

--- a/aws_dragonfly-prod_iam_dragonfly-event-manager-role_locals.tf
+++ b/aws_dragonfly-prod_iam_dragonfly-event-manager-role_locals.tf
@@ -1,0 +1,14 @@
+locals {
+  aws_account        = "dragonfly-prod"
+  role_name          = "dragonfly-event-manager-role"
+  role_description   = "IAM Role for dragonfly-event-manager"
+
+  dragonfly_msk_cluster_name = "dragonfly-msk-prod-eu1"
+
+  # AWS EKS Cluster
+  cluster_name = "dragonfly-prod-euc1-1"
+  oidc_id      = trimprefix(data.aws_eks_cluster.cluster.identity[0].oidc[0].issuer, "https://")
+
+  dragonfly_backend_namespace = "dragonfly-backend"
+  service_account             = "${local.dragonfly_backend_namespace}:dragonfly-event-manager-service-account"
+}

--- a/aws_dragonfly-prod_iam_dragonfly-event-manager-role_output.tf
+++ b/aws_dragonfly-prod_iam_dragonfly-event-manager-role_output.tf
@@ -1,0 +1,3 @@
+output "role_arn" {
+  value = aws_iam_role.role.arn
+}

--- a/aws_dragonfly-prod_iam_dragonfly-event-manager-role_providers.tf
+++ b/aws_dragonfly-prod_iam_dragonfly-event-manager-role_providers.tf
@@ -1,0 +1,39 @@
+terraform {
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+  }
+}
+
+provider "vault" {
+  address   = "https://keeper.cisco.com"
+  namespace = "eticloud"
+}
+
+data "vault_generic_secret" "aws_infra_credential" {
+  path = "secret/infra/aws/${local.aws_account}/terraform_admin"
+}
+
+variable "AWS_INFRA_REGION" {
+  description = "AWS Region"
+  default     = "eu-central-1"
+}
+
+provider "aws" {
+  access_key  = data.vault_generic_secret.aws_infra_credential.data["AWS_ACCESS_KEY_ID"]
+  secret_key  = data.vault_generic_secret.aws_infra_credential.data["AWS_SECRET_ACCESS_KEY"]
+  region      = var.AWS_INFRA_REGION
+  max_retries = 3
+
+  default_tags {
+    tags = {
+      ApplicationName    = "dragonfly"
+      CiscoMailAlias     = "eti-sre-admins@cisco.com"
+      DataClassification = "Cisco Confidential"
+      DataTaxonomy       = "Cisco Operations Data"
+      Environment        = "Prod"
+      ResourceOwner      = "ETI SRE"
+    }
+  }
+}

--- a/aws_dragonfly-prod_iam_dragonfly-event-manager-role_role.tf
+++ b/aws_dragonfly-prod_iam_dragonfly-event-manager-role_role.tf
@@ -1,0 +1,107 @@
+data "aws_iam_policy_document" "assume_role_policy" {
+  statement {
+    effect = "Allow"
+    principals {
+      type = "Federated"
+      identifiers = [
+        "arn:aws:iam::${data.aws_caller_identity.current.account_id}:oidc-provider/${local.oidc_id}",
+      ]
+    }
+    actions = ["sts:AssumeRoleWithWebIdentity"]
+    condition {
+      test     = "StringEquals"
+      values = ["sts.amazonaws.com"]
+      variable = "${local.oidc_id}:aud"
+    }
+    condition {
+      test     = "StringEquals"
+      values = ["system:serviceaccount:${local.service_account}"]
+      variable = "${local.oidc_id}:sub"
+    }
+  }
+}
+
+data "aws_iam_policy_document" "policy" {
+  statement {
+    sid = "access"
+
+    actions = [
+      "kafka-cluster:Connect",
+    ]
+
+    resources = [
+      "arn:aws:kafka:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:cluster/${data.aws_msk_cluster.dragonfly_msk_1.cluster_name}/${data.aws_msk_cluster.dragonfly_msk_1.cluster_uuid}"
+    ]
+
+    effect = "Allow"
+  }
+
+  statement {
+    sid = "topic"
+
+    actions = [
+      "kafka-cluster:DescribeTopic",
+      "kafka-cluster:ReadData",
+    ]
+
+    resources = [
+      "arn:aws:kafka:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:topic/${data.aws_msk_cluster.dragonfly_msk_1.cluster_name}/${data.aws_msk_cluster.dragonfly_msk_1.cluster_uuid}/monitoring*",
+      "arn:aws:kafka:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:topic/${data.aws_msk_cluster.dragonfly_msk_1.cluster_name}/${data.aws_msk_cluster.dragonfly_msk_1.cluster_uuid}/falco*",
+      "arn:aws:kafka:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:topic/${data.aws_msk_cluster.dragonfly_msk_1.cluster_name}/${data.aws_msk_cluster.dragonfly_msk_1.cluster_uuid}/threat*",
+      "arn:aws:kafka:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:topic/${data.aws_msk_cluster.dragonfly_msk_1.cluster_name}/${data.aws_msk_cluster.dragonfly_msk_1.cluster_uuid}/attack*",
+    ]
+
+    effect = "Allow"
+  }
+
+  statement {
+    sid = "groups"
+
+    actions = [
+      "kafka-cluster:AlterGroup",
+      "kafka-cluster:DescribeGroup",
+    ]
+
+    resources = [
+      "arn:aws:kafka:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:group/${data.aws_msk_cluster.dragonfly_msk_1.cluster_name}/${data.aws_msk_cluster.dragonfly_msk_1.cluster_uuid}/event-manager",
+    ]
+
+    effect = "Allow"
+  }
+}
+
+resource "aws_iam_role" "role" {
+  name        = local.role_name
+  description = local.role_description
+
+  assume_role_policy = data.aws_iam_policy_document.assume_role_policy.json
+  inline_policy {
+    name   = "kserve-inference-policy"
+    policy = data.aws_iam_policy_document.policy.json
+  }
+
+  managed_policy_arns = []
+}
+
+data "aws_iam_policy_document" "sqs_policy" {
+  statement {
+    sid = "PortshiftSQSAccess"
+
+    actions = [
+      "sqs:*"
+    ]
+    resources = [
+      "arn:aws:sqs:us-east-1:579418176921:queue-eventsForwarderTopic-lightspin"
+    ]
+  }
+}
+resource "aws_iam_policy" "portshift_sqs_policy" {
+  name        = "${local.cluster_name}-streaman-portshift-sqs"
+  description = "${local.cluster_name} policy for event manager role"
+  policy      = data.aws_iam_policy_document.sqs_policy.json
+}
+
+resource "aws_iam_role_policy_attachment" "dragonfly_event_manager_sqs_policy_attachment" {
+  role       = aws_iam_role.role.name
+  policy_arn = aws_iam_policy.portshift_sqs_policy.arn
+}

--- a/aws_dragonfly-prod_iam_dragonfly-event-manager-role_role.tf
+++ b/aws_dragonfly-prod_iam_dragonfly-event-manager-role_role.tf
@@ -91,7 +91,7 @@ data "aws_iam_policy_document" "sqs_policy" {
       "sqs:*"
     ]
     resources = [
-      "arn:aws:sqs:us-east-1:579418176921:queue-eventsForwarderTopic-lightspin"
+      "arn:aws:sqs:eu-central-1:975854676552:queue-eventsForwarderTopic-lightspin"
     ]
   }
 }


### PR DESCRIPTION
## Fixes/Implements # (JIRA issue if applicable)  

https://cisco-eti.atlassian.net/jira/servicedesk/projects/OPENSD/queues/issue/OPENSD-476 
https://cisco-eti.atlassian.net/browse/OPENSD-475?focusedCommentId=133681
### Description/Justification

(Why is this change needed? Which team might need it? etc...)  


### If the (atlantis) plan is destroying resources, reason for deletion  


### Additional details

- [ ] `terraform fmt` was applied
- [ ] All atlantis plans can be applied
- [ ] (For reviewers) I have verified the resource changes
