### PR TITLE
chore: rename outshift_foundational_services to ragv2 on Azure vault keys

### DIFF
--- a/azure_eti-scratch_azure-openai_mm-rag-project-agents.tf
+++ b/azure_eti-scratch_azure-openai_mm-rag-project-agents.tf
@@ -1,0 +1,42 @@
+locals {
+  mm-rag-team   = "mm-rag-team"
+  ai-team-tags = {
+    ApplicationName    = "ai-team"
+    ComponentName      = "mm-rag-team"
+    CiscoMailAlias     = "eti-sre-admins@cisco.com"
+    DataClassification = "Cisco Restricted"
+    DataTaxonomy       = "Cisco Operations Data"
+    Environment        = "NonProd"
+    ResourceOwner      = "Maciej Jerzy Filipowicz"
+  }
+}
+
+resource "azurerm_resource_group" "mm-rag-team" {
+  name     = local.mm-rag-team
+  location = local.region_eastus
+}
+
+resource "azurerm_cognitive_account" "mm-rag-team" {
+  name                  = "${local.mm-rag-team}"
+  custom_subdomain_name = "${local.mm-rag-team}"
+  location              = azurerm_resource_group.mm-rag-team.location
+  resource_group_name   = azurerm_resource_group.mm-rag-team.name
+  kind                  = "OpenAI"
+  sku_name              = "S0"
+  tags                  = local.ai-team-tags
+}
+
+resource "azurerm_cognitive_deployment" "mm-rag-team-gpt4o" {
+  name                 = "gpt-4o"
+  cognitive_account_id = azurerm_cognitive_account.mm-rag-team.id
+  model {
+    format  = "OpenAI"
+    name    = "gpt-4o"
+    version = "2024-05-13"
+  }
+
+  sku {
+    name = "GlobalStandard"
+    capacity = 1000
+  }
+}

--- a/azure_eti-scratch_azure-openai_outshift-foundational-services.tf
+++ b/azure_eti-scratch_azure-openai_outshift-foundational-services.tf
@@ -1,6 +1,6 @@
 locals {
-  outshift-foundational-services-project-agents   = "outshift-foundational-services-project-agents"
-  outshift-foundational-services-project-agents-tags = {
+  ragv2-project-agents   = "ragv2-project-agents"
+  ragv2-project-agents-tags = {
     ApplicationName    = "outshift_foundational_services"
     Component          = "ragv2"
     ResourceOwner      = "sushroff"
@@ -11,24 +11,24 @@ locals {
   }
 }
 
-resource "azurerm_resource_group" "outshift-foundational-services-project-agents" {
-  name     = local.outshift-foundational-services-project-agents
+resource "azurerm_resource_group" "ragv2-project-agents" {
+  name     = local.ragv2-project-agents
   location = local.region_eastus
 }
 
-resource "azurerm_cognitive_account" "outshift-foundational-services-project-agents" {
-  name                  = "${local.outshift-foundational-services-project-agents}"
-  custom_subdomain_name = "${local.outshift-foundational-services-project-agents}"
-  location              = azurerm_resource_group.outshift-foundational-services-project-agents.location
-  resource_group_name   = azurerm_resource_group.outshift-foundational-services-project-agents.name
+resource "azurerm_cognitive_account" "ragv2-project-agents" {
+  name                  = "${local.ragv2-project-agents}"
+  custom_subdomain_name = "${local.ragv2-project-agents}"
+  location              = azurerm_resource_group.ragv2-project-agents.location
+  resource_group_name   = azurerm_resource_group.ragv2-project-agents.name
   kind                  = "OpenAI"
   sku_name              = "S0"
-  tags                  = local.outshift-foundational-services-project-agents-tags
+  tags                  = local.ragv2-project-agents-tags
 }
 
-resource "azurerm_cognitive_deployment" "outshift-foundational-services-project-agents-gpt-4o-mini" {
+resource "azurerm_cognitive_deployment" "ragv2-project-agents-gpt-4o-mini" {
   name                 = "gpt-4o-mini"
-  cognitive_account_id = azurerm_cognitive_account.outshift-foundational-services-project-agents.id
+  cognitive_account_id = azurerm_cognitive_account.ragv2-project-agents.id
   model {
     format  = "OpenAI"
     name    = "gpt-4o-mini"

--- a/azure_eti-scratch_azure-openai_ragv2-project-agents.tf
+++ b/azure_eti-scratch_azure-openai_ragv2-project-agents.tf
@@ -1,0 +1,42 @@
+locals {
+  ragv2-project-agents   = "ragv2-project-agents"
+  ragv2-project-agents-tags = {
+    ApplicationName    = "outshift_foundational_services"
+    Component          = "ragv2"
+    ResourceOwner      = "sushroff"
+    CiscoMailAlias     = "sushroff@cisco.com"
+    DataClassification = "Cisco Restricted"
+    DataTaxonomy       = "Cisco Operations Data"
+    Environment        = "NonProd"
+  }
+}
+
+resource "azurerm_resource_group" "ragv2-project-agents" {
+  name     = local.ragv2-project-agents
+  location = local.region_eastus
+}
+
+resource "azurerm_cognitive_account" "ragv2-project-agents" {
+  name                  = "${local.ragv2-project-agents}"
+  custom_subdomain_name = "${local.ragv2-project-agents}"
+  location              = azurerm_resource_group.ragv2-project-agents.location
+  resource_group_name   = azurerm_resource_group.ragv2-project-agents.name
+  kind                  = "OpenAI"
+  sku_name              = "S0"
+  tags                  = local.ragv2-project-agents-tags
+}
+
+resource "azurerm_cognitive_deployment" "ragv2-project-agents-gpt-4o-mini" {
+  name                 = "gpt-4o-mini"
+  cognitive_account_id = azurerm_cognitive_account.ragv2-project-agents.id
+  model {
+    format  = "OpenAI"
+    name    = "gpt-4o-mini"
+    version = "2024-07-18"
+  }
+
+  sku {
+    name = "GlobalStandard"
+    capacity = 1000
+  }
+}

--- a/keeper_namespaces_eticloud_outshift-users_main.tf
+++ b/keeper_namespaces_eticloud_outshift-users_main.tf
@@ -158,11 +158,11 @@ path "engineering_rd/*"
 EOT
 }
 
-# Outshift outshift_foundational_services Vault Role
-resource "vault_jwt_auth_backend_role" "outshift_foundational_services" {
-  depends_on = [vault_policy.outshift_foundational_services]
+# Outshift ragv2 Vault Role
+resource "vault_jwt_auth_backend_role" "ragv2" {
+  depends_on = [vault_policy.ragv2]
   provider   = vault.venture
-  role_name  = "outshift_foundational_services"
+  role_name  = "ragv2"
   role_type  = "oidc"
   backend    = vault_jwt_auth_backend.oidc.path
   allowed_redirect_uris = ["https://keeper.cisco.com/ui/vault/auth/oidc/oidc/callback",
@@ -170,7 +170,7 @@ resource "vault_jwt_auth_backend_role" "outshift_foundational_services" {
   "https://west.keeper.cisco.com/ui/vault/auth/oidc/oidc/callback"]
   bound_audiences = [var.oidc_client_id]
   bound_claims = {
-    memberof = "CN=outshift-vault-outshift-foundational-services,OU=Cisco Groups,DC=cisco,DC=com"
+    memberof = "CN=outshift-vault-ragv2,OU=Cisco Groups,DC=cisco,DC=com"
   }
   disable_bound_claims_parsing = true
   bound_claims_type            = "string"
@@ -183,16 +183,16 @@ resource "vault_jwt_auth_backend_role" "outshift_foundational_services" {
   groups_claim = "memberof"
   oidc_scopes  = ["profile", "email", "openid"]
   user_claim   = "sub"
-  token_policies = [vault_policy.outshift_foundational_services.name]
+  token_policies = [vault_policy.ragv2.name]
 }
 
-resource "vault_policy" "outshift_foundational_services" {
+resource "vault_policy" "ragv2" {
   provider = vault.venture
-  name     = "outshift_foundational_services"
+  name     = "ragv2"
   policy   = <<EOT
 # Manage auth methods broadly across Vault
 # List, create, update, and delete key/value secrets
-path "outshift_foundational_services/*"
+path "outshift_foundational_services/ragv2/*"
 {
   capabilities = ["read", "list"]
 }


### PR DESCRIPTION
## Fixes/Implements # (JIRA issue if applicable)  


### Description/Justification

(Why is this change needed? Which team might need it? etc...)  


### If the (atlantis) plan is destroying resources, reason for deletion  


### Additional details

- [ ] `terraform fmt` was applied
- [ ] All atlantis plans can be applied
- [ ] (For reviewers) I have verified the resource changes
