### PR TITLE
feat(SRE-9107,keeper,aether,approle): added approle for GHA

### DIFF
--- a/keeper_namespaces_eticloud_apps_aether_approles_backend.tf
+++ b/keeper_namespaces_eticloud_apps_aether_approles_backend.tf
@@ -1,0 +1,9 @@
+terraform {
+  backend "s3" {
+    bucket         = "eticloud-tf-state-prod"
+    key            = "backend/keeper/eticloud/apps/aether/aether-auth-backend.tfstate"
+    region         = "us-east-2"
+    dynamodb_table = "eticloud-tf-locks"
+    encrypt        = true
+  }
+}

--- a/keeper_namespaces_eticloud_apps_aether_approles_main.tf
+++ b/keeper_namespaces_eticloud_apps_aether_approles_main.tf
@@ -1,0 +1,53 @@
+resource "vault_auth_backend" "approle" {
+  provider = vault.aether
+  type     = "approle"
+
+  tune {
+    default_lease_ttl = "30m"
+  }
+}
+
+#region RESOURCES FOR CI-GHA-APPROLE #######
+
+data "local_file" "gha_policy_hcl" {
+  filename = "policies/ci-gha-policy.hcl"
+}
+
+resource "vault_policy" "ci_gha_policy" {
+  provider = vault.aether
+  name     = "ci-gha"
+  policy   = data.local_file.gha_policy_hcl.content
+}
+
+resource "vault_approle_auth_backend_role" "ci_gha_approle" {
+  provider       = vault.aether
+  backend        = vault_auth_backend.approle.path
+  role_name      = "ci-gha-approle"
+  token_policies = ["default", "ci-gha"]
+  depends_on     = [
+    vault_policy.ci_gha_policy
+  ]
+}
+
+# Secret ID for the backend role. Required for automation in GitHub Actions.
+resource "vault_approle_auth_backend_role_secret_id" "ci_gha_backend_role_secret_id" {
+  provider  = vault.aether
+  backend   = vault_auth_backend.approle.path
+  role_name = vault_approle_auth_backend_role.ci_gha_approle.role_name
+}
+
+# Creates a secret with the backend role name, id, and secret id. Will be entered manually into GitHub Actions.
+resource "vault_kv_secret_v2" "ci_gha_backend_secret" {
+  provider  = vault.aether
+  mount     = "secret"
+  name      = "approle/ci-gha-approle"
+  data_json = jsonencode(
+    {
+      role_name = vault_approle_auth_backend_role.ci_gha_approle.role_name
+      role_id   = vault_approle_auth_backend_role.ci_gha_approle.role_id
+      secret_id = vault_approle_auth_backend_role_secret_id.ci_gha_backend_role_secret_id.secret_id
+    }
+  )
+}
+
+#endregion

--- a/keeper_namespaces_eticloud_apps_aether_approles_provider.tf
+++ b/keeper_namespaces_eticloud_apps_aether_approles_provider.tf
@@ -1,0 +1,4 @@
+provider "vault" {
+  alias     = "aether"
+  namespace = "eticloud/apps/aether"
+}


### PR DESCRIPTION
## Implements SRE-9107


### Description/Justification

The Aether venture needs an approle for GHA workflow access to our keeper vault to retrieve venture specific secrets.
This PR implements the approle according to the [corresponding SRE platform documentation](https://platform-docs.eticloud.io/services/secrets-management/keeper/operator-guide/vault-approle-creation-use/).

### If the (atlantis) plan is destroying resources, reason for deletion  

-

### Additional details

-
