### PR TITLE
feat: gh-actions approle for phoenix

### DIFF
--- a/keeper_namespaces_eticloud_apps_phoenix_approles_backend.tf
+++ b/keeper_namespaces_eticloud_apps_phoenix_approles_backend.tf
@@ -1,0 +1,9 @@
+terraform {
+  backend "s3" {
+    bucket         = "eticloud-tf-state-prod"
+    key            = "backend/keeper/eticloud/apps/phoenix/phoenix-auth-backend.tfstate"
+    region         = "us-east-2"
+    dynamodb_table = "eticloud-tf-locks"
+    encrypt        = true
+  }
+}

--- a/keeper_namespaces_eticloud_apps_phoenix_approles_main.tf
+++ b/keeper_namespaces_eticloud_apps_phoenix_approles_main.tf
@@ -1,0 +1,53 @@
+resource "vault_auth_backend" "approle" {
+  provider = vault.phoenix
+  type     = "approle"
+
+  tune {
+    default_lease_ttl = "30m"
+  }
+}
+
+#region RESOURCES FOR CI-GHA-APPROLE #######
+
+data "local_file" "gha_policy_hcl" {
+  filename = "policies/ci-gha-policy.hcl"
+}
+
+resource "vault_policy" "ci_gha_policy" {
+  provider = vault.phoenix
+  name     = "ci-gha"
+  policy   = data.local_file.gha_policy_hcl.content
+}
+
+resource "vault_approle_auth_backend_role" "ci_gha_approle" {
+  provider       = vault.phoenix
+  backend        = vault_auth_backend.approle.path
+  role_name      = "ci-gha-approle"
+  token_policies = ["default", "ci-gha"]
+  depends_on     = [
+    vault_policy.ci_gha_policy
+  ]
+}
+
+# Secret ID for the backend role. Required for automation in GitHub Actions.
+resource "vault_approle_auth_backend_role_secret_id" "ci_gha_backend_role_secret_id" {
+  provider  = vault.phoenix
+  backend   = vault_auth_backend.approle.path
+  role_name = vault_approle_auth_backend_role.ci_gha_approle.role_name
+}
+
+# Creates a secret with the backend role name, id, and secret id. Will be entered manually into GitHub Actions.
+resource "vault_kv_secret_v2" "ci_gha_backend_secret" {
+  provider  = vault.phoenix
+  mount     = "secret"
+  name      = "approle/ci-gha-approle"
+  data_json = jsonencode(
+    {
+      role_name = vault_approle_auth_backend_role.ci_gha_approle.role_name
+      role_id   = vault_approle_auth_backend_role.ci_gha_approle.role_id
+      secret_id = vault_approle_auth_backend_role_secret_id.ci_gha_backend_role_secret_id.secret_id
+    }
+  )
+}
+
+#endregion

--- a/keeper_namespaces_eticloud_apps_phoenix_approles_provider.tf
+++ b/keeper_namespaces_eticloud_apps_phoenix_approles_provider.tf
@@ -1,0 +1,4 @@
+provider "vault" {
+  alias     = "phoenix"
+  namespace = "eticloud/apps/phoenix"
+}


### PR DESCRIPTION
## Fixes/Implements # PHI-112

Create gh-actions approle for phoenix project

### Description/Justification

Access phoenix secrets from gh actions


### If the (atlantis) plan is destroying resources, reason for deletion  


### Additional details

- [x] `terraform fmt` was applied
- [x] All atlantis plans can be applied
- [ ] (For reviewers) I have verified the resource changes
