### PR TITLE
feat(motific-staging-prod): add VPC peerings

### DIFF
--- a/aws_motific-prod_us-west-2_vpc-peering_compute-to-data_vpc-peering.tf
+++ b/aws_motific-prod_us-west-2_vpc-peering_compute-to-data_vpc-peering.tf
@@ -1,0 +1,23 @@
+terraform {
+  backend "s3" {
+    bucket = "eticloud-tf-state-prod"
+    key    = "terraform-state/vpc/us-east-2/motf-prod-usw2-data-vpc-peering.tfstate"
+    region = "us-east-2"
+  }
+}
+
+module "motific_prod_vpc_peering_eks_us_west_2_data" {
+  source             = "git::https://github.com/cisco-eti/sre-tf-module-vpc-peering.git?ref=1.1.0"
+  aws_accounts_to_regions = {
+    "accepter" = {
+      account_name = "motific-prod"
+      region       = "us-east-2"
+    }
+    "requester" = {
+      account_name = "motific-prod"
+      region       = "us-west-2"
+    }
+  }
+  accepter_vpc_name  = "motf-prod-use2-1"
+  requester_vpc_name = "motf-prod-usw2-data"
+}

--- a/aws_motific-staging_us-west-2_vpc-peering_compute-to-data_vpc-peering.tf
+++ b/aws_motific-staging_us-west-2_vpc-peering_compute-to-data_vpc-peering.tf
@@ -1,0 +1,23 @@
+terraform {
+  backend "s3" {
+    bucket = "eticloud-tf-state-nonprod"
+    key    = "terraform-state/vpc/us-east-2/motf-staging-usw2-data-vpc-peering.tfstate"
+    region = "us-east-2"
+  }
+}
+
+module "motific_staging_vpc_peering_eks_us_west_2_data" {
+  source             = "git::https://github.com/cisco-eti/sre-tf-module-vpc-peering.git?ref=1.1.0"
+  aws_accounts_to_regions = {
+    "accepter" = {
+      account_name = "motific-staging"
+      region       = "us-east-2"
+    }
+    "requester" = {
+      account_name = "motific-staging"
+      region       = "us-west-2"
+    }
+  }
+  accepter_vpc_name  = "motf-staging-use2-1"
+  requester_vpc_name = "motf-staging-usw2-data"
+}

--- a/aws_vowel-genai-dev_us-west-2_vpc_peering_compute-to-data_vpc-peering.tf
+++ b/aws_vowel-genai-dev_us-west-2_vpc_peering_compute-to-data_vpc-peering.tf
@@ -7,7 +7,7 @@ terraform {
 }
 
 module "vpc_peering_us-east_2_eks_us_west_2_data" {
-  source             = "git::https://github.com/cisco-eti/sre-tf-module-vpc-peering.git?ref=latest"
+  source             = "git::https://github.com/cisco-eti/sre-tf-module-vpc-peering.git?ref=1.0.0"
   aws_account_name   = "vowel-genai-dev"
   accepter_vpc_name  = "motf-dev-use2-1"
   requester_vpc_name = "motf-dev-usw2-data"
@@ -16,7 +16,7 @@ module "vpc_peering_us-east_2_eks_us_west_2_data" {
 }
 
 module "vpc_peering_vowel_dev_1_eks_us_west_2_data" {
-  source             = "git::https://github.com/cisco-eti/sre-tf-module-vpc-peering.git?ref=latest"
+  source             = "git::https://github.com/cisco-eti/sre-tf-module-vpc-peering.git?ref=1.0.0"
   aws_account_name   = "vowel-genai-dev"
   accepter_vpc_name  = "vowel-dev-1-vpc" # where the vowel-dev-1 EKS cluster lives
   requester_vpc_name = "motf-dev-usw2-data"


### PR DESCRIPTION
https://cisco-eti.atlassian.net/browse/SRE-8552

- dev: nothing changes, but set the tag version as the VPC peering module we're using has changed between 1.0.0 and 1.1.0
- staging and prod: add VPC peering between the secondary data VPC in `us-west-2` and EKS cluster VPC in `us-east-2` as we're rolling out global RDS