### PR TITLE
chore(data-sync) for plg prod

### DIFF
--- a/aws_cnapp-prod_rosey-logs_iam.tf
+++ b/aws_cnapp-prod_rosey-logs_iam.tf
@@ -89,14 +89,13 @@ resource "aws_iam_policy" "datasync_cnapp_prod" {
         Effect = "Allow",
         Action = [
           "s3:AbortMultipartUpload",
-          "s3:DeleteObject",
           "s3:GetObject",
           "s3:ListMultipartUploadParts",
           "s3:PutObject",
           "s3:GetObjectTagging",
           "s3:PutObjectTagging"
         ],
-        Resource = "arn:aws:s3:::outshift-product-analytics-s3-bucket/*"
+        Resource = "arn:aws:s3:::outshift-product-analytics-s3-bucket/Rosey/*"
       }
     ]
   })

--- a/aws_cnapp-prod_rosey-logs_locals.tf
+++ b/aws_cnapp-prod_rosey-logs_locals.tf
@@ -10,11 +10,5 @@ locals {
       region_prefix    = "us"
       oidc_provider_id = "EFF9B51923E64F3067C820180603F855"
     }
-    "cnapp-prod-eu" = {
-      name             = "cnapp-prod-euc1-1"
-      region           = "eu-central-1"
-      region_prefix    = "eu"
-      oidc_provider_id = "28A49D0DC19E0AE06F2E38C0AD473F7D"
-    }
   }
 }

--- a/aws_cnapp-prod_rosey-logs_providers.tf
+++ b/aws_cnapp-prod_rosey-logs_providers.tf
@@ -1,0 +1,34 @@
+terraform {
+  required_providers {
+    aws = {
+      source                = "hashicorp/aws"
+      version               = "~> 5.0"
+    }
+  }
+}
+
+provider "aws" {
+  access_key  = data.vault_generic_secret.aws_infra_credential.data["AWS_ACCESS_KEY_ID"]
+  secret_key  = data.vault_generic_secret.aws_infra_credential.data["AWS_SECRET_ACCESS_KEY"]
+  region      = "us-east-2"
+  max_retries = 3
+  default_tags {
+    tags = {
+      ApplicationName    = "Rosey logs"
+      CiscoMailAlias     = "eti-sre-admins@cisco.com"
+      DataClassification = "Cisco Highly Confidential"
+      DataTaxonomy       = "Cisco Operations Data"
+      Environment        = "Prod"
+      ResourceOwner      = "ETI SRE"
+    }
+  }
+}
+
+provider "vault" {
+  address   = "https://keeper.cisco.com"
+  namespace = "eticloud"
+}
+
+data "vault_generic_secret" "aws_infra_credential" {
+  path = "secret/infra/aws/cnapp-prod/terraform_admin"
+}

--- a/aws_cnapp-prod_rosey-logs_providers.tf
+++ b/aws_cnapp-prod_rosey-logs_providers.tf
@@ -3,6 +3,7 @@ terraform {
     aws = {
       source                = "hashicorp/aws"
       version               = "~> 5.0"
+      configuration_aliases = [aws.us, aws.eu]
     }
   }
 }
@@ -11,6 +12,42 @@ provider "aws" {
   access_key  = data.vault_generic_secret.aws_infra_credential.data["AWS_ACCESS_KEY_ID"]
   secret_key  = data.vault_generic_secret.aws_infra_credential.data["AWS_SECRET_ACCESS_KEY"]
   region      = "us-east-2"
+  max_retries = 3
+  default_tags {
+    tags = {
+      ApplicationName    = "Rosey logs"
+      CiscoMailAlias     = "eti-sre-admins@cisco.com"
+      DataClassification = "Cisco Highly Confidential"
+      DataTaxonomy       = "Cisco Operations Data"
+      Environment        = "Prod"
+      ResourceOwner      = "ETI SRE"
+    }
+  }
+}
+
+provider "aws" {
+  alias       = "us"
+  access_key  = data.vault_generic_secret.aws_infra_credential.data["AWS_ACCESS_KEY_ID"]
+  secret_key  = data.vault_generic_secret.aws_infra_credential.data["AWS_SECRET_ACCESS_KEY"]
+  region      = "us-east-2"
+  max_retries = 3
+  default_tags {
+    tags = {
+      ApplicationName    = "Rosey logs"
+      CiscoMailAlias     = "eti-sre-admins@cisco.com"
+      DataClassification = "Cisco Highly Confidential"
+      DataTaxonomy       = "Cisco Operations Data"
+      Environment        = "Prod"
+      ResourceOwner      = "ETI SRE"
+    }
+  }
+}
+
+provider "aws" {
+  alias       = "eu"
+  access_key  = data.vault_generic_secret.aws_infra_credential.data["AWS_ACCESS_KEY_ID"]
+  secret_key  = data.vault_generic_secret.aws_infra_credential.data["AWS_SECRET_ACCESS_KEY"]
+  region      = "eu-central-1"
   max_retries = 3
   default_tags {
     tags = {

--- a/aws_cnapp-prod_rosey-logs_s3.tf
+++ b/aws_cnapp-prod_rosey-logs_s3.tf
@@ -1,9 +1,6 @@
 # https://github.com/hashicorp/terraform/issues/24476
 # have to repeat module call due to using 2 providers for each AWS region
 module "s3-us" {
-  providers = {
-    aws = aws.us
-  }
   source      = "git::https://github.com/cisco-eti/sre-tf-module-aws-s3.git?ref=1.0.2"
   bucket_name = "rosey-logs-us"
   # Continuous Security Buddy Tags.
@@ -17,39 +14,9 @@ module "s3-us" {
   CSBDataTaxonomy       = "Cisco Operations Data"
 }
 
-module "s3-eu" {
-  providers = {
-    aws = aws.eu
-  }
-  source      = "git::https://github.com/cisco-eti/sre-tf-module-aws-s3.git?ref=1.0.2"
-  bucket_name = "rosey-logs-eu"
-  # Continuous Security Buddy Tags.
-  # For more information, see the CSB tagging Sharepoint page here:
-  # https://cisco.sharepoint.com/Sites/CSB/SitePages/Security%20Tagging%20and%20Audit%20in%20AWS.aspx
-  CSBDataClassification = "Cisco Highly Confidential"
-  CSBEnvironment        = "Prod"
-  CSBApplicationName    = "rosey-logs-eu"
-  CSBResourceOwner      = "eti"
-  CSBCiscoMailAlias     = "eti-sre@cisco.com"
-  CSBDataTaxonomy       = "Cisco Operations Data"
-}
-
 resource "aws_s3_bucket_lifecycle_configuration" "rosey_logs_us" {
   provider = aws.us
   bucket   = "rosey-logs-us"
-  rule {
-    id     = "TTL-policy"
-    status = "Enabled"
-
-    expiration {
-      days = 7
-    }
-  }
-}
-
-resource "aws_s3_bucket_lifecycle_configuration" "rosey_logs_eu" {
-  provider = aws.eu
-  bucket   = "rosey-logs-eu"
   rule {
     id     = "TTL-policy"
     status = "Enabled"

--- a/aws_dragonfly-dev_cdn_cdr-ui_acm.tf
+++ b/aws_dragonfly-dev_cdn_cdr-ui_acm.tf
@@ -1,0 +1,42 @@
+locals {
+  # Get distinct list of domains and SANs
+  distinct_domain_names = distinct(
+    [for s in concat([local.cdn_domain_name], [local.cdn_domain_name]) : replace(s, "*.", "")]
+  )
+
+  # Copy domain_validation_options for the distinct domain names
+  validation_domains = [for k, v in aws_acm_certificate.this.domain_validation_options : tomap(v) if contains(local.distinct_domain_names, replace(v.domain_name, "*.", ""))]
+}
+
+data "aws_route53_zone" "domain" {
+  provider = aws.route53
+  name = "dev.panoptica.app"
+}
+resource "aws_acm_certificate" "this" {
+  provider = aws.us-east-1
+  domain_name               = local.cdn_domain_name
+  subject_alternative_names = [local.cdn_domain_name]
+  validation_method         = "DNS"
+
+  options {
+    certificate_transparency_logging_preference = "ENABLED"
+  }
+}
+
+
+resource "aws_route53_record" "validation" {
+  count = length(local.distinct_domain_names)
+  provider = aws.route53
+  zone_id =   data.aws_route53_zone.domain.zone_id
+  name    = element(local.validation_domains, count.index)["resource_record_name"]
+  type    = element(local.validation_domains, count.index)["resource_record_type"]
+  ttl     = 60
+
+  records = [
+    element(local.validation_domains, count.index)["resource_record_value"]
+  ]
+
+  allow_overwrite = true
+
+  depends_on = [aws_acm_certificate.this]
+}

--- a/aws_dragonfly-dev_cdn_cdr-ui_backend.tf
+++ b/aws_dragonfly-dev_cdn_cdr-ui_backend.tf
@@ -1,0 +1,7 @@
+terraform {
+  backend "s3" {
+    bucket = "eticloud-tf-state-nonprod"
+    key    = "terraform-state/aws/dragonfly-dev/cdn/cdr-ui-panoptica-dev.tfstate"
+    region = "us-east-2"
+  }
+}

--- a/aws_dragonfly-dev_cdn_cdr-ui_locals.tf
+++ b/aws_dragonfly-dev_cdn_cdr-ui_locals.tf
@@ -1,0 +1,6 @@
+locals {
+  aws_account         = "dragonfly-dev"
+  cdn_domain_name     = "cdr-ui.dev.panoptica.app"
+  route53_account     = "eticloud"
+  bucket_domain_name  = "dragonfly-dev-cdr-ui.s3.eu-west-1.amazonaws.com"
+}

--- a/aws_dragonfly-dev_cdn_cdr-ui_main.tf
+++ b/aws_dragonfly-dev_cdn_cdr-ui_main.tf
@@ -1,0 +1,66 @@
+module "cdr-ui-dev-cloudfront" {
+  providers = {
+    aws = aws.us-east-1
+  }
+  source                        = "terraform-aws-modules/cloudfront/aws"
+  version                       = "3.4.0"
+  aliases                       = [local.cdn_domain_name]
+  comment                       = local.cdn_domain_name
+  enabled                       = true
+  http_version                  = "http2and3"
+  is_ipv6_enabled               = true
+  price_class                   = "PriceClass_All"
+  retain_on_delete              = false
+  wait_for_deployment           = false
+  default_root_object           = "index.html"
+  # When you enable additional metrics for a distribution, CloudFront sends up to 8 metrics to CloudWatch in the US East (N. Virginia) Region.
+  # This rate is charged only once per month, per metric (up to 8 metrics per distribution).
+  create_monitoring_subscription = false
+  create_origin_access_identity  = false
+
+  custom_error_response = {
+    error_caching_min_ttl = 300
+    error_code            = 403
+    response_code         = 200
+    response_page_path    = "/index.html"
+  }
+  default_cache_behavior = {
+    path_pattern               = "*"
+    target_origin_id           = "dragonfly-dev-cdr-ui"
+    viewer_protocol_policy     = "redirect-to-https"
+    allowed_methods            = ["GET", "HEAD", "OPTIONS"]
+    cached_methods             = ["GET", "HEAD"]
+    compress                   = false
+    query_string               = true
+    cache_policy_id            = "658327ea-f89d-4fab-a63d-7e88639e58f6"
+    compress                   = true
+    min_ttl                    = 0
+    max_ttl                    = 0
+    default_ttl                = 0
+    compress                   = false
+    use_forwarded_values       = false
+  }
+
+  origin = {
+    dragonfly-dev-cdr-ui = {
+        connection_attempts      = 3
+        connection_timeout       = 10
+        domain_name              = "dragonfly-dev-cdr-ui.s3.eu-west-1.amazonaws.com"
+        origin_access_control_id = "ECSHY7OK92LX"
+        origin_id                = "dragonfly-dev-cdr-ui"
+
+        origin_shield = {
+            enabled              = true
+            origin_shield_region = "us-east-1"
+          }
+      }
+  }
+  viewer_certificate = {
+    acm_certificate_arn      =  resource.aws_acm_certificate.this.arn
+    ssl_support_method       = "sni-only"
+    minimum_protocol_version = "TLSv1.2_2021"
+  }
+  depends_on = [
+    resource.aws_acm_certificate.this
+  ]
+}

--- a/aws_dragonfly-dev_cdn_cdr-ui_provider.tf
+++ b/aws_dragonfly-dev_cdn_cdr-ui_provider.tf
@@ -1,0 +1,80 @@
+terraform {
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+    tls = {
+      source  = "hashicorp/tls"
+      version = ">= 4.0.5"
+    }
+  }
+}
+
+provider "vault" {
+  address   = "https://keeper.cisco.com"
+  namespace = "eticloud"
+}
+
+data "vault_generic_secret" "aws_infra_credential" {
+  path = "secret/infra/aws/${local.aws_account}/terraform_admin"
+}
+
+data "vault_generic_secret" "aws_infra_credential_route53" {
+  path = "secret/infra/aws/${local.route53_account}/terraform_admin"
+}
+provider "aws" {
+  alias       = "us-east-2"
+  region      = "us-east-2"
+  access_key  = data.vault_generic_secret.aws_infra_credential.data["AWS_ACCESS_KEY_ID"]
+  secret_key  = data.vault_generic_secret.aws_infra_credential.data["AWS_SECRET_ACCESS_KEY"]
+  max_retries = 3
+
+  default_tags {
+    tags = {
+      ApplicationName    = "dragonfly"
+      CiscoMailAlias     = "eti-sre-admins@cisco.com"
+      DataClassification = "Cisco Confidential"
+      DataTaxonomy       = "Cisco Operations Data"
+      Environment        = "NonProd"
+      ResourceOwner      = "ETI SRE"
+    }
+  }
+}
+
+provider "aws" {
+  alias       = "us-east-1"
+  region      = "us-east-1"
+  access_key  = data.vault_generic_secret.aws_infra_credential.data["AWS_ACCESS_KEY_ID"]
+  secret_key  = data.vault_generic_secret.aws_infra_credential.data["AWS_SECRET_ACCESS_KEY"]
+  max_retries = 3
+
+  default_tags {
+    tags = {
+      ApplicationName    = "dragonfly"
+      CiscoMailAlias     = "eti-sre-admins@cisco.com"
+      DataClassification = "Cisco Confidential"
+      DataTaxonomy       = "Cisco Operations Data"
+      Environment        = "NonProd"
+      ResourceOwner      = "ETI SRE"
+    }
+  }
+}
+
+provider "aws" {
+  alias       = "route53"
+  region      = "us-east-1"
+  access_key  = data.vault_generic_secret.aws_infra_credential_route53.data["AWS_ACCESS_KEY_ID"]
+  secret_key  = data.vault_generic_secret.aws_infra_credential_route53.data["AWS_SECRET_ACCESS_KEY"]
+  max_retries = 3
+
+  default_tags {
+    tags = {
+      ApplicationName    = "dragonfly"
+      CiscoMailAlias     = "eti-sre-admins@cisco.com"
+      DataClassification = "Cisco Confidential"
+      DataTaxonomy       = "Cisco Operations Data"
+      Environment        = "NonProd"
+      ResourceOwner      = "ETI SRE"
+    }
+  }
+}

--- a/aws_lightspin-dev_eu-west-1_vpc-peering_cspm-dev-euw1-1-peering_instanceprofile.tf
+++ b/aws_lightspin-dev_eu-west-1_vpc-peering_cspm-dev-euw1-1-peering_instanceprofile.tf
@@ -1,0 +1,42 @@
+provider "vault" {
+  alias     = "eticloud"
+  address   = "https://keeper.cisco.com"
+  namespace = "eticloud"
+}
+
+data "vault_generic_secret" "aws_infra_credential" {
+  provider = vault.eticloud
+  path     = "secret/infra/aws/${local.eks_aws_account_name}/terraform_admin"
+}
+
+provider "aws" {
+  alias       = "eks"
+  access_key  = data.vault_generic_secret.aws_infra_credential.data["AWS_ACCESS_KEY_ID"]
+  secret_key  = data.vault_generic_secret.aws_infra_credential.data["AWS_SECRET_ACCESS_KEY"]
+  region      = local.region
+  max_retries = 3
+  default_tags {
+    tags = {
+      ApplicationName    = local.name
+      CiscoMailAlias     = "eti-sre-admins@cisco.com"
+      DataClassification = "Cisco Restricted"
+      DataTaxonomy       = "Cisco Operations Data"
+      Environment        = "NonProd"
+      ResourceOwner      = "Outshift SRE"
+    }
+  }
+}
+
+locals {
+  name             = "cspm-dev-euw1-1"
+  region           = "eu-west-1"
+  eks_aws_account_name = "lightspin-dev"
+}
+
+
+# Instance profile for legacy karpenter
+resource "aws_iam_instance_profile" "ip" {
+  provider = aws.eks
+  name = "KarpenterNodeInstanceProfile-${local.name}"
+  role = "KarpenterNodeRole-${local.name}"
+}

--- a/aws_lightspin-dev_eu-west-1_vpc-peering_cspm-dev-euw1-1-peering_vpc-peering.tf
+++ b/aws_lightspin-dev_eu-west-1_vpc-peering_cspm-dev-euw1-1-peering_vpc-peering.tf
@@ -1,0 +1,19 @@
+terraform {
+  backend "s3" {
+    bucket = "eticloud-tf-state-nonprod"
+    key    = "terraform-state/vpc-peering/eu-west-1/cspm-dev-euw1-1-data.tfstate"
+    region = "us-east-2"
+  }
+}
+
+module "vpc_peering_primary_to_primary"{
+  source             = "git::https://github.com/cisco-eti/sre-tf-module-multi-region-vpc-peering.git?ref=1.1.1"
+  aws_accounts_to_regions = {
+    "common" = {
+      account_name = "lightspin-dev"
+      region       = "eu-west-1"
+    }
+  }
+  accepter_vpc_name  = "cspm-dev-euw1-1"
+  requester_vpc_name = "lightspin-dev-1-vpc"
+}

--- a/aws_motific-prod_us-east-2_msk_motf-prod-use2-1_main.tf
+++ b/aws_motific-prod_us-east-2_msk_motf-prod-use2-1_main.tf
@@ -1,0 +1,133 @@
+data "aws_vpc" "db_vpc" {
+  filter {
+    name   = "tag:Name"
+    values = ["motf-prod-use2-data"]
+  }
+}
+
+data "aws_subnets" "private" {
+  filter {
+    name   = "vpc-id"
+    values = [data.aws_vpc.db_vpc.id]
+  }
+
+  tags = {
+    Tier = "Private"
+  }
+}
+
+data "aws_security_group" "vpc_default" {
+  vpc_id = data.aws_vpc.db_vpc.id
+  name   = "default"
+}
+
+data "aws_vpc" "eks_vpc" {
+  filter {
+    name   = "tag:Name"
+    values = ["motf-prod-use2-1"]
+  }
+}
+
+data "aws_security_group" "eks_sg" {
+  vpc_id = data.aws_vpc.eks_vpc.id
+
+  filter {
+    name   = "tag:Name"
+    values = ["eks-cluster-sg-motf-prod-use2-1-*"]
+  }
+}
+
+
+output "vpc_db_security_group" {
+  value = data.aws_security_group.vpc_default.id
+}
+
+### SASL/SCRAM secrets for cluster auth
+
+resource "aws_secretsmanager_secret" "msk_secret" {
+  name                    = "AmazonMSK_msk-motific-prod"
+  kms_key_id              = aws_kms_key.msk_custom_key.key_id
+  recovery_window_in_days = 0
+
+  description = "SASL/SCRAM secret for msk-motific-prod"
+}
+
+resource "aws_kms_key" "msk_custom_key" {
+  description = "Custom Key for MSK Cluster Scram Secret Association"
+}
+
+data "vault_generic_secret" "msk_credentials" {
+  provider = vault.eticloud
+  path     = "secret/infra/msk/motf-prod-use2-1"
+}
+
+resource "aws_secretsmanager_secret_version" "msk_secret" {
+  secret_id     = aws_secretsmanager_secret.msk_secret.id
+  secret_string = data.vault_generic_secret.msk_credentials.data_json
+}
+
+data "aws_iam_policy_document" "msk_secret" {
+  statement {
+    sid    = "AWSKafkaResourcePolicy"
+    effect = "Allow"
+
+    principals {
+      type        = "Service"
+      identifiers = ["kafka.amazonaws.com"]
+    }
+
+    actions   = ["secretsmanager:getSecretValue"]
+    resources = [aws_secretsmanager_secret.msk_secret.arn]
+  }
+}
+
+resource "aws_secretsmanager_secret_policy" "msk_secret" {
+  secret_arn = aws_secretsmanager_secret.msk_secret.arn
+  policy     = data.aws_iam_policy_document.msk_secret.json
+}
+
+# Allow inbound from db vpc CIDR to SASL/SCRAM port 9096 for bastion tunnels
+resource "aws_security_group_rule" "kafka_ingress_eks_motf-prod-use2-1" {
+  type              = "ingress"
+  from_port         = 9096
+  to_port           = 9096
+  protocol          = "tcp"
+  cidr_blocks       = [data.aws_vpc.db_vpc.cidr_block]
+  security_group_id = data.aws_security_group.vpc_default.id
+}
+
+module "msk" {
+  source               = "cloudposse/msk-apache-kafka-cluster/aws"
+  version              = "2.3.0"
+  name                 = "motf-prod-use2-1"
+  vpc_id               = data.aws_vpc.db_vpc.id
+  subnet_ids           = data.aws_subnets.private.ids
+  kafka_version        = "3.5.1"
+  broker_instance_type = "kafka.m5.2xlarge"
+  properties = {
+    "auto.create.topics.enable"      = true
+    "default.replication.factor"     = 3
+    "min.insync.replicas"            = 2
+    "num.io.threads"                 = 8
+    "num.network.threads"            = 5
+    "num.partitions"                 = 100
+    "num.replica.fetchers"           = 2
+    "replica.lag.time.max.ms"        = 30000
+    "socket.receive.buffer.bytes"    = 102400
+    "socket.request.max.bytes"       = 104857600
+    "socket.send.buffer.bytes"       = 102400
+    "unclean.leader.election.enable" = true
+    "zookeeper.session.timeout.ms"   = 18000
+    "group.max.session.timeout.ms"   = 120000
+  }
+
+  # security groups to put on the cluster itself
+  associated_security_group_ids = [data.aws_security_group.vpc_default.id]
+  # security groups to give access to the cluster
+  allowed_security_group_ids                = [data.aws_security_group.eks_sg.id]
+  client_sasl_scram_enabled                 = true
+  client_sasl_scram_secret_association_arns = [aws_secretsmanager_secret.msk_secret.arn]
+  jmx_exporter_enabled                      = true
+  node_exporter_enabled                     = true
+  enhanced_monitoring                       = "PER_TOPIC_PER_PARTITION"
+}

--- a/github.com_outshift-platform_gh_actions_org_secrets.tf
+++ b/github.com_outshift-platform_gh_actions_org_secrets.tf
@@ -1,0 +1,58 @@
+data "vault_generic_secret" "gha_ci_secrets" {
+  provider = vault.eticloud
+  path     = "ci/gha/gh-actions"
+}
+
+data "github_actions_organization_public_key" "gha_org_public_key" {
+}
+
+data "sodium_encrypted_item" "GHCR_TOKEN" {
+  public_key_base64 = data.github_actions_organization_public_key.gha_org_public_key.key
+  content_base64 = base64encode(data.vault_generic_secret.generic_user_gh_token.data["GHA_GHCR_TOKEN"])
+}
+
+data "sodium_encrypted_item" "GHCR_USERNAME" {
+  public_key_base64 = data.github_actions_organization_public_key.gha_org_public_key.key
+  content_base64 = base64encode(data.vault_generic_secret.gha_ci_secrets.data["GHEC_USERNAME"])
+}
+
+data "sodium_encrypted_item" "VAULT_APPROLE_ROLE_ID" {
+  public_key_base64 = data.github_actions_organization_public_key.gha_org_public_key.key
+  content_base64 = base64encode(vault_approle_auth_backend_role.github_actions.role_id)
+}
+
+data "sodium_encrypted_item" "VAULT_APPROLE_SECRET_ID" {
+  public_key_base64 = data.github_actions_organization_public_key.gha_org_public_key.key
+  content_base64 = base64encode(vault_approle_auth_backend_role_secret_id.github_actions.secret_id)
+}
+
+data "sodium_encrypted_item" "WEBEX_PLATFORM_NOTIFICATION_ROOM_ID" {
+  public_key_base64 = data.github_actions_organization_public_key.gha_org_public_key.key
+  content_base64 = base64encode(data.vault_generic_secret.gha_ci_secrets.data["WEBEX_PLATFORM_NOTIFICATION_ROOM_ID"])
+}
+
+data "sodium_encrypted_item" "WEBEX_TOKEN" {
+  public_key_base64 = data.github_actions_organization_public_key.gha_org_public_key.key
+  content_base64 = base64encode(data.vault_generic_secret.gha_ci_secrets.data["WEBEX_TOKEN"])
+}
+
+locals {
+  github_secrets = {
+    "GHCR_TOKEN" = data.sodium_encrypted_item.GHCR_TOKEN.encrypted_value_base64
+    "GHCR_USERNAME" = data.sodium_encrypted_item.GHCR_USERNAME.encrypted_value_base64
+    "VAULT_APPROLE_ROLE_ID" = data.sodium_encrypted_item.VAULT_APPROLE_ROLE_ID.encrypted_value_base64
+    "VAULT_APPROLE_SECRET_ID" = data.sodium_encrypted_item.VAULT_APPROLE_SECRET_ID.encrypted_value_base64
+    "WEBEX_PLATFORM_NOTIFICATION_ROOM_ID" = data.sodium_encrypted_item.WEBEX_PLATFORM_NOTIFICATION_ROOM_ID.encrypted_value_base64
+    "WEBEX_TOKEN" = data.sodium_encrypted_item.WEBEX_TOKEN.encrypted_value_base64
+  }
+}
+resource "github_actions_organization_secret" "dynamic" {
+  for_each         = local.github_secrets
+  secret_name      = each.key
+  visibility       = "private"
+  encrypted_value  = each.value
+
+  lifecycle {
+    ignore_changes = [ encrypted_value ]
+  }
+}

--- a/github.com_outshift-platform_gh_actions_org_variables.tf
+++ b/github.com_outshift-platform_gh_actions_org_variables.tf
@@ -1,0 +1,24 @@
+locals {
+  github_variables = {
+    "DEFAULT_RUNNER_GROUP" = "outshift-platform-large-runners"
+    "ECR_PUBLIC_REGISTRY_ALIAS" = "ciscoeti"
+    "GHCR_REGISTRY" = "ghcr.io/cisco-eti"
+    "LATEST_SRE_BUILD_IMAGE" = "ghcr.io/cisco-eti/sre-pipeline-docker:2024.05.30-e409a0c-90"
+    "SONAR_PROPERTIES_FILE" = "build/sonar-project.properties"
+    "SONAR_SCANNER_CLI_DOCKER_IMAGE" = "ghcr.io/cisco-eti/sonar-scanner-cli:latest"
+    "SRE_BUILD_IMAGE" = "ghcr.io/cisco-eti/sre-pipeline-docker:2024.05.30-e409a0c-91"
+    "UBUNTU_RUNNER" = "ubuntu-latest"
+    "KEEPER_URL" = "https://keeper.cisco.com"
+    "VAULT_ADDR" = "https://keeper.cisco.com"
+    "VAULT_NAMESPACE" = "eticloud"
+    "VAULT_SECRET_PATH" = "ci/data/gha/gh-actions"
+  }
+}
+
+resource "github_actions_organization_variable" "dynamic" {
+  for_each      = local.github_variables
+
+  variable_name = each.key
+  visibility    = "private"
+  value         = each.value
+}

--- a/github.com_outshift-platform_gh_actions_runner_group.tf
+++ b/github.com_outshift-platform_gh_actions_runner_group.tf
@@ -1,0 +1,4 @@
+resource "github_actions_runner_group" "SRE-Large-Runners" {
+  name                    = "SRE-Large-Runners"
+  visibility              = "all"
+}

--- a/github.com_outshift-platform_gh_actions_vault_approle.tf
+++ b/github.com_outshift-platform_gh_actions_vault_approle.tf
@@ -1,0 +1,44 @@
+data "vault_auth_backend" "approle" {
+  provider = vault.eticloud
+  path = "approle"
+}
+
+resource "vault_policy" "github_actions" {
+  provider = vault.eticloud
+  name = "outshift-platform-github-actions"
+  policy = <<EOF
+path "ci/data/gha/gh-actions" {
+  capabilities = ["read"]
+}
+path "auth/approle/role/github-actions" {
+  capabilities = ["read"]
+}
+path "ci-aws-eti-ci/*" {
+  capabilities = ["read"]
+}
+EOF
+}
+
+resource "vault_approle_auth_backend_role" "github_actions" {
+  provider = vault.eticloud
+  backend        = data.vault_auth_backend.approle.path
+  role_name      = "github-actions"
+  token_policies = [vault_policy.github_actions.name]
+}
+
+resource "vault_approle_auth_backend_role_secret_id" "github_actions" {
+  provider = vault.eticloud
+  backend = data.vault_auth_backend.approle.path
+  role_name = vault_approle_auth_backend_role.github_actions.role_name
+}
+
+resource "vault_generic_secret" "gha_ci_secrets" {
+  provider = vault.eticloud
+  path     = "ci/gha/approle"
+  data_json = <<EOT
+  {
+    "VAULT_APPROLE_ROLE_ID": "${vault_approle_auth_backend_role.github_actions.role_id}",
+    "VAULT_APPROLE_SECRET_ID": "${vault_approle_auth_backend_role_secret_id.github_actions.secret_id}"
+  }
+  EOT
+}

--- a/github.com_outshift-platform_provider.tf
+++ b/github.com_outshift-platform_provider.tf
@@ -1,0 +1,40 @@
+terraform {
+  backend "s3" {
+    bucket = "eticloud-tf-state-prod"
+    key    = "terraform-state/github.com/outshift-platform/backend.tfstate"
+    region = "us-east-2"
+  }
+  required_providers {
+    sodium = {
+      source  = "killmeplz/sodium"
+      version = "~> 0.0.3"
+    }
+    github = {
+      source  = "integrations/github"
+      version = "~> 6.0"
+    }
+  }
+}
+provider "vault" {
+  alias     = "eticloud_teamsecrets"
+  address   = "https://keeper.cisco.com"
+  namespace = "eticloud/teamsecrets"
+}
+
+provider "vault" {
+  alias     = "eticloud"
+  address   = "https://keeper.cisco.com"
+  namespace = "eticloud"
+}
+
+data "vault_generic_secret" "generic_user_gh_token" {
+  provider = vault.eticloud_teamsecrets
+  path     = "secret/generic_users/eti-sre-cicd.gen"
+}
+
+# Configure the GitHub Provider
+provider "github" {
+  token = data.vault_generic_secret.generic_user_gh_token.data["TERRAFORM_ADMIN_GHEC_PAT"]
+  owner = "outshift-platform"   # CHANGE_ME: The owner of the repository
+}
+


### PR DESCRIPTION
## Fixes/Implements # (JIRA issue if applicable)  

1. Destroy the `rosey-eu` S3 bucket and related resources, no longer needed.
2. Step 1 of https://docs.aws.amazon.com/datasync/latest/userguide/tutorial_s3-s3-cross-account-transfer.html#s3-s3-cross-account-create-iam-role-source-account. 
PLG Analytics use an S3 bucket located in their AWS account. 

### Description/Justification

(Why is this change needed? Which team might need it? etc...)  


### If the (atlantis) plan is destroying resources, reason for deletion  

No longer collecting EU logs for Rosey/PLG

### Additional details

- [x] `terraform fmt` was applied
- [x] All atlantis plans can be applied
- [x] (For reviewers) I have verified the resource changes
