### PR TITLE
chore(AMI): fix CVE - motf-prod-use2-1

### DIFF
--- a/aws_motific-prod_us-east-2_eks_motf-prod-use2-1_main.tf
+++ b/aws_motific-prod_us-east-2_eks_motf-prod-use2-1_main.tf
@@ -13,7 +13,7 @@ locals {
 }
 
 module "eks_all_in_one" {
-  source           = "git::https://github.com/cisco-eti/sre-tf-module-eks-allinone.git?ref=0.6.1"
+  source           = "git::https://github.com/cisco-eti/sre-tf-module-eks-allinone.git?ref=0.6.0"
   name             = local.name             # EKS cluster name
   region           = local.region           # AWS provider region
   aws_account_name = local.aws_account_name # AWS account name

--- a/aws_motific-prod_us-east-2_eks_motf-prod-use2-1_main.tf
+++ b/aws_motific-prod_us-east-2_eks_motf-prod-use2-1_main.tf
@@ -13,7 +13,7 @@ locals {
 }
 
 module "eks_all_in_one" {
-  source           = "git::https://github.com/cisco-eti/sre-tf-module-eks-allinone.git?ref=latest"
+  source           = "git::https://github.com/cisco-eti/sre-tf-module-eks-allinone.git?ref=0.6.1"
   name             = local.name             # EKS cluster name
   region           = local.region           # AWS provider region
   aws_account_name = local.aws_account_name # AWS account name


### PR DESCRIPTION
## Fixes/Implements # (JIRA issue if applicable) 

[Wiz link](https://app.wiz.io/issues#%7E%28issue%7E%2710c60949-1e18-4cd7-b2d3-befb88c47009%7Efilters%7E%28status%7E%28equals%7E%28%7E%27OPEN%7E%27IN_PROGRESS%29%29%29%7Eentity%7E%28%7E%27acad466f-9aa9-55ca-bfdf-51b9726e5016*2cSECURITY_TOOL_FINDING%29%29)

### Description/Justification

(Why is this change needed? Which team might need it? etc...)

Promotes an AMI that is more recent (the most recent at this point).

### If the (atlantis) plan is destroying resources, reason for deletion

N/A

### Additional details

- [x] `terraform fmt` was applied
- [x] All atlantis plans can be applied
- [ ] (For reviewers) I have verified the resource changes