### PR TITLE
chore(rosey): add k8s Auth method, config and policy for comn-dev-use2-1

### DIFF
--- a/aws_outshift-common-dev_us-east-2_eks_comn-dev-use2-1_eso.tf
+++ b/aws_outshift-common-dev_us-east-2_eks_comn-dev-use2-1_eso.tf
@@ -123,3 +123,12 @@ module "eso_eticloud_apps_ppu" {
   kubernetes_ca        = base64decode(data.vault_generic_secret.cluster_certificate.data["b64certificate"])
   policies             = ["external-secrets-${local.name}"]
 }
+
+module "eso_eticloud_apps_rosey" {
+  source               = "git::https://github.com/cisco-eti/sre-tf-module-eso-access.git?ref=1.0.0"
+  cluster_name         = local.name
+  vault_namespace      = "eticloud/apps/rosey"
+  kubernetes_host      = data.aws_eks_cluster.cluster.endpoint
+  kubernetes_ca        = base64decode(data.vault_generic_secret.cluster_certificate.data["b64certificate"])
+  policies             = ["external-secrets-${local.name}"]
+}

--- a/keeper_namespaces_eticloud_apps_rosey_main.tf
+++ b/keeper_namespaces_eticloud_apps_rosey_main.tf
@@ -126,7 +126,6 @@ locals {
     "external-secrets-staging"              = "policies/external-secrets-staging.hcl",
     "external-secrets-prod"                 = "policies/external-secrets-prod.hcl",
     "external-secrets-comn-dev-use2-1"      = "policies/external-secrets-comn-dev-use2-1.hcl",
-    "external-secrets-rosey-dev-euw1-1.hcl" = "policies/external-secrets-rosey-dev-euw1-1.hcl",
     "external-secrets-cnapp-staging-euc1-1" = "policies/external-secrets-cnapp-staging-euc1-1.hcl",
     "external-secrets-cnapp-staging-use2-1" = "policies/external-secrets-cnapp-staging-use2-1.hcl",
     "external-secrets-cnapp-prod-euc1-1"    = "policies/external-secrets-cnapp-prod-euc1-1.hcl",

--- a/keeper_namespaces_eticloud_apps_rosey_main.tf
+++ b/keeper_namespaces_eticloud_apps_rosey_main.tf
@@ -125,7 +125,7 @@ locals {
     "external-secrets-dev"                  = "policies/external-secrets-dev.hcl",
     "external-secrets-staging"              = "policies/external-secrets-staging.hcl",
     "external-secrets-prod"                 = "policies/external-secrets-prod.hcl",
-    "external-secrets-rosey-dev-euw1-1"     = "policies/external-secrets-rosey-dev-euw1-1.hcl",
+    "external-secrets-comn-dev-use2-1"     = "policies/external-secrets-comn-dev-use2-1.hcl",
     "external-secrets-cnapp-staging-euc1-1" = "policies/external-secrets-cnapp-staging-euc1-1.hcl",
     "external-secrets-cnapp-staging-use2-1" = "policies/external-secrets-cnapp-staging-use2-1.hcl",
     "external-secrets-cnapp-prod-euc1-1"    = "policies/external-secrets-cnapp-prod-euc1-1.hcl",

--- a/keeper_namespaces_eticloud_apps_rosey_main.tf
+++ b/keeper_namespaces_eticloud_apps_rosey_main.tf
@@ -120,6 +120,7 @@ resource "vault_jwt_auth_backend_role" "developer" {
 # Define a map of policy names to filenames
 locals {
   policies = {
+    "default"                               = "policies/default.hcl",
     "developer"                             = "policies/developer.hcl",
     "admin"                                 = "policies/admin.hcl",
     "external-secrets-dev"                  = "policies/external-secrets-dev.hcl",
@@ -129,8 +130,7 @@ locals {
     "external-secrets-cnapp-staging-euc1-1" = "policies/external-secrets-cnapp-staging-euc1-1.hcl",
     "external-secrets-cnapp-staging-use2-1" = "policies/external-secrets-cnapp-staging-use2-1.hcl",
     "external-secrets-cnapp-prod-euc1-1"    = "policies/external-secrets-cnapp-prod-euc1-1.hcl",
-    "external-secrets-cnapp-prod-use2-1"    = "policies/external-secrets-cnapp-prod-use2-1.hcl",
-    "default"                               = "policies/default.hcl",
+    "external-secrets-cnapp-prod-use2-1"    = "policies/external-secrets-cnapp-prod-use2-1.hcl"
   }
 }
 

--- a/keeper_namespaces_eticloud_apps_rosey_main.tf
+++ b/keeper_namespaces_eticloud_apps_rosey_main.tf
@@ -37,14 +37,14 @@ resource "vault_namespace" "namespace" {
 resource "vault_mount" "kvv2" {
   provider = vault.venture
   path     = "secret"
-  type    = "kv"
-  options = { version = "2" }
+  type     = "kv"
+  options  = { version = "2" }
 }
 
 # OIDC Credentials
 data "vault_generic_secret" "oidc_credential" {
   provider = vault.teamsecrets
-  path = "secret/cisco_sso_auth_clients/vault_oidc_creds"
+  path     = "secret/cisco_sso_auth_clients/vault_oidc_creds"
 }
 
 # oidc auth backend
@@ -62,15 +62,15 @@ resource "vault_jwt_auth_backend" "oidc" {
 
 # vault roles
 resource "vault_jwt_auth_backend_role" "admin" {
-  depends_on                   = [ vault_policy.policy["admin"], vault_policy.policy["developer"] ]
-  provider                     = vault.venture
-  role_name                    = "admin"
-  role_type                    = "oidc"
-  backend                      = vault_jwt_auth_backend.oidc.path
-  allowed_redirect_uris        = ["https://keeper.cisco.com/ui/vault/auth/oidc/oidc/callback",
-                                  "https://east.keeper.cisco.com/ui/vault/auth/oidc/oidc/callback",
-                                  "https://west.keeper.cisco.com/ui/vault/auth/oidc/oidc/callback"]
-  bound_audiences              = [var.oidc_client_id]
+  depends_on = [vault_policy.policy["admin"], vault_policy.policy["developer"]]
+  provider   = vault.venture
+  role_name  = "admin"
+  role_type  = "oidc"
+  backend    = vault_jwt_auth_backend.oidc.path
+  allowed_redirect_uris = ["https://keeper.cisco.com/ui/vault/auth/oidc/oidc/callback",
+    "https://east.keeper.cisco.com/ui/vault/auth/oidc/oidc/callback",
+  "https://west.keeper.cisco.com/ui/vault/auth/oidc/oidc/callback"]
+  bound_audiences = [var.oidc_client_id]
   bound_claims = {
     memberof = "CN=eti-${var.venture_name}-vault-admin,OU=Cisco Groups,DC=cisco,DC=com"
   }
@@ -82,23 +82,23 @@ resource "vault_jwt_auth_backend_role" "admin" {
     given_name  = "given_name",
     sub         = "sub"
   }
-  groups_claim                 = "memberof"
-  oidc_scopes                  = ["profile", "email", "openid"]
-  user_claim                   = "sub"
-  token_policies               = [vault_policy.policy["admin"].name,
-                                  vault_policy.policy["default"].name]
+  groups_claim = "memberof"
+  oidc_scopes  = ["profile", "email", "openid"]
+  user_claim   = "sub"
+  token_policies = [vault_policy.policy["admin"].name,
+  vault_policy.policy["default"].name]
 }
 
 resource "vault_jwt_auth_backend_role" "developer" {
-  depends_on                   = [ vault_policy.policy["developer"], vault_policy.policy["developer"] ]
-  provider                     = vault.venture
-  role_name                    = "developer"
-  role_type                    = "oidc"
-  backend                      = vault_jwt_auth_backend.oidc.path
-  allowed_redirect_uris        = ["https://keeper.cisco.com/ui/vault/auth/oidc/oidc/callback",
-                                  "https://east.keeper.cisco.com/ui/vault/auth/oidc/oidc/callback",
-                                  "https://west.keeper.cisco.com/ui/vault/auth/oidc/oidc/callback"]
-  bound_audiences              = [var.oidc_client_id]
+  depends_on = [vault_policy.policy["developer"], vault_policy.policy["developer"]]
+  provider   = vault.venture
+  role_name  = "developer"
+  role_type  = "oidc"
+  backend    = vault_jwt_auth_backend.oidc.path
+  allowed_redirect_uris = ["https://keeper.cisco.com/ui/vault/auth/oidc/oidc/callback",
+    "https://east.keeper.cisco.com/ui/vault/auth/oidc/oidc/callback",
+  "https://west.keeper.cisco.com/ui/vault/auth/oidc/oidc/callback"]
+  bound_audiences = [var.oidc_client_id]
   bound_claims = {
     memberof = "CN=eti-${var.venture_name}-vault-developer,OU=Cisco Groups,DC=cisco,DC=com"
   }
@@ -110,11 +110,11 @@ resource "vault_jwt_auth_backend_role" "developer" {
     given_name  = "given_name",
     sub         = "sub"
   }
-  groups_claim                 = "memberof"
-  oidc_scopes                  = ["profile", "email", "openid"]
-  user_claim                   = "sub"
-  token_policies               = [vault_policy.policy["developer"].name,
-                                  vault_policy.policy["default"].name]
+  groups_claim = "memberof"
+  oidc_scopes  = ["profile", "email", "openid"]
+  user_claim   = "sub"
+  token_policies = [vault_policy.policy["developer"].name,
+  vault_policy.policy["default"].name]
 }
 
 # Define a map of policy names to filenames
@@ -125,7 +125,7 @@ locals {
     "external-secrets-dev"                  = "policies/external-secrets-dev.hcl",
     "external-secrets-staging"              = "policies/external-secrets-staging.hcl",
     "external-secrets-prod"                 = "policies/external-secrets-prod.hcl",
-    "external-secrets-comn-dev-use2-1"     = "policies/external-secrets-comn-dev-use2-1.hcl",
+    "external-secrets-comn-dev-use2-1"      = "policies/external-secrets-comn-dev-use2-1.hcl",
     "external-secrets-cnapp-staging-euc1-1" = "policies/external-secrets-cnapp-staging-euc1-1.hcl",
     "external-secrets-cnapp-staging-use2-1" = "policies/external-secrets-cnapp-staging-use2-1.hcl",
     "external-secrets-cnapp-prod-euc1-1"    = "policies/external-secrets-cnapp-prod-euc1-1.hcl",

--- a/keeper_namespaces_eticloud_apps_rosey_main.tf
+++ b/keeper_namespaces_eticloud_apps_rosey_main.tf
@@ -126,7 +126,7 @@ locals {
     "external-secrets-staging"              = "policies/external-secrets-staging.hcl",
     "external-secrets-prod"                 = "policies/external-secrets-prod.hcl",
     "external-secrets-comn-dev-use2-1"      = "policies/external-secrets-comn-dev-use2-1.hcl",
-    "external-secrets-rosey-dev-euw1-1.hcl" = "policies/external-secrets-rosey-dev-euw1-1.hcl.hcl",
+    "external-secrets-rosey-dev-euw1-1.hcl" = "policies/external-secrets-rosey-dev-euw1-1.hcl",
     "external-secrets-cnapp-staging-euc1-1" = "policies/external-secrets-cnapp-staging-euc1-1.hcl",
     "external-secrets-cnapp-staging-use2-1" = "policies/external-secrets-cnapp-staging-use2-1.hcl",
     "external-secrets-cnapp-prod-euc1-1"    = "policies/external-secrets-cnapp-prod-euc1-1.hcl",

--- a/keeper_namespaces_eticloud_apps_rosey_main.tf
+++ b/keeper_namespaces_eticloud_apps_rosey_main.tf
@@ -148,3 +148,85 @@ resource "vault_policy" "policy" {
   name   = each.key
   policy = each.value.content
 }
+
+# Fixme: This policy should already be set in the above policies map
+# but the terraform plan is not picking it up and wants to remove it. So, adding it here.
+resource "vault_policy" "default" {
+  provider = vault.venture
+  name     = "default"
+  policy   = <<EOT
+# Allow tokens to look up their own properties
+path "auth/token/lookup-self" {
+    capabilities = ["read"]
+}
+# Allow tokens to renew themselves
+path "auth/token/renew-self" {
+    capabilities = ["update"]
+}
+# Allow tokens to revoke themselves
+path "auth/token/revoke-self" {
+    capabilities = ["update"]
+}
+# Allow a token to look up its own capabilities on a path
+path "sys/capabilities-self" {
+    capabilities = ["update"]
+}
+# Allow a token to look up its own entity by id or name
+path "identity/entity/id/{{identity.entity.id}}" {
+  capabilities = ["read"]
+}
+path "identity/entity/name/{{identity.entity.name}}" {
+  capabilities = ["read"]
+}
+# Allow a token to look up its resultant ACL from all policies. This is useful
+# for UIs. It is an internal path because the format may change at any time
+# based on how the internal ACL features and capabilities change.
+path "sys/internal/ui/resultant-acl" {
+    capabilities = ["read"]
+}
+# Allow a token to renew a lease via lease_id in the request body; old path for
+# old clients, new path for newer
+path "sys/renew" {
+    capabilities = ["update"]
+}
+path "sys/leases/renew" {
+    capabilities = ["update"]
+}
+# Allow looking up lease properties. This requires knowing the lease ID ahead
+# of time and does not divulge any sensitive information.
+path "sys/leases/lookup" {
+    capabilities = ["update"]
+}
+# Allow a token to manage its own cubbyhole
+path "cubbyhole/*" {
+    capabilities = ["create", "read", "update", "delete", "list"]
+}
+# Allow a token to wrap arbitrary values in a response-wrapping token
+path "sys/wrapping/wrap" {
+    capabilities = ["update"]
+}
+# Allow a token to look up the creation time and TTL of a given
+# response-wrapping token
+path "sys/wrapping/lookup" {
+    capabilities = ["update"]
+}
+# Allow a token to unwrap a response-wrapping token. This is a convenience to
+# avoid client token swapping since this is also part of the response wrapping
+# policy.
+path "sys/wrapping/unwrap" {
+    capabilities = ["update"]
+}
+# Allow general purpose tools
+path "sys/tools/hash" {
+    capabilities = ["update"]
+}
+path "sys/tools/hash/*" {
+    capabilities = ["update"]
+}
+# Allow checking the status of a Control Group request if the user has the
+# accessor
+path "sys/control-group/request" {
+    capabilities = ["update"]
+}
+EOT
+}

--- a/keeper_namespaces_eticloud_apps_rosey_main.tf
+++ b/keeper_namespaces_eticloud_apps_rosey_main.tf
@@ -126,6 +126,7 @@ locals {
     "external-secrets-staging"              = "policies/external-secrets-staging.hcl",
     "external-secrets-prod"                 = "policies/external-secrets-prod.hcl",
     "external-secrets-comn-dev-use2-1"      = "policies/external-secrets-comn-dev-use2-1.hcl",
+    "external-secrets-rosey-dev-euw1-1.hcl" = "policies/external-secrets-rosey-dev-euw1-1.hcl.hcl",
     "external-secrets-cnapp-staging-euc1-1" = "policies/external-secrets-cnapp-staging-euc1-1.hcl",
     "external-secrets-cnapp-staging-use2-1" = "policies/external-secrets-cnapp-staging-use2-1.hcl",
     "external-secrets-cnapp-prod-euc1-1"    = "policies/external-secrets-cnapp-prod-euc1-1.hcl",


### PR DESCRIPTION
## Fixes/Implements # (JIRA issue if applicable)  

https://cisco-eti.atlassian.net/browse/OPENSD-800
Since they're using `comn-dev-use2-1` and the `rosey-dev-` cluster no longer exists, adapting their config to grant access to secrets in Vault.

### Description/Justification

(Why is this change needed? Which team might need it? etc...)  

Their app can't access secrets in Vault.


### If the (atlantis) plan is destroying resources, reason for deletion  


### Additional details

- [x] `terraform fmt` was applied
- [ ] All atlantis plans can be applied
- [ ] (For reviewers) I have verified the resource changes