### PR TITLE
feat(data-sync): enable sync between 2 S3 buckets in 2 AWS accounts

### DIFF
--- a/aws_eticloud-plg-prod_us-east-1_s3_backend.tf
+++ b/aws_eticloud-plg-prod_us-east-1_s3_backend.tf
@@ -1,0 +1,8 @@
+# AWS account: eticloud
+terraform {
+  backend "s3" {
+    bucket = "eticloud-tf-state-prod"
+    key    = "terraform-state/eticloud-plg-prod/s3/s3.tfstate"
+    region = "us-east-2"
+  }
+}

--- a/aws_eticloud-plg-prod_us-east-1_s3_locals.tf
+++ b/aws_eticloud-plg-prod_us-east-1_s3_locals.tf
@@ -1,0 +1,3 @@
+locals {
+  cnapp_prod_account_id = "590184006103"
+}

--- a/aws_eticloud-plg-prod_us-east-1_s3_providers.tf
+++ b/aws_eticloud-plg-prod_us-east-1_s3_providers.tf
@@ -1,0 +1,25 @@
+provider "vault" {
+  address   = "https://keeper.cisco.com"
+  namespace = "eticloud/eticcprod"
+}
+
+data "vault_generic_secret" "aws_infra_credential" {
+  path = "secret/eticcprod/infra/eticloud-plg-prod/aws"
+}
+
+provider "aws" {
+  access_key = data.vault_generic_secret.aws_infra_credential.data["AWS_ACCESS_KEY_ID"]
+  secret_key = data.vault_generic_secret.aws_infra_credential.data["AWS_SECRET_ACCESS_KEY"]
+  region     = "us-east-1"
+
+  default_tags {
+    tags = {
+      ApplicationName    = "S3 bucket - ETI Plg prod"
+      CiscoMailAlias     = "eti-sre-admins@cisco.com"
+      DataClassification = "Cisco Confidential"
+      DataTaxonomy       = "Cisco Operations Data"
+      EnvironmentName    = "Prod"
+      ResourceOwner      = "ETI SRE"
+    }
+  }
+}

--- a/aws_eticloud-plg-prod_us-east-1_s3_providers.tf
+++ b/aws_eticloud-plg-prod_us-east-1_s3_providers.tf
@@ -14,12 +14,13 @@ provider "aws" {
 
   default_tags {
     tags = {
-      ApplicationName    = "S3 bucket - ETI Plg prod"
-      CiscoMailAlias     = "eti-sre-admins@cisco.com"
-      DataClassification = "Cisco Confidential"
-      DataTaxonomy       = "Cisco Operations Data"
-      EnvironmentName    = "Prod"
-      ResourceOwner      = "ETI SRE"
+      ApplicationName    = "Panoptica"
+      CiscoMailAlias     = "outshift_plg_data@cisco.com"
+      DataClassification = "Cisco Highly Confidential"
+      DataTaxonomy       = "Product Usage Data"
+      Environment        = "Prod"
+      ResourceOwner      = "Outshift PLG"
+      SecurityCompliance = "Yes"
     }
   }
 }

--- a/aws_eticloud-plg-prod_us-east-1_s3_s3.tf
+++ b/aws_eticloud-plg-prod_us-east-1_s3_s3.tf
@@ -3,7 +3,7 @@ import {
   id = "outshift-product-analytics-s3-bucket"
 }
 
-data "aws_s3_bucket" "outshift_product_analytics" {
+resource "aws_s3_bucket" "outshift_product_analytics" {
   bucket = "outshift-product-analytics-s3-bucket"
 }
 
@@ -27,13 +27,13 @@ data "aws_iam_policy_document" "data_sync_from_cnapp_prod_account" {
     ]
 
     resources = [
-      data.aws_s3_bucket.outshift_product_analytics.arn,
-      "${data.aws_s3_bucket.outshift_product_analytics.arn}/Rosey/*",
+      aws_s3_bucket.outshift_product_analytics.arn,
+      "${aws_s3_bucket.outshift_product_analytics.arn}/Rosey/*",
     ]
   }
 }
 
 resource "aws_s3_bucket_policy" "data_sync_from_cnapp_prod_account" {
-  bucket = data.aws_s3_bucket.outshift_product_analytics.id
+  bucket = aws_s3_bucket.outshift_product_analytics.id
   policy = data.aws_iam_policy_document.data_sync_from_cnapp_prod_account.json
 }

--- a/aws_eticloud-plg-prod_us-east-1_s3_s3.tf
+++ b/aws_eticloud-plg-prod_us-east-1_s3_s3.tf
@@ -3,6 +3,10 @@ import {
   id = "outshift-product-analytics-s3-bucket"
 }
 
+data "aws_s3_bucket" "outshift_product_analytics" {
+  bucket = "outshift-product-analytics-s3-bucket"
+}
+
 data "aws_iam_policy_document" "data_sync_from_cnapp_prod_account" {
   statement {
     principals {
@@ -23,13 +27,13 @@ data "aws_iam_policy_document" "data_sync_from_cnapp_prod_account" {
     ]
 
     resources = [
-      aws_s3_bucket.outshift_product_analytics.arn,
-      "${aws_s3_bucket.outshift_product_analytics.arn}/Rosey/*",
+      data.aws_s3_bucket.outshift_product_analytics.arn,
+      "${data.aws_s3_bucket.outshift_product_analytics.arn}/Rosey/*",
     ]
   }
 }
 
 resource "aws_s3_bucket_policy" "data_sync_from_cnapp_prod_account" {
-  bucket = aws_s3_bucket.outshift_product_analytics.id
+  bucket = data.aws_s3_bucket.outshift_product_analytics.id
   policy = data.aws_iam_policy_document.allow_access_from_another_account.json
 }

--- a/aws_eticloud-plg-prod_us-east-1_s3_s3.tf
+++ b/aws_eticloud-plg-prod_us-east-1_s3_s3.tf
@@ -1,0 +1,34 @@
+resource "aws_s3_bucket" "outshift_product_analytics" {
+  bucket = "outshift-product-analytics-s3-bucket"
+}
+
+data "aws_iam_policy_document" "data_sync_from_cnapp_prod_account" {
+  statement {
+    principals {
+      type        = "AWS"
+      identifiers = ["arn:aws:iam::${local.cnapp_prod_account_id}:role/source-datasync-role"]
+    }
+
+    actions = [
+      "s3:GetBucketLocation",
+      "s3:ListBucket",
+      "s3:ListBucketMultipartUploads",
+      "s3:AbortMultipartUpload",
+      "s3:GetObject",
+      "s3:ListMultipartUploadParts",
+      "s3:PutObject",
+      "s3:GetObjectTagging",
+      "s3:PutObjectTagging"
+    ]
+
+    resources = [
+      aws_s3_bucket.outshift_product_analytics.arn,
+      "${aws_s3_bucket.outshift_product_analytics.arn}/Rosey/*",
+    ]
+  }
+}
+
+resource "aws_s3_bucket_policy" "data_sync_from_cnapp_prod_account" {
+  bucket = aws_s3_bucket.outshift_product_analytics.id
+  policy = data.aws_iam_policy_document.allow_access_from_another_account.json
+}

--- a/aws_eticloud-plg-prod_us-east-1_s3_s3.tf
+++ b/aws_eticloud-plg-prod_us-east-1_s3_s3.tf
@@ -35,5 +35,5 @@ data "aws_iam_policy_document" "data_sync_from_cnapp_prod_account" {
 
 resource "aws_s3_bucket_policy" "data_sync_from_cnapp_prod_account" {
   bucket = data.aws_s3_bucket.outshift_product_analytics.id
-  policy = data.aws_iam_policy_document.allow_access_from_another_account.json
+  policy = data.aws_iam_policy_document.data_sync_from_cnapp_prod_account.json
 }

--- a/aws_eticloud-plg-prod_us-east-1_s3_s3.tf
+++ b/aws_eticloud-plg-prod_us-east-1_s3_s3.tf
@@ -1,5 +1,6 @@
-resource "aws_s3_bucket" "outshift_product_analytics" {
-  bucket = "outshift-product-analytics-s3-bucket"
+import {
+  to = aws_s3_bucket.outshift_product_analytics
+  id = "outshift-product-analytics-s3-bucket"
 }
 
 data "aws_iam_policy_document" "data_sync_from_cnapp_prod_account" {

--- a/aws_eticloud-plg-prod_us-east-1_s3_s3.tf
+++ b/aws_eticloud-plg-prod_us-east-1_s3_s3.tf
@@ -6,7 +6,7 @@ data "aws_iam_policy_document" "data_sync_from_cnapp_prod_account" {
   statement {
     principals {
       type        = "AWS"
-      identifiers = ["arn:aws:iam::${local.cnapp_prod_account_id}:role/source-datasync-role"]
+      identifiers = ["arn:aws:iam::${local.cnapp_prod_account_id}:role/DataSync-cnapp-prod"]
     }
 
     actions = [

--- a/aws_eticloud-plg-prod_us-east-1_s3_versions.tf
+++ b/aws_eticloud-plg-prod_us-east-1_s3_versions.tf
@@ -1,0 +1,9 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+  required_version = ">= 1.5.5"
+}


### PR DESCRIPTION
## Fixes/Implements # (JIRA issue if applicable)  

Import existing S3 bucket and enable data-sync, follow up from #552.
Tag updates to fix typos as they were manually added in the AWS console. 

### Description/Justification

(Why is this change needed? Which team might need it? etc...)  

Request from PLG Analytics

### If the (atlantis) plan is destroying resources, reason for deletion  


### Additional details

- [x] `terraform fmt` was applied
- [x] All atlantis plans can be applied
- [ ] (For reviewers) I have verified the resource changes