### PR TITLE
feat(vpc-peering): test peering between EKS and data VPC (Pulumi created EKS)

### DIFF
--- a/aws_outshift-common-dev_eu-central-1_vpc_test-pulumi-data_main.tf
+++ b/aws_outshift-common-dev_eu-central-1_vpc_test-pulumi-data_main.tf
@@ -35,3 +35,15 @@ module "vpc" {
   environment         = "NonProd"
   resource_owner      = "eti-sre-admins"
 }
+
+module "vpc_peering_compute_to_data" {
+  source             = "git::https://github.com/cisco-eti/sre-tf-module-vpc-peering.git?ref=2.0.0"
+  aws_accounts_to_regions = {
+    "common" = {
+      account_name = "outshift-common-dev"
+      region       = "eu-central-1"
+    }
+  }
+  accepter_vpc_name  = "outshift-platform-pulumi-test-vpc" # EKS VPC
+  requester_vpc_name = "test-pulumi-data"
+}


### PR DESCRIPTION
## Fixes/Implements # (JIRA issue if applicable)  

The EKS VPC architecture looks like this with Collab AI's code: 
<img width="1048" alt="Screenshot 2024-11-26 at 11 16 55 AM" src="https://github.com/user-attachments/assets/308fce81-3fab-413f-a6df-55c40b504202">

Compared to: 
<img width="1048" alt="Screenshot 2024-11-26 at 11 17 36 AM" src="https://github.com/user-attachments/assets/8678f613-134b-4acc-bd51-30de2908898d">
with our current EKS architecture.

Need to test a few things in order to validate whether that'll work with our data VPCs (but we'll most likely need to replicate our current VPC architecture in Pulumi).

### Additional details

- [x] `terraform fmt` was applied
- [x] All atlantis plans can be applied
- [ ] (For reviewers) I have verified the resource changes