### PR TITLE
chore: add vpc peering between the new eks clusters and mongodb vpc

### DIFF
--- a/aws_outshift-common-staging_global_cross-region-vpc-peering_cross-account_vpc-peering.tf
+++ b/aws_outshift-common-staging_global_cross-region-vpc-peering_cross-account_vpc-peering.tf
@@ -35,7 +35,7 @@ module "primary_eks_cluster_to_secondary"{
     }
   }
   accepter_vpc_name  = "prod-db-vpc-1"
-  requester_vpc_name  = "common-staging-use2-1"
+  requester_vpc_name  = "comn-staging-use2-1"
 }
 
 module "secondary_eks_cluster_to_secondary"{
@@ -51,5 +51,5 @@ module "secondary_eks_cluster_to_secondary"{
     }
   }
   accepter_vpc_name  = "prod-db-vpc-1"
-  requester_vpc_name  = "common-staging-usw2-1"
+  requester_vpc_name  = "comn-staging-usw2-1"
 }

--- a/aws_outshift-common-staging_global_cross-region-vpc-peering_cross-account_vpc-peering.tf
+++ b/aws_outshift-common-staging_global_cross-region-vpc-peering_cross-account_vpc-peering.tf
@@ -21,3 +21,35 @@ module "primary_cluster_to_secondary"{
   accepter_vpc_name  = "prod-db-vpc-1"
   requester_vpc_name  = "common-staging-use2-vpc-data"
 }
+
+module "primary_eks_cluster_to_secondary"{
+  source             = "git::https://github.com/cisco-eti/sre-tf-module-multi-region-vpc-peering.git?ref=1.1.1"
+  aws_accounts_to_regions = {
+    "accepter" = {
+      account_name = "eticloud"
+      region       = "us-east-2"
+    }
+    "requester" = {
+      account_name = "outshift-common-staging"
+      region       = "us-east-2"
+    }
+  }
+  accepter_vpc_name  = "prod-db-vpc-1"
+  requester_vpc_name  = "common-staging-use2-1"
+}
+
+module "secondary_eks_cluster_to_secondary"{
+  source             = "git::https://github.com/cisco-eti/sre-tf-module-multi-region-vpc-peering.git?ref=1.1.1"
+  aws_accounts_to_regions = {
+    "accepter" = {
+      account_name = "eticloud"
+      region       = "us-east-2"
+    }
+    "requester" = {
+      account_name = "outshift-common-staging"
+      region       = "us-west-2"
+    }
+  }
+  accepter_vpc_name  = "prod-db-vpc-1"
+  requester_vpc_name  = "common-staging-usw2-1"
+}


### PR DESCRIPTION
## Fixes/Implements # (JIRA issue if applicable)  


### Description/Justification

(Why is this change needed? Which team might need it? etc...)  


### If the (atlantis) plan is destroying resources, reason for deletion  


### Additional details

- [ ] `terraform fmt` was applied
- [ ] All atlantis plans can be applied
- [ ] (For reviewers) I have verified the resource changes
