### PR TITLE
feat(dragonfly): allow service account dragonfly-ml-inferenceclient to assume ml-inference-client role

### DIFF
--- a/aws_dragonfly-dev_iam_ml-inference-client-role_dependencies.tf
+++ b/aws_dragonfly-dev_iam_ml-inference-client-role_dependencies.tf
@@ -1,5 +1,5 @@
-data aws_caller_identity current {}
-data aws_region current {}
+data "aws_caller_identity" "current" {}
+data "aws_region" "current" {}
 
 data "aws_eks_cluster" "cluster" {
   name = local.cluster_name

--- a/aws_dragonfly-dev_iam_ml-inference-client-role_locals.tf
+++ b/aws_dragonfly-dev_iam_ml-inference-client-role_locals.tf
@@ -1,0 +1,18 @@
+locals {
+  aws_account        = "dragonfly-dev"
+  role_name          = "ml-inferenceclient-role"
+  role_description   = "IAM Role for inference client service"
+
+  # AWS EKS Cluster
+  cluster_name = "eks-dragonfly-dev-2"
+  oidc_id      = trimprefix(data.aws_eks_cluster.cluster.identity[0].oidc[0].issuer, "https://")
+
+  # AWS MSK Cluster
+  dragonfly_msk_cluster_name = "dragonfly-msk-1"
+
+  dragonfly_backend_namespace = "dragonfly-backend"
+  service_accounts            = [
+    "system:serviceaccount:${local.dragonfly_backend_namespace}:dragonfly-ml-inferenceclient-a-dev-app",
+    "system:serviceaccount:${local.dragonfly_backend_namespace}:dragonfly-ml-inferenceclient",
+  ]
+}

--- a/aws_dragonfly-dev_iam_ml-inference-client-role_locals.tf
+++ b/aws_dragonfly-dev_iam_ml-inference-client-role_locals.tf
@@ -1,7 +1,7 @@
 locals {
-  aws_account        = "dragonfly-dev"
-  role_name          = "ml-inferenceclient-role"
-  role_description   = "IAM Role for inference client service"
+  aws_account      = "dragonfly-dev"
+  role_name        = "ml-inferenceclient-role"
+  role_description = "IAM Role for inference client service"
 
   # AWS EKS Cluster
   cluster_name = "eks-dragonfly-dev-2"
@@ -11,7 +11,7 @@ locals {
   dragonfly_msk_cluster_name = "dragonfly-msk-1"
 
   dragonfly_backend_namespace = "dragonfly-backend"
-  service_accounts            = [
+  service_accounts = [
     "system:serviceaccount:${local.dragonfly_backend_namespace}:dragonfly-ml-inferenceclient-a-dev-app",
     "system:serviceaccount:${local.dragonfly_backend_namespace}:dragonfly-ml-inferenceclient",
   ]

--- a/aws_dragonfly-dev_iam_ml-inference-client-role_role.tf
+++ b/aws_dragonfly-dev_iam_ml-inference-client-role_role.tf
@@ -10,12 +10,12 @@ data "aws_iam_policy_document" "assume_role_policy" {
     actions = ["sts:AssumeRoleWithWebIdentity"]
     condition {
       test     = "StringEquals"
-      values = ["sts.amazonaws.com"]
+      values   = ["sts.amazonaws.com"]
       variable = "${local.oidc_id}:aud"
     }
     condition {
       test     = "StringEquals"
-      values = local.service_accounts
+      values   = local.service_accounts
       variable = "${local.oidc_id}:sub"
     }
   }

--- a/aws_dragonfly-dev_iam_ml-inference-client-role_role.tf
+++ b/aws_dragonfly-dev_iam_ml-inference-client-role_role.tf
@@ -1,0 +1,82 @@
+data "aws_iam_policy_document" "assume_role_policy" {
+  statement {
+    effect = "Allow"
+    principals {
+      type = "Federated"
+      identifiers = [
+        "arn:aws:iam::${data.aws_caller_identity.current.account_id}:oidc-provider/${local.oidc_id}",
+      ]
+    }
+    actions = ["sts:AssumeRoleWithWebIdentity"]
+    condition {
+      test     = "StringEquals"
+      values = ["sts.amazonaws.com"]
+      variable = "${local.oidc_id}:aud"
+    }
+    condition {
+      test     = "StringEquals"
+      values = local.service_accounts
+      variable = "${local.oidc_id}:sub"
+    }
+  }
+}
+
+data "aws_iam_policy_document" "policy" {
+  statement {
+    sid = "access"
+
+    actions = [
+      "kafka-cluster:Connect",
+    ]
+
+    resources = [
+      "arn:aws:kafka:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:cluster/${data.aws_msk_cluster.dragonfly_msk_1.cluster_name}/${data.aws_msk_cluster.dragonfly_msk_1.cluster_uuid}"
+    ]
+
+    effect = "Allow"
+  }
+
+  statement {
+    sid = "topic"
+
+    actions = [
+      "kafka-cluster:DescribeTopic",
+      "kafka-cluster:ReadData",
+    ]
+
+    resources = [
+      "arn:aws:kafka:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:topic/${data.aws_msk_cluster.dragonfly_msk_1.cluster_name}/${data.aws_msk_cluster.dragonfly_msk_1.cluster_uuid}/kg-node*",
+      "arn:aws:kafka:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:topic/${data.aws_msk_cluster.dragonfly_msk_1.cluster_name}/${data.aws_msk_cluster.dragonfly_msk_1.cluster_uuid}/kg-edge*",
+    ]
+
+    effect = "Allow"
+  }
+
+  statement {
+    sid = "groups"
+
+    actions = [
+      "kafka-cluster:AlterGroup",
+      "kafka-cluster:DescribeGroup",
+    ]
+
+    resources = [
+      "arn:aws:kafka:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:group/${data.aws_msk_cluster.dragonfly_msk_1.cluster_name}/${data.aws_msk_cluster.dragonfly_msk_1.cluster_uuid}/*",
+    ]
+
+    effect = "Allow"
+  }
+}
+
+resource "aws_iam_role" "role" {
+  name        = local.role_name
+  description = local.role_description
+
+  assume_role_policy = data.aws_iam_policy_document.assume_role_policy.json
+  inline_policy {
+    name   = "inference-client-policy"
+    policy = data.aws_iam_policy_document.policy.json
+  }
+
+  managed_policy_arns = []
+}


### PR DESCRIPTION
## Fixes/Implements #EXP-3688


### Description/Justification

(Why is this change needed? Which team might need it? etc...)  


### If the (atlantis) plan is destroying resources, reason for deletion  


### Additional details

- [x] `terraform fmt` was applied
- [x] All atlantis plans can be applied
- [ ] (For reviewers) I have verified the resource changes
