### PR TITLE
chore: add eticloud/apps/ppu ESO for comn-dev-use2-1 cluster

### DIFF
--- a/aws_outshift-common-dev_us-east-2_eks_comn-dev-use2-1_eso.tf
+++ b/aws_outshift-common-dev_us-east-2_eks_comn-dev-use2-1_eso.tf
@@ -44,14 +44,6 @@ module "eso_eticloud_apps_appnet" {
   policies        = ["external-secrets-${local.name}"]
 }
 
-module "eso_eticloud_apps_research" {
-  source          = "git::https://github.com/cisco-eti/sre-tf-module-eso-access.git?ref=1.0.0"
-  cluster_name    = local.name
-  vault_namespace = "eticloud/apps/research"
-  kubernetes_host = data.aws_eks_cluster.cluster.endpoint
-  kubernetes_ca   = base64decode(data.vault_generic_secret.cluster_certificate.data["b64certificate"])
-  policies        = ["external-secrets-${local.name}"]
-}
 module "eso_eticloud_apps_sre" {
   source          = "git::https://github.com/cisco-eti/sre-tf-module-eso-access.git?ref=1.0.0"
   cluster_name    = local.name
@@ -113,4 +105,13 @@ module "eso_eticloud_apps_cil" {
   kubernetes_host = data.aws_eks_cluster.cluster.endpoint
   kubernetes_ca   = base64decode(data.vault_generic_secret.cluster_certificate.data["b64certificate"])
   policies        = ["external-secrets-${local.name}"]
+}
+
+module "eso_eticloud_apps_ppu" {
+  source               = "git::https://github.com/cisco-eti/sre-tf-module-eso-access.git?ref=1.0.0"
+  cluster_name         = local.name
+  vault_namespace      = "eticloud/apps/ppu"
+  kubernetes_host      = data.aws_eks_cluster.cluster.endpoint
+  kubernetes_ca        = base64decode(data.vault_generic_secret.cluster_certificate.data["b64certificate"])
+  policies             = ["external-secrets-${local.name}"]
 }

--- a/aws_outshift-common-dev_us-east-2_eks_comn-dev-use2-1_eso.tf
+++ b/aws_outshift-common-dev_us-east-2_eks_comn-dev-use2-1_eso.tf
@@ -44,6 +44,14 @@ module "eso_eticloud_apps_appnet" {
   policies        = ["external-secrets-${local.name}"]
 }
 
+module "eso_eticloud_apps_research" {
+  source          = "git::https://github.com/cisco-eti/sre-tf-module-eso-access.git?ref=1.0.0"
+  cluster_name    = local.name
+  vault_namespace = "eticloud/apps/research"
+  kubernetes_host = data.aws_eks_cluster.cluster.endpoint
+  kubernetes_ca   = base64decode(data.vault_generic_secret.cluster_certificate.data["b64certificate"])
+  policies        = ["external-secrets-${local.name}"]
+}
 module "eso_eticloud_apps_sre" {
   source          = "git::https://github.com/cisco-eti/sre-tf-module-eso-access.git?ref=1.0.0"
   cluster_name    = local.name

--- a/aws_outshift-common-dev_us-east-2_eks_comn-dev-use2-1_eso.tf
+++ b/aws_outshift-common-dev_us-east-2_eks_comn-dev-use2-1_eso.tf
@@ -36,7 +36,6 @@ module "eso_eticloud" {
 }
 
 module "eso_eticloud_apps_appnet" {
-  count = 0 # This module is not needed for this cluster
   source          = "git::https://github.com/cisco-eti/sre-tf-module-eso-access.git?ref=1.0.0"
   cluster_name    = local.name
   vault_namespace = "eticloud/apps/appnet"

--- a/aws_outshift-common-dev_us-east-2_eks_comn-dev-use2-1_eso.tf
+++ b/aws_outshift-common-dev_us-east-2_eks_comn-dev-use2-1_eso.tf
@@ -35,6 +35,16 @@ module "eso_eticloud" {
   policies        = ["external-secrets-${local.name}"]
 }
 
+module "eso_eticloud_apps_appnet" {
+  count = 0 # This module is not needed for this cluster
+  source          = "git::https://github.com/cisco-eti/sre-tf-module-eso-access.git?ref=1.0.0"
+  cluster_name    = local.name
+  vault_namespace = "eticloud/apps/appnet"
+  kubernetes_host = data.aws_eks_cluster.cluster.endpoint
+  kubernetes_ca   = base64decode(data.vault_generic_secret.cluster_certificate.data["b64certificate"])
+  policies        = ["external-secrets-${local.name}"]
+}
+
 module "eso_eticloud_apps_research" {
   source          = "git::https://github.com/cisco-eti/sre-tf-module-eso-access.git?ref=1.0.0"
   cluster_name    = local.name
@@ -43,7 +53,6 @@ module "eso_eticloud_apps_research" {
   kubernetes_ca   = base64decode(data.vault_generic_secret.cluster_certificate.data["b64certificate"])
   policies        = ["external-secrets-${local.name}"]
 }
-
 module "eso_eticloud_apps_sre" {
   source          = "git::https://github.com/cisco-eti/sre-tf-module-eso-access.git?ref=1.0.0"
   cluster_name    = local.name

--- a/aws_outshift-common-dev_us-east-2_eks_comn-dev-use2-1_eso.tf
+++ b/aws_outshift-common-dev_us-east-2_eks_comn-dev-use2-1_eso.tf
@@ -35,10 +35,10 @@ module "eso_eticloud" {
   policies        = ["external-secrets-${local.name}"]
 }
 
-module "eso_eticloud_apps_appnet" {
+module "eso_eticloud_apps_research" {
   source          = "git::https://github.com/cisco-eti/sre-tf-module-eso-access.git?ref=1.0.0"
   cluster_name    = local.name
-  vault_namespace = "eticloud/apps/appnet"
+  vault_namespace = "eticloud/apps/research"
   kubernetes_host = data.aws_eks_cluster.cluster.endpoint
   kubernetes_ca   = base64decode(data.vault_generic_secret.cluster_certificate.data["b64certificate"])
   policies        = ["external-secrets-${local.name}"]


### PR DESCRIPTION
## Fixes/Implements # (JIRA issue if applicable)  
Fix eticloud/apps/ppu secretstore access denial for this cluster.
Error in argocd: https://argocd-common.eticloud.io/applications/argocd/comn-dev-use2-1-external-secrets?view=tree&resource=&node=external-secrets.io%2FClusterSecretStore%2F%2Fvault-eticloud-apps-ppu%2F0&tab=events

### Description/Justification

[SRE-8913](https://cisco-eti.atlassian.net/browse/SRE-8913) - Matrix project apps migration to common dev cluster

### If the (atlantis) plan is destroying resources, reason for deletion  


### Additional details

- [ ] `terraform fmt` was applied
- [ ] All atlantis plans can be applied
- [ ] (For reviewers) I have verified the resource changes


[SRE-8913]: https://cisco-eti.atlassian.net/browse/SRE-8913?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ