### PR TITLE
chore: update developer role to include e2e, pentest and perf paths

### DIFF
--- a/aws_motific-pentest_iam_enhanced_monitoring_backend.tf
+++ b/aws_motific-pentest_iam_enhanced_monitoring_backend.tf
@@ -1,0 +1,7 @@
+terraform {
+  backend "s3" {
+    bucket = "eticloud-tf-state-nonprod"
+    key    = "terraform-state/aws/motific-pentest/iam/enhanced-monitoring-iam-roles.tfstate"
+    region = "us-east-2"
+ }
+}

--- a/aws_motific-pentest_iam_enhanced_monitoring_data.tf
+++ b/aws_motific-pentest_iam_enhanced_monitoring_data.tf
@@ -1,0 +1,1 @@
+data "aws_caller_identity" "current" {}

--- a/aws_motific-pentest_iam_enhanced_monitoring_locals.tf
+++ b/aws_motific-pentest_iam_enhanced_monitoring_locals.tf
@@ -1,0 +1,4 @@
+locals {
+  account_name = "motific-pentest"
+  account_id = data.aws_caller_identity.current.account_id
+}

--- a/aws_motific-pentest_iam_enhanced_monitoring_provider.tf
+++ b/aws_motific-pentest_iam_enhanced_monitoring_provider.tf
@@ -1,0 +1,29 @@
+provider "vault" {
+  address   = "https://keeper.cisco.com" # DON'T CHANGE THIS VALUE
+  namespace = "eticloud"                 # DON'T CHANGE THIS VALUE
+  alias     = "eticloud"
+}
+
+
+data "vault_generic_secret" "aws_infra_credential" {
+  path     = "secret/infra/aws/${local.account_name}/terraform_admin"
+}
+
+provider "aws" {
+  access_key  = data.vault_generic_secret.aws_infra_credential.data["AWS_ACCESS_KEY_ID"]     # DON'T CHANGE THIS VALUE
+  secret_key  = data.vault_generic_secret.aws_infra_credential.data["AWS_SECRET_ACCESS_KEY"] # DON'T CHANGE THIS VALUE
+  region      = "us-east-2" # Must match the region where the EKS cluster and VPC are created.
+  max_retries = 3
+  default_tags {
+    # These tags are required for security compliance.
+    # For more information on Data Classification and Data Taxonomy, please talk to the SRE team.
+    tags = {
+      ApplicationName    = "${local.account_name} Enhanced monitoring IAM Roles"
+      CiscoMailAlias     = "eti-sre-admins@cisco.com"
+      DataClassification = "Cisco Confidential"
+      DataTaxonomy       = "Cisco Operations Data"
+      Environment        = "NonProd"
+      ResourceOwner      = "ETI SRE"
+    }
+  }
+}

--- a/aws_motific-pentest_iam_enhanced_monitoring_rds.tf
+++ b/aws_motific-pentest_iam_enhanced_monitoring_rds.tf
@@ -1,0 +1,24 @@
+resource "aws_iam_role" "rds_enhanced_monitoring" {
+  name               = "rds-enhanced-monitoring-${local.account_name}"
+  assume_role_policy = data.aws_iam_policy_document.rds_enhanced_monitoring.json
+}
+
+resource "aws_iam_role_policy_attachment" "rds_enhanced_monitoring" {
+  role       = aws_iam_role.rds_enhanced_monitoring.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonRDSEnhancedMonitoringRole"
+}
+
+data "aws_iam_policy_document" "rds_enhanced_monitoring" {
+  statement {
+    actions = [
+      "sts:AssumeRole",
+    ]
+
+    effect = "Allow"
+
+    principals {
+      type        = "Service"
+      identifiers = ["monitoring.rds.amazonaws.com"]
+    }
+  }
+}

--- a/aws_motific-prod_iam_enhanced_monitoring_backend.tf
+++ b/aws_motific-prod_iam_enhanced_monitoring_backend.tf
@@ -1,0 +1,7 @@
+terraform {
+  backend "s3" {
+    bucket = "eticloud-tf-state-prod"
+    key    = "terraform-state/aws/motific-prod/iam/enhanced-monitoring-iam-roles.tfstate"
+    region = "us-east-2"
+ }
+}

--- a/aws_motific-prod_iam_enhanced_monitoring_data.tf
+++ b/aws_motific-prod_iam_enhanced_monitoring_data.tf
@@ -1,0 +1,1 @@
+data "aws_caller_identity" "current" {}

--- a/aws_motific-prod_iam_enhanced_monitoring_locals.tf
+++ b/aws_motific-prod_iam_enhanced_monitoring_locals.tf
@@ -1,0 +1,4 @@
+locals {
+  account_name = "motific-prod"
+  account_id = data.aws_caller_identity.current.account_id
+}

--- a/aws_motific-prod_iam_enhanced_monitoring_provider.tf
+++ b/aws_motific-prod_iam_enhanced_monitoring_provider.tf
@@ -1,0 +1,29 @@
+provider "vault" {
+  address   = "https://keeper.cisco.com" # DON'T CHANGE THIS VALUE
+  namespace = "eticloud"                 # DON'T CHANGE THIS VALUE
+  alias     = "eticloud"
+}
+
+
+data "vault_generic_secret" "aws_infra_credential" {
+  path     = "secret/infra/aws/${local.account_name}/terraform_admin"
+}
+
+provider "aws" {
+  access_key  = data.vault_generic_secret.aws_infra_credential.data["AWS_ACCESS_KEY_ID"]     # DON'T CHANGE THIS VALUE
+  secret_key  = data.vault_generic_secret.aws_infra_credential.data["AWS_SECRET_ACCESS_KEY"] # DON'T CHANGE THIS VALUE
+  region      = "us-east-2" # Must match the region where the EKS cluster and VPC are created.
+  max_retries = 3
+  default_tags {
+    # These tags are required for security compliance.
+    # For more information on Data Classification and Data Taxonomy, please talk to the SRE team.
+    tags = {
+      ApplicationName    = "${local.account_name} Enhanced monitoring IAM Roles"
+      CiscoMailAlias     = "eti-sre-admins@cisco.com"
+      DataClassification = "Cisco Confidential"
+      DataTaxonomy       = "Cisco Operations Data"
+      Environment        = "Prod"
+      ResourceOwner      = "ETI SRE"
+    }
+  }
+}

--- a/aws_motific-prod_iam_enhanced_monitoring_rds.tf
+++ b/aws_motific-prod_iam_enhanced_monitoring_rds.tf
@@ -1,0 +1,24 @@
+resource "aws_iam_role" "rds_enhanced_monitoring" {
+  name               = "rds-enhanced-monitoring-${local.account_name}"
+  assume_role_policy = data.aws_iam_policy_document.rds_enhanced_monitoring.json
+}
+
+resource "aws_iam_role_policy_attachment" "rds_enhanced_monitoring" {
+  role       = aws_iam_role.rds_enhanced_monitoring.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonRDSEnhancedMonitoringRole"
+}
+
+data "aws_iam_policy_document" "rds_enhanced_monitoring" {
+  statement {
+    actions = [
+      "sts:AssumeRole",
+    ]
+
+    effect = "Allow"
+
+    principals {
+      type        = "Service"
+      identifiers = ["monitoring.rds.amazonaws.com"]
+    }
+  }
+}

--- a/aws_motific-staging_iam_enhanced_monitoring_backend.tf
+++ b/aws_motific-staging_iam_enhanced_monitoring_backend.tf
@@ -1,0 +1,7 @@
+terraform {
+  backend "s3" {
+    bucket = "eticloud-tf-state-nonprod"
+    key    = "terraform-state/aws/motific-staging/iam/enhanced-monitoring-iam-roles.tfstate"
+    region = "us-east-2"
+ }
+}

--- a/aws_motific-staging_iam_enhanced_monitoring_data.tf
+++ b/aws_motific-staging_iam_enhanced_monitoring_data.tf
@@ -1,0 +1,1 @@
+data "aws_caller_identity" "current" {}

--- a/aws_motific-staging_iam_enhanced_monitoring_locals.tf
+++ b/aws_motific-staging_iam_enhanced_monitoring_locals.tf
@@ -1,0 +1,4 @@
+locals {
+  account_name = "motific-staging"
+  account_id = data.aws_caller_identity.current.account_id
+}

--- a/aws_motific-staging_iam_enhanced_monitoring_provider.tf
+++ b/aws_motific-staging_iam_enhanced_monitoring_provider.tf
@@ -1,0 +1,29 @@
+provider "vault" {
+  address   = "https://keeper.cisco.com" # DON'T CHANGE THIS VALUE
+  namespace = "eticloud"                 # DON'T CHANGE THIS VALUE
+  alias     = "eticloud"
+}
+
+
+data "vault_generic_secret" "aws_infra_credential" {
+  path     = "secret/infra/aws/${local.account_name}/terraform_admin"
+}
+
+provider "aws" {
+  access_key  = data.vault_generic_secret.aws_infra_credential.data["AWS_ACCESS_KEY_ID"]     # DON'T CHANGE THIS VALUE
+  secret_key  = data.vault_generic_secret.aws_infra_credential.data["AWS_SECRET_ACCESS_KEY"] # DON'T CHANGE THIS VALUE
+  region      = "us-east-2" # Must match the region where the EKS cluster and VPC are created.
+  max_retries = 3
+  default_tags {
+    # These tags are required for security compliance.
+    # For more information on Data Classification and Data Taxonomy, please talk to the SRE team.
+    tags = {
+      ApplicationName    = "${local.account_name} Enhanced monitoring IAM Roles"
+      CiscoMailAlias     = "eti-sre-admins@cisco.com"
+      DataClassification = "Cisco Confidential"
+      DataTaxonomy       = "Cisco Operations Data"
+      Environment        = "NonProd"
+      ResourceOwner      = "ETI SRE"
+    }
+  }
+}

--- a/aws_motific-staging_iam_enhanced_monitoring_rds.tf
+++ b/aws_motific-staging_iam_enhanced_monitoring_rds.tf
@@ -1,0 +1,24 @@
+resource "aws_iam_role" "rds_enhanced_monitoring" {
+  name               = "rds-enhanced-monitoring-${local.account_name}"
+  assume_role_policy = data.aws_iam_policy_document.rds_enhanced_monitoring.json
+}
+
+resource "aws_iam_role_policy_attachment" "rds_enhanced_monitoring" {
+  role       = aws_iam_role.rds_enhanced_monitoring.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonRDSEnhancedMonitoringRole"
+}
+
+data "aws_iam_policy_document" "rds_enhanced_monitoring" {
+  statement {
+    actions = [
+      "sts:AssumeRole",
+    ]
+
+    effect = "Allow"
+
+    principals {
+      type        = "Service"
+      identifiers = ["monitoring.rds.amazonaws.com"]
+    }
+  }
+}

--- a/aws_vowel-genai-dev_iam_enhanced_monitoring_backend.tf
+++ b/aws_vowel-genai-dev_iam_enhanced_monitoring_backend.tf
@@ -1,0 +1,7 @@
+terraform {
+  backend "s3" {
+    bucket = "eticloud-tf-state-nonprod"
+    key    = "terraform-state/aws/motific-staging/iam/enhanced-monitoring-iam-roles.tfstate"
+    region = "us-east-2"
+ }
+}

--- a/aws_vowel-genai-dev_iam_enhanced_monitoring_data.tf
+++ b/aws_vowel-genai-dev_iam_enhanced_monitoring_data.tf
@@ -1,0 +1,1 @@
+data "aws_caller_identity" "current" {}

--- a/aws_vowel-genai-dev_iam_enhanced_monitoring_locals.tf
+++ b/aws_vowel-genai-dev_iam_enhanced_monitoring_locals.tf
@@ -1,0 +1,4 @@
+locals {
+  account_name = "vowel-genai-dev"
+  account_id = data.aws_caller_identity.current.account_id
+}

--- a/aws_vowel-genai-dev_iam_enhanced_monitoring_provider.tf
+++ b/aws_vowel-genai-dev_iam_enhanced_monitoring_provider.tf
@@ -1,0 +1,29 @@
+provider "vault" {
+  address   = "https://keeper.cisco.com" # DON'T CHANGE THIS VALUE
+  namespace = "eticloud"                 # DON'T CHANGE THIS VALUE
+  alias     = "eticloud"
+}
+
+
+data "vault_generic_secret" "aws_infra_credential" {
+  path     = "secret/infra/aws/${local.account_name}/terraform_admin"
+}
+
+provider "aws" {
+  access_key  = data.vault_generic_secret.aws_infra_credential.data["AWS_ACCESS_KEY_ID"]     # DON'T CHANGE THIS VALUE
+  secret_key  = data.vault_generic_secret.aws_infra_credential.data["AWS_SECRET_ACCESS_KEY"] # DON'T CHANGE THIS VALUE
+  region      = "us-east-2" # Must match the region where the EKS cluster and VPC are created.
+  max_retries = 3
+  default_tags {
+    # These tags are required for security compliance.
+    # For more information on Data Classification and Data Taxonomy, please talk to the SRE team.
+    tags = {
+      ApplicationName    = "${local.account_name} Enhanced monitoring IAM Roles"
+      CiscoMailAlias     = "eti-sre-admins@cisco.com"
+      DataClassification = "Cisco Confidential"
+      DataTaxonomy       = "Cisco Operations Data"
+      Environment        = "NonProd"
+      ResourceOwner      = "ETI SRE"
+    }
+  }
+}

--- a/aws_vowel-genai-dev_iam_enhanced_monitoring_rds.tf
+++ b/aws_vowel-genai-dev_iam_enhanced_monitoring_rds.tf
@@ -1,0 +1,24 @@
+resource "aws_iam_role" "rds_enhanced_monitoring" {
+  name               = "rds-enhanced-monitoring-${local.account_name}"
+  assume_role_policy = data.aws_iam_policy_document.rds_enhanced_monitoring.json
+}
+
+resource "aws_iam_role_policy_attachment" "rds_enhanced_monitoring" {
+  role       = aws_iam_role.rds_enhanced_monitoring.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonRDSEnhancedMonitoringRole"
+}
+
+data "aws_iam_policy_document" "rds_enhanced_monitoring" {
+  statement {
+    actions = [
+      "sts:AssumeRole",
+    ]
+
+    effect = "Allow"
+
+    principals {
+      type        = "Service"
+      identifiers = ["monitoring.rds.amazonaws.com"]
+    }
+  }
+}

--- a/keeper_namespaces_eticloud_apps_vowel_main.tf
+++ b/keeper_namespaces_eticloud_apps_vowel_main.tf
@@ -275,7 +275,7 @@ EOT
 locals {
   policies = {
     "admin"                    = "policies/admin.hcl",
-    "developer"                = "policies/developer.hcl",
+    "developer"                = "policies/developer-dev.hcl",
     "developer-staging"        = "policies/developer-staging.hcl",
     "developer-prod"           = "policies/developer-prod.hcl",
     "external-secrets-dev"     = "policies/external-secrets-dev.hcl",


### PR DESCRIPTION
## Fixes/Implements # (JIRA issue if applicable)  

https://cisco-eti.atlassian.net/browse/SRE-8112

### Description/Justification

(Why is this change needed? Which team might need it? etc...)  


### If the (atlantis) plan is destroying resources, reason for deletion  


### Additional details

- [ ] `terraform fmt` was applied
- [ ] All atlantis plans can be applied
- [ ] (For reviewers) I have verified the resource changes
