### PR TITLE
chore(lightspin-prod): import RDS Proxy

### DIFF
--- a/aws_lightspin-prod_us-east-2_rds_backend.tf
+++ b/aws_lightspin-prod_us-east-2_rds_backend.tf
@@ -1,7 +1,7 @@
 terraform {
   backend "s3" {
     bucket         = "eticloud-tf-state-prod"
-    key            = "terraform-state/aws/lightspin-prod/global/rds/rds.tfstate"
+    key            = "terraform-state/aws/lightspin-prod/us-east-2/rds/rds.tfstate"
     region         = "us-east-2"
     dynamodb_table = "eticloud-tf-locks"
     encrypt        = true

--- a/aws_lightspin-prod_us-east-2_rds_backend.tf
+++ b/aws_lightspin-prod_us-east-2_rds_backend.tf
@@ -1,0 +1,9 @@
+terraform {
+  backend "s3" {
+    bucket         = "eticloud-tf-state-prod"
+    key            = "terraform-state/aws/lightspin-prod/global/rds/rds.tfstate"
+    region         = "us-east-2"
+    dynamodb_table = "eticloud-tf-locks"
+    encrypt        = true
+  }
+}

--- a/aws_lightspin-prod_us-east-2_rds_data.tf
+++ b/aws_lightspin-prod_us-east-2_rds_data.tf
@@ -1,0 +1,1 @@
+data "aws_caller_identity" "current" {}

--- a/aws_lightspin-prod_us-east-2_rds_locals.tf
+++ b/aws_lightspin-prod_us-east-2_rds_locals.tf
@@ -1,0 +1,4 @@
+locals {
+  account_id   = data.aws_caller_identity.current.account_id
+  account_name = "lightspin-prod"
+}

--- a/aws_lightspin-prod_us-east-2_rds_provider.tf
+++ b/aws_lightspin-prod_us-east-2_rds_provider.tf
@@ -1,0 +1,28 @@
+provider "vault" {
+  address   = "https://keeper.cisco.com"
+  namespace = "eticloud"
+}
+
+
+data "vault_generic_secret" "aws_infra_credential" {
+  path     = "secret/infra/aws/${local.account_name}/terraform_admin"
+}
+
+provider "aws" {
+  access_key  = data.vault_generic_secret.aws_infra_credential.data["AWS_ACCESS_KEY_ID"]
+  secret_key  = data.vault_generic_secret.aws_infra_credential.data["AWS_SECRET_ACCESS_KEY"]
+  region      = "us-east-2" # Must match the region where the EKS cluster and VPC are created.
+  max_retries = 3
+  default_tags {
+    # These tags are required for security compliance.
+    # For more information on Data Classification and Data Taxonomy, please talk to the SRE team.
+    tags = {
+      ApplicationName    = "Lightspin Production RDS resources"
+      CiscoMailAlias     = "eti-sre-admins@cisco.com"
+      DataClassification = "Cisco Confidential"
+      DataTaxonomy       = "Cisco Operations Data"
+      Environment        = "Prod"
+      ResourceOwner      = "ETI SRE"
+    }
+  }
+}

--- a/aws_lightspin-prod_us-east-2_rds_proxy.tf
+++ b/aws_lightspin-prod_us-east-2_rds_proxy.tf
@@ -1,0 +1,40 @@
+import {
+  to = aws_db_proxy.light_api
+  id = "light-api"
+}
+
+resource "aws_db_proxy" "light_api" {
+  name                   = "light-api"
+  debug_logging          = false
+  engine_family          = "POSTGRESQL"
+  idle_client_timeout    = 5400  # 1h30min
+  require_tls            = false # wasn't enabled in the console
+  role_arn               = "arn:aws:iam::145875358567:role/service-role/rds-proxy-role-1694096671734"
+  vpc_security_group_ids = ["sg-0e5a1960c739e03d2"]
+  vpc_subnet_ids = [
+    "subnet-01c19ec6fa4a8bcd2",
+    "subnet-0cf1f4c3d66540f2c",
+    "subnet-055b6ed0c2efe951c",
+    "subnet-091c5244f2c69a89d",
+    "subnet-0b712add5be7f684c",
+    "subnet-05eeb2e87468be887",
+    "subnet-08e3841671bf96b0e",
+    "subnet-0ec08cde06ea408db",
+    "subnet-0cc969f64811560ff",
+    "subnet-004e6e95b150b5b95"
+  ]
+
+  auth {
+    auth_scheme               = "SECRETS"
+    client_password_auth_type = "POSTGRES_SCRAM_SHA_256"
+    iam_auth                  = "DISABLED" # wasn't enabled in the console
+    secret_arn                = "arn:aws:secretsmanager:us-east-2:145875358567:secret:prod/light-api/externaluser-3ZsVbq"
+  }
+
+  auth {
+    auth_scheme               = "SECRETS"
+    client_password_auth_type = "POSTGRES_SCRAM_SHA_256"
+    iam_auth                  = "DISABLED" # wasn't enabled in the console
+    secret_arn                = "arn:aws:secretsmanager:us-east-2:145875358567:secret:prod/light-api/rds-GAs2Wm"
+  }
+}

--- a/aws_motific-prod_global_rds_motf-prod-global-1_main.tf
+++ b/aws_motific-prod_global_rds_motf-prod-global-1_main.tf
@@ -1,0 +1,87 @@
+module "rds" {
+  source            = "git::https://github.com/cisco-eti/sre-tf-module-aws-aurora-postgres?ref=1.1.1"
+  vpc_name          = local.vpc_name
+  database_name     = "postgressql"
+  db_instance_type  = "db.r7g.4xlarge"
+  cluster_name      = local.rds_name
+  secret_path       = "secret/eticcprod/infra/aurora-pg/us-east-2/motific-prod/motf-prod-use2-1"
+  db_allowed_cidrs  = [data.aws_vpc.cluster_vpc.cidr_block]
+  db_engine_version = "15"
+}
+
+resource "aws_rds_global_cluster" "motf_prod_global" {
+  global_cluster_identifier = "motf-prod-1-global"
+  # (Optional) Enable to remove DB Cluster members from Global Cluster on destroy. Required with source_db_cluster_identifier.
+  force_destroy                = true
+  deletion_protection          = true
+  source_db_cluster_identifier = module.rds.cluster_arn
+  depends_on                   = [module.rds_primary]
+}
+
+resource "aws_kms_key" "rds_multi_region_secondary" {
+  provider            = aws.secondary
+  description         = "RDS multi-region secondary KMS key for ${local.aws_account_name}"
+  multi_region        = true
+  enable_key_rotation = true
+}
+
+resource "aws_kms_key_policy" "rds" {
+  provider = aws.secondary
+  key_id   = aws_kms_key.rds_multi_region_secondary.id
+  policy = jsonencode({
+    Id = "rds"
+    Statement = [
+      {
+        Action = "kms:*"
+        Effect = "Allow"
+        Principal = {
+          AWS = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:root",
+        }
+
+        Resource = "*"
+        Sid      = "Enable IAM User Permissions"
+      },
+      {
+        Action = [
+          "kms:Encrypt",
+          "kms:Decrypt",
+          "kms:ReEncrypt*",
+          "kms:GenerateDataKey*",
+          "kms:DescribeKey"
+        ]
+        Effect = "Allow"
+        Principal = {
+          AWS = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/admin"
+        }
+
+        Resource = "*"
+        Sid      = "Enable IAM User Permissions"
+      }
+    ]
+    Version = "2012-10-17"
+  })
+}
+
+module "rds_secondary" {
+  providers = {
+    aws = aws.secondary
+  }
+  source                    = "git::https://github.com/cisco-eti/sre-tf-module-aws-aurora-postgres?ref=2.0.4"
+  vpc_name                  = local.data_secondary_vpc_name
+  database_name             = null
+  global_cluster_identifier = aws_rds_global_cluster.motf_prod_global.id
+  is_primary_cluster        = false
+  master_username           = null
+  db_instance_type          = "db.r7g.4xlarge"
+  instances = {
+    1 = {
+      availability_zone = "us-west-2a"
+    }
+  }
+  cluster_name        = "motf-prod-usw2-1"
+  kms_key_id          = aws_kms_key.rds_multi_region_secondary.arn
+  secret_path         = "secret/staging/infra/aurora-pg/us-west-2/motific-prod/motf-prod-usw2-1"
+  db_engine_version   = "15"
+  db_allowed_cidrs    = [data.aws_vpc.cluster_vpc.cidr_block]
+  skip_final_snapshot = true
+}

--- a/aws_motific-prod_global_rds_motf-prod-global-1_main.tf
+++ b/aws_motific-prod_global_rds_motf-prod-global-1_main.tf
@@ -15,7 +15,6 @@ resource "aws_rds_global_cluster" "motf_prod_global" {
   force_destroy                = true
   deletion_protection          = true
   source_db_cluster_identifier = module.rds.cluster_arn
-  depends_on                   = [module.rds_primary]
 }
 
 resource "aws_kms_key" "rds_multi_region_secondary" {

--- a/aws_motific-prod_global_rds_motf-prod-knowledgebase-1_main.tf
+++ b/aws_motific-prod_global_rds_motf-prod-knowledgebase-1_main.tf
@@ -1,0 +1,92 @@
+module "rds" {
+  source            = "git::https://github.com/cisco-eti/sre-tf-module-aws-aurora-postgres?ref=1.1.1"
+  vpc_name          = local.vpc_name
+  database_name     = "postgres"
+  db_instance_type  = "db.r7g.4xlarge"
+  cluster_name      = local.rds_name
+  secret_path       = "secret/eticcprod/infra/aurora-pg/us-east-2/motific-prod/motf-prod-use2-1-knowledgebase"
+  db_allowed_cidrs  = [data.aws_vpc.cluster_vpc.cidr_block]
+  db_engine_version = "15"
+}
+
+resource "aws_rds_global_cluster" "motf_prod_knowledgebase_global" {
+  global_cluster_identifier = "motf-prod-1-knowledgebase-global"
+  # (Optional) Enable to remove DB Cluster members from Global Cluster on destroy. Required with source_db_cluster_identifier.
+  force_destroy                = true
+  deletion_protection          = true
+  source_db_cluster_identifier = module.rds.cluster_arn
+  depends_on                   = [module.rds]
+}
+
+resource "aws_kms_key" "rds_multi_region_secondary" {
+  provider            = aws.secondary
+  description         = "RDS multi-region secondary KMS key for ${local.aws_account_name}"
+  multi_region        = true
+  enable_key_rotation = true
+}
+
+resource "aws_kms_key_policy" "rds" {
+  provider = aws.secondary
+  key_id   = aws_kms_key.rds_multi_region_secondary.id
+  policy = jsonencode({
+    Id = "rds"
+    Statement = [
+      {
+        Action = [
+          "kms:Describe*",
+          "kms:Get*",
+          "kms:List*",
+          "kms:RevokeGrant"
+        ]
+        Effect = "Allow"
+        Principal = {
+          AWS = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:root",
+        }
+
+        Resource = "*"
+        Sid      = "Enable IAM User Permissions"
+      },
+      {
+        Action = [
+          "kms:Encrypt",
+          "kms:Decrypt",
+          "kms:ReEncrypt*",
+          "kms:GenerateDataKey*",
+          "kms:DescribeKey"
+        ]
+        Effect = "Allow"
+        Principal = {
+          AWS = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/admin"
+        }
+
+        Resource = "*"
+        Sid      = "Enable IAM User Permissions"
+      }
+    ]
+    Version = "2012-10-17"
+  })
+}
+
+module "rds_secondary" {
+  providers = {
+    aws = aws.secondary
+  }
+  source                    = "git::https://github.com/cisco-eti/sre-tf-module-aws-aurora-postgres?ref=2.0.4"
+  vpc_name                  = local.data_secondary_vpc_name
+  database_name             = null
+  global_cluster_identifier = aws_rds_global_cluster.motf_prod_knowledgebase_global.id
+  is_primary_cluster        = false
+  master_username           = null
+  db_instance_type          = "db.r7g.xlarge"
+  instances = {
+    1 = {
+      availability_zone = "us-west-2a"
+    }
+  }
+  cluster_name        = "motf-prod-usw2-1-knowledgebase"
+  kms_key_id          = aws_kms_key.rds_multi_region_secondary.arn
+  secret_path         = "secret/staging/infra/aurora-pg/us-west-2/motific-prod/motf-prod-usw2-1-knowledgebase"
+  db_engine_version   = "15"
+  db_allowed_cidrs    = [data.aws_vpc.cluster_vpc.cidr_block]
+  skip_final_snapshot = true
+}

--- a/aws_motific-prod_global_rds_motf-prod-knowledgebase-1_main.tf
+++ b/aws_motific-prod_global_rds_motf-prod-knowledgebase-1_main.tf
@@ -15,7 +15,6 @@ resource "aws_rds_global_cluster" "motf_prod_knowledgebase_global" {
   force_destroy                = true
   deletion_protection          = true
   source_db_cluster_identifier = module.rds.cluster_arn
-  depends_on                   = [module.rds]
 }
 
 resource "aws_kms_key" "rds_multi_region_secondary" {

--- a/aws_outshift-common-prod_global_cross-region-vpc-peering_cross-account_vpc-peering.tf
+++ b/aws_outshift-common-prod_global_cross-region-vpc-peering_cross-account_vpc-peering.tf
@@ -1,0 +1,23 @@
+terraform {
+  backend "s3" {
+    bucket = "eticloud-tf-state-prod"
+    key    = "terraform-state/cross-account-vpc-peering/rds-prod-1-data-comn-prod-clusters.tfstate"
+    region = "us-east-2"
+  }
+}
+
+module "primary_cluster_to_secondary"{
+  source             = "git::https://github.com/cisco-eti/sre-tf-module-multi-region-vpc-peering.git?ref=1.1.1"
+  aws_accounts_to_regions = {
+    "accepter" = {
+      account_name = "eticloud"
+      region       = "us-east-2"
+    }
+    "requester" = {
+      account_name = "outshift-common-prod"
+      region       = "us-east-2"
+    }
+  }
+  accepter_vpc_name  = "prod-db-vpc-1"
+  requester_vpc_name  = "common-prod-use2-vpc-data"
+}

--- a/aws_outshift-common-staging_global_cross-region-vpc-peering_cross-account_vpc-peering.tf
+++ b/aws_outshift-common-staging_global_cross-region-vpc-peering_cross-account_vpc-peering.tf
@@ -1,0 +1,23 @@
+terraform {
+  backend "s3" {
+    bucket = "eticloud-tf-state-nonprod"
+    key    = "terraform-state/cross-account-vpc-peering/rds-prod-1-data-comn-staging-clusters.tfstate"
+    region = "us-east-2"
+  }
+}
+
+module "primary_cluster_to_secondary"{
+  source             = "git::https://github.com/cisco-eti/sre-tf-module-multi-region-vpc-peering.git?ref=1.1.1"
+  aws_accounts_to_regions = {
+    "accepter" = {
+      account_name = "eticloud"
+      region       = "us-east-2"
+    }
+    "requester" = {
+      account_name = "outshift-common-staging"
+      region       = "us-east-2"
+    }
+  }
+  accepter_vpc_name  = "prod-db-vpc-1"
+  requester_vpc_name  = "common-staging-use2-vpc-data"
+}


### PR DESCRIPTION
## Fixes/Implements # (JIRA issue if applicable)  

Import existing RDS Proxy (`light-api`) in tf state. Not in JIRA. Code not in https://wwwin-github.cisco.com/eti/sre-tf-infra.

### Description/Justification

Tags resource, import settings in order to track changes.
Prod resource, should be in a tf state. 

### If the (atlantis) plan is destroying resources, reason for deletion  

No

### Additional details

- [x] `terraform fmt` was applied
- [x] All atlantis plans can be applied
- [ ] (For reviewers) I have verified the resource changes