### PR TITLE
chore(namespaces): add missing Vault secret engines in outshift-users

### DIFF
--- a/keeper_namespaces_eticloud_outshift-users_main.tf
+++ b/keeper_namespaces_eticloud_outshift-users_main.tf
@@ -61,6 +61,41 @@ resource "vault_mount" "phoenix" {
   options  = { version = "2" }
 }
 
+resource "vault_mount" "prcoach" {
+  provider = vault.venture
+  path     = "prcoach"
+  type     = "kv"
+  options  = { version = "2" }
+}
+
+resource "vault_mount" "engineering_rd" {
+  provider = vault.venture
+  path     = "engineering_rd"
+  type     = "kv"
+  options  = { version = "2" }
+}
+
+resource "vault_mount" "dmonkey" {
+  provider = vault.venture
+  path     = "dmonkey"
+  type     = "kv"
+  options  = { version = "2" }
+}
+
+resource "vault_mount" "autosync" {
+  provider = vault.venture
+  path     = "autosync"
+  type     = "kv"
+  options  = { version = "2" }
+}
+
+resource "vault_mount" "actionengine" {
+  provider = vault.venture
+  path     = "actionengine"
+  type     = "kv"
+  options  = { version = "2" }
+}
+
 # OIDC Credentials
 data "vault_generic_secret" "oidc_credential" {
   provider = vault.teamsecrets

--- a/keeper_namespaces_eticloud_outshift-users_main.tf
+++ b/keeper_namespaces_eticloud_outshift-users_main.tf
@@ -54,6 +54,13 @@ resource "vault_mount" "ostinato" {
   options  = { version = "2" }
 }
 
+resource "vault_mount" "phoenix" {
+  provider = vault.venture
+  path     = "phoenix"
+  type     = "kv"
+  options  = { version = "2" }
+}
+
 # OIDC Credentials
 data "vault_generic_secret" "oidc_credential" {
   provider = vault.teamsecrets
@@ -70,4 +77,3 @@ resource "vault_jwt_auth_backend" "oidc" {
   oidc_discovery_url = "https://sso-dbbfec7f.sso.duosecurity.com/oidc/${var.oidc_client_id}"
   default_role       = "generic-user"
 }
-

--- a/keeper_namespaces_eticloud_outshift-users_main.tf
+++ b/keeper_namespaces_eticloud_outshift-users_main.tf
@@ -55,45 +55,51 @@ resource "vault_mount" "ostinato" {
 }
 
 resource "vault_mount" "phoenix" {
-  provider = vault.venture
-  path     = "phoenix"
-  type     = "kv"
-  options  = { version = "2" }
+  provider           = vault.venture
+  path               = "phoenix"
+  type               = "kv"
+  options            = { version = "2" }
+  listing_visibility = "hidden"
 }
 
 resource "vault_mount" "prcoach" {
-  provider = vault.venture
-  path     = "prcoach"
-  type     = "kv"
-  options  = { version = "2" }
+  provider           = vault.venture
+  path               = "prcoach"
+  type               = "kv"
+  options            = { version = "2" }
+  listing_visibility = "hidden"
 }
 
 resource "vault_mount" "engineering_rd" {
-  provider = vault.venture
-  path     = "engineering_rd"
-  type     = "kv"
-  options  = { version = "2" }
+  provider           = vault.venture
+  path               = "engineering_rd"
+  type               = "kv"
+  options            = { version = "2" }
+  listing_visibility = "hidden"
 }
 
 resource "vault_mount" "dmonkey" {
-  provider = vault.venture
-  path     = "dmonkey"
-  type     = "kv"
-  options  = { version = "2" }
+  provider           = vault.venture
+  path               = "dmonkey"
+  type               = "kv"
+  options            = { version = "2" }
+  listing_visibility = "hidden"
 }
 
 resource "vault_mount" "autosync" {
-  provider = vault.venture
-  path     = "autosync"
-  type     = "kv"
-  options  = { version = "2" }
+  provider           = vault.venture
+  path               = "autosync"
+  type               = "kv"
+  options            = { version = "2" }
+  listing_visibility = "hidden"
 }
 
 resource "vault_mount" "actionengine" {
-  provider = vault.venture
-  path     = "actionengine"
-  type     = "kv"
-  options  = { version = "2" }
+  provider           = vault.venture
+  path               = "actionengine"
+  type               = "kv"
+  options            = { version = "2" }
+  listing_visibility = "hidden"
 }
 
 # OIDC Credentials


### PR DESCRIPTION
## Fixes/Implements # (JIRA issue if applicable)  

Add missing secret engines in the terraform state, some of them have been created manually in Keeper, while others had already been set in this repo.

### Description/Justification

(Why is this change needed? Which team might need it? etc...)  


### If the (atlantis) plan is destroying resources, reason for deletion  


### Additional details

- [x] `terraform fmt` was applied
- [ ] All atlantis plans can be applied
- [ ] (For reviewers) I have verified the resource changes
