### PR TITLE
chore(vault): extend perms to csm path to CSMs

### DIFF
--- a/keeper_namespaces_eticloud_outshift-users_main.tf
+++ b/keeper_namespaces_eticloud_outshift-users_main.tf
@@ -151,10 +151,10 @@ resource "vault_policy" "csm" {
   name     = "csm"
   policy   = <<EOT
 # Manage auth methods broadly across Vault
-# List, create, update, and delete key/value secrets
+# Read, list, create, update key/value secrets
 path "csm/*"
 {
-  capabilities = ["read", "list"]
+  capabilities = ["read", "list", "create", "update"]
 }
 EOT
 }


### PR DESCRIPTION
https://cisco-eti.atlassian.net/browse/OPENSD-567

Command to run: `atlantis plan -p keeper-eticloud-outshift-users -- -target=vault_policy.csm`, not sure why there are resource removal in that plan