### PR TITLE
chore: bump kafka broker instance

### DIFF
--- a/aws_motific-prod_us-east-2_msk_motf-prod-use2-1_main.tf
+++ b/aws_motific-prod_us-east-2_msk_motf-prod-use2-1_main.tf
@@ -103,7 +103,7 @@ module "msk" {
   vpc_id               = data.aws_vpc.db_vpc.id
   subnet_ids           = data.aws_subnets.private.ids
   kafka_version        = "3.5.1"
-  broker_instance_type = "kafka.m5.large"
+  broker_instance_type = "kafka.m5.2xlarge"
   properties = {
     "auto.create.topics.enable"      = true
     "default.replication.factor"     = 3


### PR DESCRIPTION
## Fixes/Implements # (JIRA issue if applicable)  


### Description/Justification

(Why is this change needed? Which team might need it? etc...)  


### If the (atlantis) plan is destroying resources, reason for deletion  


### Additional details

- [ ] `terraform fmt` was applied
- [ ] All atlantis plans can be applied
- [ ] (For reviewers) I have verified the resource changes
