### PR TITLE
feat(data-sync): actually enable data-sync cross accounts

### DIFF
--- a/aws_cnapp-prod_rosey-logs_iam.tf
+++ b/aws_cnapp-prod_rosey-logs_iam.tf
@@ -67,9 +67,9 @@ resource "aws_iam_role_policy_attachment" "rosey_logs" {
 
 
 # Sync data with outshift-product-analytics-s3-bucket S3 bucket located in eticloud-plg-prod account
-resource "aws_iam_policy" "datasync_cnapp_prod" {
-  name        = "WriteToPLGAnalyticsS3Bucket"
-  description = "IAM policy that allows to sync data across 2 S3 buckets in 2 AWS accounts"
+resource "aws_iam_role_policy" "datasync_cnapp_prod" {
+  name = "WriteToPLGAnalyticsS3Bucket"
+  role = aws_iam_role.datasync_cnapp_prod.id
 
   policy = jsonencode({
     Version = "2012-10-17",


### PR DESCRIPTION
## Fixes/Implements # (JIRA issue if applicable)

Still for https://cisco-eti.atlassian.net/browse/SRE-7888
Step 4: https://docs.aws.amazon.com/datasync/latest/userguide/tutorial_s3-s3-cross-account-transfer.html#s3-s3-cross-account-create-iam-role-source-account

### Description/Justification

(Why is this change needed? Which team might need it? etc...)

Request from PLG Analytics

### If the (atlantis) plan is destroying resources, reason for deletion


### Additional details

- [x] `terraform fmt` was applied
- [x] All atlantis plans can be applied
- [ ] (For reviewers) I have verified the resource changes
