### PR TITLE
feat(dragonfly): allow service account dragonfly-ml-inferenceclient to assume ml-inference-client role

### DIFF
--- a/aws_dragonfly-dev_iam_ml-inference-client-role_locals.tf
+++ b/aws_dragonfly-dev_iam_ml-inference-client-role_locals.tf
@@ -11,5 +11,8 @@ locals {
   dragonfly_msk_cluster_name = "dragonfly-msk-1"
 
   dragonfly_backend_namespace = "dragonfly-backend"
-  service_account             = "${local.dragonfly_backend_namespace}:dragonfly-ml-inferenceclient-a-dev-app"
+  service_accounts            = [
+    "system:serviceaccount:${local.dragonfly_backend_namespace}:dragonfly-ml-inferenceclient-a-dev-app",
+    "system:serviceaccount:${local.dragonfly_backend_namespace}:dragonfly-ml-inferenceclient",
+  ]
 }

--- a/aws_dragonfly-dev_iam_ml-inference-client-role_locals.tf
+++ b/aws_dragonfly-dev_iam_ml-inference-client-role_locals.tf
@@ -1,7 +1,7 @@
 locals {
-  aws_account        = "dragonfly-dev"
-  role_name          = "ml-inferenceclient-role"
-  role_description   = "IAM Role for inference client service"
+  aws_account      = "dragonfly-dev"
+  role_name        = "ml-inferenceclient-role"
+  role_description = "IAM Role for inference client service"
 
   # AWS EKS Cluster
   cluster_name = "eks-dragonfly-dev-2"
@@ -11,7 +11,7 @@ locals {
   dragonfly_msk_cluster_name = "dragonfly-msk-1"
 
   dragonfly_backend_namespace = "dragonfly-backend"
-  service_accounts            = [
+  service_accounts = [
     "system:serviceaccount:${local.dragonfly_backend_namespace}:dragonfly-ml-inferenceclient-a-dev-app",
     "system:serviceaccount:${local.dragonfly_backend_namespace}:dragonfly-ml-inferenceclient",
   ]

--- a/aws_dragonfly-dev_iam_ml-inference-client-role_role.tf
+++ b/aws_dragonfly-dev_iam_ml-inference-client-role_role.tf
@@ -10,12 +10,12 @@ data "aws_iam_policy_document" "assume_role_policy" {
     actions = ["sts:AssumeRoleWithWebIdentity"]
     condition {
       test     = "StringEquals"
-      values = ["sts.amazonaws.com"]
+      values   = ["sts.amazonaws.com"]
       variable = "${local.oidc_id}:aud"
     }
     condition {
       test     = "StringEquals"
-      values = local.service_accounts
+      values   = local.service_accounts
       variable = "${local.oidc_id}:sub"
     }
   }

--- a/aws_dragonfly-dev_iam_ml-inference-client-role_role.tf
+++ b/aws_dragonfly-dev_iam_ml-inference-client-role_role.tf
@@ -15,7 +15,7 @@ data "aws_iam_policy_document" "assume_role_policy" {
     }
     condition {
       test     = "StringEquals"
-      values = ["system:serviceaccount:${local.service_account}"]
+      values = local.service_accounts
       variable = "${local.oidc_id}:sub"
     }
   }


### PR DESCRIPTION
## Fixes/Implements #EXP-3688

### Allow service account dragonfly-ml-inferenceclient to assume ml-inference-client role

Keeping both service accounts for the moment, then I'll remove `dragonfly-ml-inferenceclient-a-dev-app` once we are sure it is working.

### Additional details

- [x] `terraform fmt` was applied
- [x] All atlantis plans can be applied
- [ ] (For reviewers) I have verified the resource changes
