### PR TITLE
chore:  Migrate genie global RDS and DocumentDB to outshift-common-dev account

### DIFF
--- a/aws_outshift-common-dev_global_rds_global-rds-genie-dev-1_aurora-postgres.tf
+++ b/aws_outshift-common-dev_global_rds_global-rds-genie-dev-1_aurora-postgres.tf
@@ -1,0 +1,71 @@
+terraform {
+  backend "s3" {
+    bucket  = "eticloud-tf-state-nonprod"                                                
+    key     = "terraform-state/aws/eticloud/global/rds/global-rds-genie-dev-1.tfstate"     
+    region  = "us-east-2"                                                                  
+  }
+}
+
+#
+resource "aws_rds_global_cluster" "rds_global" {
+  # global RDS cluster aren't tied to a region so the provider should not matter here
+  provider                     = aws.primary
+  global_cluster_identifier    = local.rds_name
+  force_destroy                = true
+  source_db_cluster_identifier = module.rds_primary.cluster_arn
+  depends_on                   = [module.rds_primary]
+}
+
+resource "aws_kms_key" "primary" {
+  provider     = aws.primary
+  description  = "Multi-Region primary key for RDS global"
+  multi_region = true
+}
+
+resource "aws_kms_replica_key" "secondary" {
+  provider        = aws.secondary
+  description     = "Multi-Region replica key"
+  primary_key_arn = aws_kms_key.primary.arn
+}
+
+# Primary region us-east-2
+module "rds_primary" {
+  providers = {
+    aws = aws.primary
+  }
+  source              = "git::https://github.com/cisco-eti/sre-tf-module-aws-aurora-postgres?ref=2.0.2"
+  vpc_name            = local.data_primary_vpc
+  database_name       = "postgressql"
+  db_instance_type    = "db.r5.xlarge"
+  cluster_name        = "global-rds-genie-dev-use2-1"
+  kms_key_id          = aws_kms_key.primary.arn
+  master_username     = "root"
+  secret_path         = "secret/dev/infra/aurora-pg/us-east-2/outshift-common-dev/global-rds-genie-dev-use2-1"
+  db_engine_version   = "15.4"
+  db_allowed_cidrs    = [ data.aws_vpc.eks_primary_vpc.cidr_block, data.aws_vpc.eks_secondary_vpc.cidr_block ]
+  skip_final_snapshot = true
+}
+
+# Secondary region us-east-2
+module "rds_secondary" {
+  providers = {
+    aws = aws.secondary
+  }
+  source                    = "git::https://github.com/cisco-eti/sre-tf-module-aws-aurora-postgres?ref=2.0.2"
+  vpc_name                  = local.data_secondary_vpc
+  database_name             = null
+  global_cluster_identifier = aws_rds_global_cluster.rds_global.id
+  is_primary_cluster        = false
+  master_username           = null
+  db_instance_type          = "db.r5.xlarge"
+  # headless, no instances
+  instances                 = {}
+  cluster_name              = "global-rds-genie-dev-usw2-1"
+  kms_key_id                = aws_kms_replica_key.secondary.arn
+  secret_path               = "secret/dev/infra/aurora-pg/us-west-2/outshift-common-dev/global-rds-genie-dev-usw2-1"
+  db_engine_version         = "15.4"
+  db_allowed_cidrs          = [ data.aws_vpc.eks_primary_vpc.cidr_block, data.aws_vpc.eks_secondary_vpc.cidr_block ]
+  skip_final_snapshot       = true
+
+  depends_on = [module.rds_primary]
+}

--- a/aws_outshift-common-dev_global_rds_global-rds-genie-dev-1_data.tf
+++ b/aws_outshift-common-dev_global_rds_global-rds-genie-dev-1_data.tf
@@ -1,0 +1,20 @@
+data "vault_generic_secret" "aws_infra_credential" {
+  provider    = vault.eticloud
+  path        = "secret/infra/aws/${local.aws_account_name}/terraform_admin"
+}
+
+data "aws_vpc" "eks_primary_vpc" {
+  provider = aws.primary
+  filter {
+    name   = "tag:Name"
+    values = [local.eks_primary_vpc]
+  }
+}
+
+data "aws_vpc" "eks_secondary_vpc" {
+  provider = aws.secondary
+  filter {
+    name   = "tag:Name"
+    values = [local.eks_secondary_vpc]
+  }
+}

--- a/aws_outshift-common-dev_global_rds_global-rds-genie-dev-1_locals.tf
+++ b/aws_outshift-common-dev_global_rds_global-rds-genie-dev-1_locals.tf
@@ -1,0 +1,8 @@
+locals {
+  aws_account_name   = "outshift-common-dev"
+  data_primary_vpc   = "common-dev-use2-vpc-data"
+  data_secondary_vpc = "common-dev-usw2-vpc-data"
+  eks_primary_vpc    = "comn-dev-use2-1"
+  eks_secondary_vpc  = "comn-dev-usw2-1"
+  rds_name           = "global-rds-genie-dev-1"
+}

--- a/aws_outshift-common-dev_global_rds_global-rds-genie-dev-1_providers.tf
+++ b/aws_outshift-common-dev_global_rds_global-rds-genie-dev-1_providers.tf
@@ -1,0 +1,64 @@
+provider "vault" {
+  alias     = "eticloud"
+  address   = "https://keeper.cisco.com"
+  namespace = "eticloud"
+}
+
+provider "vault" {
+  alias     = "teamsecrets"
+  address   = "https://keeper.cisco.com"
+  namespace = "eticloud/teamsecrets"
+}
+
+provider "aws" {
+  alias       = "primary"
+  access_key  = data.vault_generic_secret.aws_infra_credential.data["AWS_ACCESS_KEY_ID"]
+  secret_key  = data.vault_generic_secret.aws_infra_credential.data["AWS_SECRET_ACCESS_KEY"]
+  region      = "us-east-2"
+  max_retries = 3
+  default_tags {
+    tags = {
+      ApplicationName    = "global-rds-genie-dev-1_primary"
+      CiscoMailAlias     = "eti-sre-admins@cisco.com"
+      DataClassification = "Cisco Confidential"
+      DataTaxonomy       = "Cisco Operations Data"
+      EnvironmentName    = "NonProd"
+      ResourceOwner      = "ETI SRE"
+    }
+  }
+}
+
+provider "aws" {
+  alias       = "secondary"
+  access_key  = data.vault_generic_secret.aws_infra_credential.data["AWS_ACCESS_KEY_ID"]
+  secret_key  = data.vault_generic_secret.aws_infra_credential.data["AWS_SECRET_ACCESS_KEY"]
+  region      = "us-west-2"
+  max_retries = 3
+  default_tags {
+    tags = {
+      ApplicationName    = "outshift_common_services"
+      Component          = "genie"
+      CiscoMailAlias     = "eti-sre-admins@cisco.com"
+      DataClassification = "Cisco Confidential"
+      DataTaxonomy       = "Cisco Operations Data"
+      EnvironmentName    = "NonProd"
+      ResourceOwner      = "ETI SRE"
+    }
+  }
+}
+
+terraform {
+  required_version = ">= 1.5.5"
+
+  required_providers {
+    aws = {
+      source                = "hashicorp/aws"
+      version               = "~> 5.0"
+      configuration_aliases = [aws.primary, aws.secondary]
+    }
+    vault = {
+      source  = "hashicorp/vault"
+      version = "~> 3.0"
+    }
+  }
+}


### PR DESCRIPTION
## Fixes/Implements # (JIRA issue if applicable)  


### Description/Justification

(Why is this change needed? Which team might need it? etc...)  


### If the (atlantis) plan is destroying resources, reason for deletion  


### Additional details

- [ ] `terraform fmt` was applied
- [ ] All atlantis plans can be applied
- [ ] (For reviewers) I have verified the resource changes
