### PR TITLE
fix: VPC peering to data for marvin-test-use2-1 cluster

### DIFF
--- a/aws_outshift-common-dev_us-east-2_vpc-peering_marvin-test-use2-1-peering_main.tf
+++ b/aws_outshift-common-dev_us-east-2_vpc-peering_marvin-test-use2-1-peering_main.tf
@@ -1,0 +1,19 @@
+terraform {
+  backend "s3" {
+    bucket = "eticloud-tf-state-nonprod"
+    key    = "terraform-state/vpc-peering/us-east-2/marvin-test-use2-1-peering.tfstate"
+    region = "us-east-2"
+  }
+}
+
+module "vpc_peering_primary_to_primary"{
+  source             = "git::https://github.com/cisco-eti/sre-tf-module-multi-region-vpc-peering.git?ref=1.1.0"
+  aws_accounts_to_regions = {
+    "common" = {
+      account_name = "outshift-common-dev"
+      region       = "us-east-2"
+    }
+  }
+  accepter_vpc_name  = "comn-dev-use2-1"
+  requester_vpc_name = "marvin-test-use2-1"
+}


### PR DESCRIPTION
## Fixes/Implements #

https://cisco-eti.atlassian.net/browse/SRE-8285

### Description/Justification

Marvin development environment needs VPC peering to the data VPC 


### If the (atlantis) plan is destroying resources, reason for deletion  


### Additional details

- [x] `terraform fmt` was applied
- [x] All atlantis plans can be applied
- [ ] (For reviewers) I have verified the resource changes
