### PR TITLE
fix(vpc-peering): marvin-test with marvin-dev data VPC

### DIFF
--- a/aws_outshift-common-dev_us-east-2_vpc-peering_marvin-test-use2-1-peering_main.tf
+++ b/aws_outshift-common-dev_us-east-2_vpc-peering_marvin-test-use2-1-peering_main.tf
@@ -14,6 +14,6 @@ module "vpc_peering_primary_to_primary"{
       region       = "us-east-2"
     }
   }
-  accepter_vpc_name  = "comn-dev-use2-1"
-  requester_vpc_name = "marvin-test-use2-1"
+  accepter_vpc_name  = "marvin-test-use2-1"
+  requester_vpc_name = "marvin-dev-use2-data"
 }


### PR DESCRIPTION
## Fixes/Implements # (JIRA issue if applicable)  

Where datastores live.

### Description/Justification

(Why is this change needed? Which team might need it? etc...)  


### If the (atlantis) plan is destroying resources, reason for deletion  

N/A 

### Additional details

- [x] `terraform fmt` was applied
- [x] All atlantis plans can be applied
- [ ] (For reviewers) I have verified the resource changes
