### PR TITLE
feat(dragonfly-staging): msk connector for kg ingestion

### DIFF
--- a/aws_dragonfly-dev_eu-west-1_msk_dragonly-msk-connect-1_locals.tf
+++ b/aws_dragonfly-dev_eu-west-1_msk_dragonly-msk-connect-1_locals.tf
@@ -4,10 +4,10 @@ locals {
   compute_vpc                     = "dragonfly-dev-2-vpc"
   data_vpc                        = "dragonfly-data-vpc"
 
-  arangodb_connector_plugin_name   = "kafka-connect-arangodb-1-2-0-dragonfly-2"
+  arangodb_connector_plugin_name   = "kafka-connect-arangodb-1-2-0-dragonfly-4"
   arangodb_connector_logs_bucket   = "dragonfly-dev-kafka-connector-log-files"
   arangodb_connector_plugin_bucket = "dragonfly-dev-binaries-repository"
-  arangodb_connector_plugin_jar    = "kafka-connect-arangodb-1.2.0-dragonfly-3.zip"
+  arangodb_connector_plugin_jar    = "kafka-connect-arangodb-1.2.0-dragonfly-4.zip"
 
   arangodb_secret_name            = "thrill-arangodb"
 }

--- a/aws_dragonfly-staging_eu-west-1_msk_dragonly-msk-connect-1_backend.tf
+++ b/aws_dragonfly-staging_eu-west-1_msk_dragonly-msk-connect-1_backend.tf
@@ -1,0 +1,7 @@
+terraform {
+  backend "s3" {
+    bucket = "eticloud-tf-state-nonprod"
+    key    = "terraform-state/aws-dragonfly-staging/msk/eu-west-1/dragonfly-msk-connect-1.tfstate"
+    region = "us-east-2"
+  }
+}

--- a/aws_dragonfly-staging_eu-west-1_msk_dragonly-msk-connect-1_cloudwatch.tf
+++ b/aws_dragonfly-staging_eu-west-1_msk_dragonly-msk-connect-1_cloudwatch.tf
@@ -1,0 +1,3 @@
+resource "aws_cloudwatch_log_group" "dragonfly_kg_connector" {
+  name = "dragonfly-kg-connector-logs"
+}

--- a/aws_dragonfly-staging_eu-west-1_msk_dragonly-msk-connect-1_dependencies.tf
+++ b/aws_dragonfly-staging_eu-west-1_msk_dragonly-msk-connect-1_dependencies.tf
@@ -15,7 +15,7 @@ data "vault_generic_secret" "arangodb_secrets" {
 
 // kafka cluster information
 data "aws_msk_cluster" "dragonfly_msk_1" {
-  cluster_name = "dragonfly-msk-1"
+  cluster_name = "dragonfly-staging-msk-1"
 }
 
 // data vpc information

--- a/aws_dragonfly-staging_eu-west-1_msk_dragonly-msk-connect-1_dependencies.tf
+++ b/aws_dragonfly-staging_eu-west-1_msk_dragonly-msk-connect-1_dependencies.tf
@@ -1,0 +1,76 @@
+data "vault_generic_secret" "aws_infra_credential" {
+  path     = "secret/infra/aws/${local.aws_account_name}/terraform_admin"
+  provider = vault.eticloud
+}
+
+// account information
+data "aws_caller_identity" "current" {}
+data "aws_region" "current" {}
+
+// Arangodb secrets from vault
+data "vault_generic_secret" "arangodb_secrets" {
+  path     = "secret/staging/thrill-arangodb"
+  provider = vault.dragonfly
+}
+
+// kafka cluster information
+data "aws_msk_cluster" "dragonfly_msk_1" {
+  cluster_name = "dragonfly-msk-1"
+}
+
+// data vpc information
+data "aws_vpc" "msk_vpc" {
+  filter {
+    name = "tag:Name"
+    values = [
+      local.data_vpc
+    ]
+  }
+}
+
+// data subnets information
+data "aws_subnets" "msk_subnets" {
+  filter {
+    name = "vpc-id"
+    values = [
+      data.aws_vpc.msk_vpc.id
+    ]
+  }
+  tags = {
+    Tier = "Private"
+  }
+}
+
+// compute vpc information
+data "aws_vpc" "eks_vpc" {
+  filter {
+    name = "tag:Name"
+    values = [
+      local.compute_vpc
+    ]
+  }
+}
+
+// compute subnets information
+data "aws_subnets" "eks_subnets" {
+  filter {
+    name = "vpc-id"
+    values = [
+      data.aws_vpc.eks_vpc.id
+    ]
+  }
+  tags = {
+    Tier = "Private"
+  }
+}
+
+// bucket containing the custom plugin jar
+data "aws_s3_bucket" "mskconnect_custom_plugin_bucket" {
+  bucket = local.arangodb_connector_plugin_bucket
+}
+
+// Jar object in the bucket
+data "aws_s3_object" "mskconnect_custom_plugin_jar" {
+  bucket = data.aws_s3_bucket.mskconnect_custom_plugin_bucket.bucket
+  key    = local.arangodb_connector_plugin_jar
+}

--- a/aws_dragonfly-staging_eu-west-1_msk_dragonly-msk-connect-1_execution-role.tf
+++ b/aws_dragonfly-staging_eu-west-1_msk_dragonly-msk-connect-1_execution-role.tf
@@ -1,0 +1,141 @@
+resource "aws_iam_role" "msk_connect_kg_execution_role" {
+  name = "dragonfly-kg-connector-role-${data.aws_region.current.name}"
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        "Effect" = "Allow",
+        "Principal" : {
+          "Service" = "kafkaconnect.amazonaws.com"
+        },
+        "Action" = "sts:AssumeRole"
+      }
+    ]
+  })
+}
+
+data "aws_iam_policy_document" "msk_connect_kg_role_policy_document" {
+  statement {
+    effect = "Allow"
+
+    actions = [
+      "kafka-cluster:Connect",
+      "kafka-cluster:AlterCluster",
+      "kafka-cluster:DescribeCluster",
+      "kafka:DescribeClusterV2",
+      "kafka:GetBootstrapBrokers"
+    ]
+
+    resources = [
+      data.aws_msk_cluster.dragonfly_msk_1.arn
+    ]
+  }
+
+  statement {
+    effect = "Allow"
+
+    actions = [
+      "kafka-cluster:*Topic*",
+      "kafka-cluster:ReadData"
+    ]
+
+    resources = [
+      "arn:aws:kafka:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:topic/${data.aws_msk_cluster.dragonfly_msk_1.cluster_name}/${data.aws_msk_cluster.dragonfly_msk_1.cluster_uuid}/*",
+    ]
+  }
+
+  statement {
+    actions = [
+      "kafka-cluster:CreateTopic",
+      "kafka-cluster:WriteData",
+      "kafka-cluster:ReadData",
+      "kafka-cluster:DescribeTopic"
+    ]
+
+    resources = [
+      "arn:aws:kafka:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:topic/${data.aws_msk_cluster.dragonfly_msk_1.cluster_name}/${data.aws_msk_cluster.dragonfly_msk_1.cluster_uuid}/__amazon_msk_connect_*",
+    ]
+  }
+
+  statement {
+    effect = "Allow"
+
+    actions = [
+      "kafka-cluster:AlterGroup",
+      "kafka-cluster:DescribeGroup"
+    ]
+
+    resources = [
+      "arn:aws:kafka:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:group/${data.aws_msk_cluster.dragonfly_msk_1.cluster_name}/${data.aws_msk_cluster.dragonfly_msk_1.cluster_uuid}/__amazon_msk_connect_*",
+      "arn:aws:kafka:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:group/${data.aws_msk_cluster.dragonfly_msk_1.cluster_name}/${data.aws_msk_cluster.dragonfly_msk_1.cluster_uuid}/connect-*",
+    ]
+  }
+
+  statement {
+    effect = "Allow"
+
+    actions = [
+      "logs:CreateLogDelivery",
+      "logs:GetLogDelivery",
+      "logs:DescribeLogDelivery",
+      "logs:DeleteLogDelivery",
+      "logs:ListLogDeliveries"
+    ]
+
+    resources = [
+      aws_cloudwatch_log_group.dragonfly_kg_connector.arn
+    ]
+  }
+
+  statement {
+    effect = "Allow"
+
+    actions = [
+      "s3:PutObject"
+    ]
+
+    resources = [
+      "arn:aws:s3:::${local.arangodb_connector_logs_bucket}/*"
+    ]
+  }
+
+  statement {
+    effect = "Allow"
+
+    actions = [
+      "secretsmanager:GetResourcePolicy",
+      "secretsmanager:GetSecretValue",
+      "secretsmanager:DescribeSecret",
+      "secretsmanager:ListSecretVersionIds",
+    ]
+
+    resources = [
+      aws_secretsmanager_secret.msk_connect_kg.arn
+    ]
+  }
+
+  // kms access
+  statement {
+    effect = "Allow"
+
+    actions = [
+      "kms:Decrypt",
+      "kms:DescribeKey"
+    ]
+
+    resources = [
+      aws_kms_key.encryption_key.arn
+    ]
+  }
+}
+
+resource "aws_iam_policy" "role_policy" {
+  name        = "dragonfly-kg-connector-role-policy-${data.aws_region.current.name}"
+  description = "Policies for arangodb connector role"
+  policy      = data.aws_iam_policy_document.msk_connect_kg_role_policy_document.json
+}
+
+resource "aws_iam_role_policy_attachment" "role_policy_attachment" {
+  role       = aws_iam_role.msk_connect_kg_execution_role.name
+  policy_arn = aws_iam_policy.role_policy.arn
+}

--- a/aws_dragonfly-staging_eu-west-1_msk_dragonly-msk-connect-1_kg-connector.tf
+++ b/aws_dragonfly-staging_eu-west-1_msk_dragonly-msk-connect-1_kg-connector.tf
@@ -1,0 +1,108 @@
+resource "aws_mskconnect_worker_configuration" "dragonfly_kg_worker_config" {
+  name                    = "dragonfly-kg-worker"
+  properties_file_content = <<EOT
+# define names of config providers:
+config.providers=secretsmanager
+config.providers.secretsmanager.param.region=${data.aws_region.current.name}
+
+key.converter=org.apache.kafka.connect.storage.StringConverter
+value.converter=org.apache.kafka.connect.storage.StringConverter
+
+# provide implementation classes for each provider:
+config.providers.secretsmanager.class=com.amazonaws.kafka.config.providers.SecretsManagerConfigProvider
+EOT
+}
+
+resource "aws_mskconnect_custom_plugin" "dragonfly_kg_connector" {
+  name         = "${local.arangodb_connector_plugin_name}-plugin"
+  content_type = "ZIP"
+  location {
+    s3 {
+      bucket_arn = data.aws_s3_bucket.mskconnect_custom_plugin_bucket.arn
+      file_key   = data.aws_s3_object.mskconnect_custom_plugin_jar.key
+    }
+  }
+}
+
+resource "aws_mskconnect_connector" "dragonfly_kg_connector" {
+  name = "dragonfly-kg-connector"
+
+  kafkaconnect_version = "2.7.1"
+
+  capacity {
+    autoscaling {
+      mcu_count        = 1
+      min_worker_count = 1
+      max_worker_count = 2
+
+      scale_in_policy {
+        cpu_utilization_percentage = 20
+      }
+
+      scale_out_policy {
+        cpu_utilization_percentage = 80
+      }
+    }
+  }
+
+  connector_configuration = {
+    "connection.endpoints"           = "$${secretsmanager:dragonfly-msk-connect-kg:endpoint}"
+    "connector.class"                = "com.arangodb.kafka.ArangoSinkConnector"
+    "connection.password"            = "$${secretsmanager:dragonfly-msk-connect-kg:password}"
+    "connection.user"                = "$${secretsmanager:dragonfly-msk-connect-kg:username}"
+    "data.errors.log.enable"         = "true"
+    "data.errors.tolerance"          = "all"
+    "insert.overwriteMode"           = "UPDATE"
+    "ssl.enabled"                    = "true"
+    "ssl.hostname.verification"      = "true"
+    "ssl.cert.value"                 = "$${secretsmanager:dragonfly-msk-connect-kg:ca-certificate}"
+    "topics"                         = "$${secretsmanager:dragonfly-msk-connect-kg:topics}"
+    "tasks.max"                      = "2"
+    "value.converter.schemas.enable" = "false"
+    "value.converter"                = "org.apache.kafka.connect.json.JsonConverter"
+  }
+
+  kafka_cluster {
+    apache_kafka_cluster {
+      bootstrap_servers = data.aws_msk_cluster.dragonfly_msk_1.bootstrap_brokers_sasl_iam
+
+      vpc {
+        security_groups = [
+          aws_security_group.dragonfly_kg_1.id
+        ]
+        subnets = data.aws_subnets.msk_subnets.ids
+      }
+    }
+  }
+
+  kafka_cluster_client_authentication {
+    authentication_type = "IAM"
+  }
+
+  kafka_cluster_encryption_in_transit {
+    encryption_type = "TLS"
+  }
+
+  plugin {
+    custom_plugin {
+      arn      = aws_mskconnect_custom_plugin.dragonfly_kg_connector.arn
+      revision = aws_mskconnect_custom_plugin.dragonfly_kg_connector.latest_revision
+    }
+  }
+
+  service_execution_role_arn = aws_iam_role.msk_connect_kg_execution_role.arn
+
+  worker_configuration {
+    arn      = aws_mskconnect_worker_configuration.dragonfly_kg_worker_config.arn
+    revision = aws_mskconnect_worker_configuration.dragonfly_kg_worker_config.latest_revision
+  }
+
+  log_delivery {
+    worker_log_delivery {
+      cloudwatch_logs {
+        enabled = true
+        log_group = aws_cloudwatch_log_group.dragonfly_kg_connector.name
+      }
+    }
+  }
+}

--- a/aws_dragonfly-staging_eu-west-1_msk_dragonly-msk-connect-1_kms.tf
+++ b/aws_dragonfly-staging_eu-west-1_msk_dragonly-msk-connect-1_kms.tf
@@ -28,7 +28,7 @@ resource "aws_kms_key" "encryption_key" {
       {
         "Sid" : "External",
         "Effect" : "Allow",
-        "Principal" : { "AWS" = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/dragonfly-kg-connector-role" },
+        "Principal" : { "AWS" = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/dragonfly-kg-connector-role-${data.aws_region.current.name}" },
         "Action" : [
           "kms:Decrypt",
           "kms:DescribeKey"

--- a/aws_dragonfly-staging_eu-west-1_msk_dragonly-msk-connect-1_kms.tf
+++ b/aws_dragonfly-staging_eu-west-1_msk_dragonly-msk-connect-1_kms.tf
@@ -1,0 +1,40 @@
+resource "aws_kms_key" "encryption_key" {
+  description = "encryption key for msk-kg-connector secrets"
+
+  policy = jsonencode({
+    "Version" : "2012-10-17",
+    "Statement" : [
+      {
+        "Sid" : "Internal",
+        "Effect" : "Allow",
+        "Principal" : { "AWS" : data.aws_caller_identity.current.arn },
+        "Action" : "kms:*",
+        "Resource" : "*"
+      },
+      {
+        "Sid" : "External",
+        "Effect" : "Allow",
+        "Principal" : { "AWS" : "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/admin" },
+        "Action" : [
+          "kms:Decrypt",
+          "kms:Describe*",
+          "kms:Encrypt",
+          "kms:ReEncrypt*",
+          "kms:GenerateDataKey*",
+          "kms:GetKeyPolicy*",
+        ],
+        Resource : "*"
+      },
+      {
+        "Sid" : "External",
+        "Effect" : "Allow",
+        "Principal" : { "AWS" = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/dragonfly-kg-connector-role" },
+        "Action" : [
+          "kms:Decrypt",
+          "kms:DescribeKey"
+        ],
+        Resource : "*"
+      }
+    ]
+  })
+}

--- a/aws_dragonfly-staging_eu-west-1_msk_dragonly-msk-connect-1_locals.tf
+++ b/aws_dragonfly-staging_eu-west-1_msk_dragonly-msk-connect-1_locals.tf
@@ -1,0 +1,13 @@
+locals {
+  aws_account_name                 = "dragonfly-staging"
+
+  compute_vpc                     = "dragonfly-compute-staging-1-vpc"
+  data_vpc                        = "dragonfly-data-staging-1-vpc"
+
+  arangodb_connector_plugin_name   = "kafka-connect-arangodb-1-2-0-dragonfly-2"
+  arangodb_connector_logs_bucket   = "dragonfly-staging-kafka-connector-log-files"
+  arangodb_connector_plugin_bucket = "dragonfly-staging-binaries-repository"
+  arangodb_connector_plugin_jar    = "kafka-connect-arangodb-1.2.0-dragonfly-3.zip"
+
+  arangodb_secret_name            = "thrill-arangodb"
+}

--- a/aws_dragonfly-staging_eu-west-1_msk_dragonly-msk-connect-1_locals.tf
+++ b/aws_dragonfly-staging_eu-west-1_msk_dragonly-msk-connect-1_locals.tf
@@ -4,10 +4,10 @@ locals {
   compute_vpc                     = "dragonfly-compute-staging-1-vpc"
   data_vpc                        = "dragonfly-data-staging-1-vpc"
 
-  arangodb_connector_plugin_name   = "kafka-connect-arangodb-1-2-0-dragonfly-3"
+  arangodb_connector_plugin_name   = "kafka-connect-arangodb-1-2-0-dragonfly-4"
   arangodb_connector_logs_bucket   = "dragonfly-staging-kafka-connector-log-files"
   arangodb_connector_plugin_bucket = "dragonfly-staging-binaries-repository"
-  arangodb_connector_plugin_jar    = "kafka-connect-arangodb-1.2.0-dragonfly-3.zip"
+  arangodb_connector_plugin_jar    = "kafka-connect-arangodb-1.2.0-dragonfly-4.zip"
 
   arangodb_secret_name            = "thrill-arangodb"
 }

--- a/aws_dragonfly-staging_eu-west-1_msk_dragonly-msk-connect-1_locals.tf
+++ b/aws_dragonfly-staging_eu-west-1_msk_dragonly-msk-connect-1_locals.tf
@@ -4,7 +4,7 @@ locals {
   compute_vpc                     = "dragonfly-compute-staging-1-vpc"
   data_vpc                        = "dragonfly-data-staging-1-vpc"
 
-  arangodb_connector_plugin_name   = "kafka-connect-arangodb-1-2-0-dragonfly-2"
+  arangodb_connector_plugin_name   = "kafka-connect-arangodb-1-2-0-dragonfly-3"
   arangodb_connector_logs_bucket   = "dragonfly-staging-kafka-connector-log-files"
   arangodb_connector_plugin_bucket = "dragonfly-staging-binaries-repository"
   arangodb_connector_plugin_jar    = "kafka-connect-arangodb-1.2.0-dragonfly-3.zip"

--- a/aws_dragonfly-staging_eu-west-1_msk_dragonly-msk-connect-1_providers.tf
+++ b/aws_dragonfly-staging_eu-west-1_msk_dragonly-msk-connect-1_providers.tf
@@ -1,0 +1,28 @@
+provider "aws" {
+  access_key = data.vault_generic_secret.aws_infra_credential.data["AWS_ACCESS_KEY_ID"]
+  secret_key = data.vault_generic_secret.aws_infra_credential.data["AWS_SECRET_ACCESS_KEY"]
+  region     = "eu-west-1"
+
+  default_tags {
+    tags = {
+      ApplicationName    = "dragonfly-msk-connect-1"
+      CiscoMailAlias     = "eti-sre-admins@cisco.com"
+      DataClassification = "Cisco Confidential"
+      DataTaxonomy       = "Cisco Operations Data"
+      EnvironmentName    = "NonProd"
+      ResourceOwner      = "ETI SRE"
+    }
+  }
+}
+
+provider "vault" {
+  alias     = "eticloud"
+  address   = "https://keeper.cisco.com"
+  namespace = "eticloud"
+}
+
+provider "vault" {
+  alias     = "dragonfly"
+  address   = "https://keeper.cisco.com"
+  namespace = "eticloud/apps/dragonfly"
+}

--- a/aws_dragonfly-staging_eu-west-1_msk_dragonly-msk-connect-1_secretsmanager.tf
+++ b/aws_dragonfly-staging_eu-west-1_msk_dragonly-msk-connect-1_secretsmanager.tf
@@ -1,0 +1,23 @@
+locals {
+  secret = {
+    endpoint       = data.vault_generic_secret.arangodb_secrets.data["endpoint"]
+    username       = data.vault_generic_secret.arangodb_secrets.data["username"]
+    password       = data.vault_generic_secret.arangodb_secrets.data["password"]
+    ca-certificate = data.vault_generic_secret.arangodb_secrets.data["ca.crt.b64"]
+    topics         = data.vault_generic_secret.arangodb_secrets.data["topics"]
+  }
+}
+
+// Secrets for aragodb authentication
+resource "aws_secretsmanager_secret" "msk_connect_kg" {
+  name        = "dragonfly-msk-connect-kg"
+  description = "Secrets to connect to arangodb database."
+
+  kms_key_id = aws_kms_key.encryption_key.arn
+}
+
+// Secret versions
+resource "aws_secretsmanager_secret_version" "msk_connect_kg_password_v1" {
+  secret_id     = aws_secretsmanager_secret.msk_connect_kg.id
+  secret_string = jsonencode(local.secret)
+}

--- a/aws_dragonfly-staging_eu-west-1_msk_dragonly-msk-connect-1_securitygroups.tf
+++ b/aws_dragonfly-staging_eu-west-1_msk_dragonly-msk-connect-1_securitygroups.tf
@@ -1,0 +1,43 @@
+locals {
+  ingress_rules = []
+
+  egress_rules = [
+    {
+      from_port   = 0
+      to_port     = 65535
+      protocol    = "tcp"
+      cidr_blocks = [
+        "0.0.0.0/0",
+      ]
+    }
+  ]
+}
+
+
+resource "aws_security_group" "dragonfly_kg_1" {
+  name        = "dragonfly-kg-connector"
+  description = "Security group for Dragonfly Knowledge Graph Connector"
+  vpc_id      = data.aws_vpc.msk_vpc.id
+
+  dynamic "ingress" {
+    for_each = toset(local.ingress_rules)
+
+    content {
+      from_port   = ingress.value.from_port
+      to_port     = ingress.value.to_port
+      protocol    = ingress.value.protocol
+      cidr_blocks = ingress.value.cidr_blocks
+    }
+  }
+
+  dynamic "egress" {
+    for_each = toset(local.egress_rules)
+
+    content {
+      from_port   = egress.value.from_port
+      to_port     = egress.value.to_port
+      protocol    = egress.value.protocol
+      cidr_blocks = egress.value.cidr_blocks
+    }
+  }
+}

--- a/aws_dragonfly-staging_eu-west-1_msk_dragonly-msk-connect-1_versions.tf
+++ b/aws_dragonfly-staging_eu-west-1_msk_dragonly-msk-connect-1_versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.3.6"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+}


### PR DESCRIPTION
## Create MSK KG connector in staging env

### Description/Justification

Deploy the MSK connector to export edges and nodes from kafka and ingest them into arangodb.

### Additional details

- [x] `terraform fmt` was applied
- [x] All atlantis plans can be applied
- [ ] (For reviewers) I have verified the resource changes
