### PR TITLE
fix: update policy to move groups automation to another path

### DIFF
--- a/keeper_namespaces_eticloud_root_main.tf
+++ b/keeper_namespaces_eticloud_root_main.tf
@@ -136,10 +136,10 @@ resource "vault_policy" "groups_automation_devs" {
   name   = "groups_automation_devs"
   policy = <<EOT
 # Common secrets
-path "secret/data/common/groups-automation/*" {
+path "secret/data/projects/groups-automation/*" {
   capabilities = ["update","delete","create","read", "list"]
 }
-path "secret/common/groups-automation/*" {
+path "secret/projects/groups-automation/*" {
   capabilities = ["update","delete","create","read", "list"]
 }
 


### PR DESCRIPTION
## Fixes/Implements # (JIRA issue if applicable)  


### Description/Justification

(Why is this change needed? Which team might need it? etc...)  


### If the (atlantis) plan is destroying resources, reason for deletion  


### Additional details

- [ ] `terraform fmt` was applied
- [ ] All atlantis plans can be applied
- [ ] (For reviewers) I have verified the resource changes
