### PR TITLE
fix(dragonfly-prod): update dragonfly-event-manager-role to include c…

### DIFF
--- a/aws_dragonfly-prod_iam_dragonfly-event-manager-role-euc1_role.tf
+++ b/aws_dragonfly-prod_iam_dragonfly-event-manager-role-euc1_role.tf
@@ -80,7 +80,9 @@ resource "aws_iam_role" "role" {
     policy = data.aws_iam_policy_document.policy.json
   }
 
-  managed_policy_arns = []
+  managed_policy_arns = [
+    aws_iam_policy.portshift_sqs_policy.arn
+  ]
 }
 
 data "aws_iam_policy_document" "sqs_policy" {
@@ -91,7 +93,7 @@ data "aws_iam_policy_document" "sqs_policy" {
       "sqs:*"
     ]
     resources = [
-      "arn:aws:sqs:eu-central-1:975854676552:queue-eventsForwarderTopic-lightspin"
+      "arn:aws:sqs:eu-central-1:975854676552:queue-eventsForwarderTopic-eu-production"
     ]
   }
 }

--- a/aws_dragonfly-prod_iam_dragonfly-event-manager-role-use2_role.tf
+++ b/aws_dragonfly-prod_iam_dragonfly-event-manager-role-use2_role.tf
@@ -93,7 +93,7 @@ data "aws_iam_policy_document" "sqs_policy" {
       "sqs:*"
     ]
     resources = [
-      "arn:aws:sqs:us-east-1:975854676552:queue-eventsForwarderTopic-production"
+      "arn:aws:sqs:us-east-2:975854676552:queue-eventsForwarderTopic-production"
     ]
   }
 }

--- a/aws_dragonfly-prod_iam_dragonfly-event-manager-role-use2_role.tf
+++ b/aws_dragonfly-prod_iam_dragonfly-event-manager-role-use2_role.tf
@@ -80,7 +80,9 @@ resource "aws_iam_role" "role" {
     policy = data.aws_iam_policy_document.policy.json
   }
 
-  managed_policy_arns = []
+  managed_policy_arns = [
+    aws_iam_policy.portshift_sqs_policy.arn
+  ]
 }
 
 data "aws_iam_policy_document" "sqs_policy" {


### PR DESCRIPTION
- CDR uses an SQS queue in cwpp-prod account for communications
- Allow CDR K8s clusters to access SQS queue

## Fixes/Implements # (JIRA issue if applicable)  


### Description/Justification

(Why is this change needed? Which team might need it? etc...)  


### If the (atlantis) plan is destroying resources, reason for deletion  


### Additional details

- [x] `terraform fmt` was applied
- [x] All atlantis plans can be applied
- [x] (For reviewers) I have verified the resource changes
