### PR TITLE
OPENSD-967-968: create azure openai key for puccini project

### DIFF
--- a/azure_eti-scratch_azure-openai_puccini-project-agents.tf
+++ b/azure_eti-scratch_azure-openai_puccini-project-agents.tf
@@ -1,0 +1,42 @@
+locals {
+  puccini-project-agents = "puccini-project-agents"
+  puccini-project-agents-tags = {
+    ApplicationName    = "puccini"
+    Component          = "nolan"
+    ResourceOwner      = "mahviswa"
+    CiscoMailAlias     = "mahviswa@cisco.com"
+    DataClassification = "Cisco Restricted"
+    DataTaxonomy       = "Cisco Operations Data"
+    Environment        = "NonProd"
+  }
+}
+
+resource "azurerm_resource_group" "puccini-project-agents" {
+  name     = local.puccini-project-agents
+  location = local.region_eastus
+}
+
+resource "azurerm_cognitive_account" "puccini-project-agents" {
+  name                  = "${local.puccini-project-agents}"
+  custom_subdomain_name = "${local.puccini-project-agents}"
+  location              = azurerm_resource_group.puccini-project-agents.location
+  resource_group_name   = azurerm_resource_group.puccini-project-agents.name
+  kind                  = "OpenAI"
+  sku_name              = "S0"
+  tags                  = local.puccini-project-agents-tags
+}
+
+resource "azurerm_cognitive_deployment" "puccini-project-agents-gpt4o" {
+  name                 = "gpt-4o"
+  cognitive_account_id = azurerm_cognitive_account.puccini-project-agents.id
+  model {
+    format  = "OpenAI"
+    name    = "gpt-4o"
+    version = "2024-05-13"
+  }
+
+  sku {
+    name = "GlobalStandard"
+    capacity = 1000
+  }
+}

--- a/azure_eti-scratch_azure-openai_puccini-project-agents.tf
+++ b/azure_eti-scratch_azure-openai_puccini-project-agents.tf
@@ -40,3 +40,18 @@ resource "azurerm_cognitive_deployment" "puccini-project-agents-gpt4o" {
     capacity = 1000
   }
 }
+
+resource "azurerm_cognitive_deployment" "puccini-project-agents-gpt4o-mini"  {
+  name                 = "gpt-4o-mini"
+  cognitive_account_id = azurerm_cognitive_account.puccini-project-agents.id
+  model {
+    format  = "OpenAI"
+    name    = "gpt-4o-mini"
+    version = "2024-07-18"
+  }
+
+  sku {
+    name = "GlobalStandard"
+    capacity = 1000
+  }
+}

--- a/keeper_namespaces_eticloud_outshift-users_main.tf
+++ b/keeper_namespaces_eticloud_outshift-users_main.tf
@@ -102,6 +102,14 @@ resource "vault_mount" "actionengine" {
   listing_visibility = "hidden"
 }
 
+resource "vault_mount" "puccini" {
+  provider           = vault.venture
+  path               = "puccini"
+  type               = "kv"
+  options            = { version = "2" }
+  listing_visibility = "hidden"
+}
+
 # OIDC Credentials
 data "vault_generic_secret" "oidc_credential" {
   provider = vault.teamsecrets

--- a/keeper_namespaces_eticloud_outshift-users_puccini.tf
+++ b/keeper_namespaces_eticloud_outshift-users_puccini.tf
@@ -1,0 +1,40 @@
+# Outshift puccini Vault Role
+resource "vault_jwt_auth_backend_role" "puccini" {
+  depends_on = [vault_policy.puccini]
+  provider   = vault.venture
+  role_name  = "puccini"
+  role_type  = "oidc"
+  backend    = vault_jwt_auth_backend.oidc.path
+  allowed_redirect_uris = ["https://keeper.cisco.com/ui/vault/auth/oidc/oidc/callback",
+    "http://localhost:8250/oidc/callback",
+  "https://west.keeper.cisco.com/ui/vault/auth/oidc/oidc/callback"]
+  bound_audiences = [var.oidc_client_id]
+  bound_claims = {
+    memberof = "CN=outshift-vault-puccini,OU=Cisco Groups,DC=cisco,DC=com"
+  }
+  disable_bound_claims_parsing = true
+  bound_claims_type            = "string"
+  claim_mappings = {
+    email       = "email",
+    family_name = "family_name",
+    given_name  = "given_name",
+    sub         = "sub"
+  }
+  groups_claim = "memberof"
+  oidc_scopes  = ["profile", "email", "openid"]
+  user_claim   = "sub"
+  token_policies = [vault_policy.puccini.name]
+}
+
+resource "vault_policy" "puccini" {
+  provider = vault.venture
+  name     = "puccini"
+  policy   = <<EOT
+# Manage auth methods broadly across Vault
+# List, create, update, and delete key/value secrets
+path "puccini/*"
+{
+  capabilities = ["read", "list"]
+}
+EOT
+}


### PR DESCRIPTION
## Fixes/Implements # (JIRA issue if applicable)  
[OPENSD-967](https://cisco-eti.atlassian.net/browse/OPENSD-967)
[OPENSD-968](https://cisco-eti.atlassian.net/browse/OPENSD-968)

### Description/Justification
PR as a replacement for the [previous one](https://github.com/cisco-eti/platform-terraform-infra/pull/669) for generating azure openai keys, as it appears that `Nolan is part of puccini project`

### If the (atlantis) plan is destroying resources, reason for deletion  
No

[OPENSD-967]: https://cisco-eti.atlassian.net/browse/OPENSD-967?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[OPENSD-968]: https://cisco-eti.atlassian.net/browse/OPENSD-968?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ