### PR TITLE
chore(rds): test instance upgrade + migration

### DIFF
--- a/aws_eticloud-scratch-c_rds_test-rds_backend.tf
+++ b/aws_eticloud-scratch-c_rds_test-rds_backend.tf
@@ -1,0 +1,8 @@
+
+terraform {
+  backend "s3" {
+    bucket = "eticloud-tf-state-nonprod"
+    key    = "terraform-state/aurora-postgres/us-east-2/eticloud-scratch-c/test-rds.tfstate"
+    region = "us-east-2"
+  }
+}

--- a/aws_eticloud-scratch-c_rds_test-rds_data.tf
+++ b/aws_eticloud-scratch-c_rds_test-rds_data.tf
@@ -1,0 +1,4 @@
+data "vault_generic_secret" "aws_infra_credential" {
+  path     = "secret/infra/aws/${local.aws_account_name}/terraform_admin"
+  provider = vault.eticloud
+}

--- a/aws_eticloud-scratch-c_rds_test-rds_locals.tf
+++ b/aws_eticloud-scratch-c_rds_test-rds_locals.tf
@@ -1,0 +1,6 @@
+
+locals {
+  vpc_name         = "rds-dev-euw1-1"
+  aws_account_name = "eticloud-scratch-c"
+  rds_name         = "test-rds-cluster"
+}

--- a/aws_eticloud-scratch-c_rds_test-rds_main.tf
+++ b/aws_eticloud-scratch-c_rds_test-rds_main.tf
@@ -1,0 +1,10 @@
+module "rds" {
+  source            = "git::https://github.com/cisco-eti/sre-tf-module-aws-aurora-postgres?ref=1.1.0"
+  vpc_name          = local.vpc_name
+  database_name     = "postgressql"
+  db_instance_type  = "db.r5.xlarge"
+  cluster_name      = local.rds_name
+  secret_path       = "secret/eticcprod/infra/aurora-pg/us-east-2/eticloud-scratch-c/rds/"
+  db_allowed_cidrs  = []  # this is a test, not associated to an EKS cluster
+  db_engine_version = "15"
+}

--- a/aws_eticloud-scratch-c_rds_test-rds_providers.tf
+++ b/aws_eticloud-scratch-c_rds_test-rds_providers.tf
@@ -1,0 +1,22 @@
+provider "vault" {
+  alias     = "eticloud"
+  address   = "https://keeper.cisco.com"
+  namespace = "eticloud"
+}
+
+provider "aws" {
+  access_key  = data.vault_generic_secret.aws_infra_credential.data["AWS_ACCESS_KEY_ID"]
+  secret_key  = data.vault_generic_secret.aws_infra_credential.data["AWS_SECRET_ACCESS_KEY"]
+  region      = "us-west-1"
+  max_retries = 3
+  default_tags {
+    tags = {
+      ApplicationName    = "rosey-prod-rds-use2-1"
+      CiscoMailAlias     = "eti-sre-admins@cisco.com"
+      DataClassification = "Cisco Confidential"
+      DataTaxonomy       = "Cisco Operations Data"
+      Environment        = "NonProd"
+      ResourceOwner      = "Outshift SRE"
+    }
+  }
+}


### PR DESCRIPTION
I don't think we can use any existing RDS cluster for this, so need a test RDS cluster for the following:

- Test instance class upgrade (and type), we ran into issues while trying to upgrade Motific's.
- Test module upgrade from regional (1.x.x) to global (2.x.x)
- Potentially test RDS Proxy too.