### PR TITLE
add jarvis-agent IAM user to jarvis-sandbox admin

### DIFF
--- a/aws_outshift-common-dev_us-east-2_eks_jarvis-sandbox_main.tf
+++ b/aws_outshift-common-dev_us-east-2_eks_jarvis-sandbox_main.tf
@@ -31,5 +31,10 @@ module "eks_all_in_one" {
       username = "devops",
       groups   = ["system:masters"]
     }
+    , {
+      rolearn  = "arn:aws:iam::${local.account_id}:user/jarvis-agent",
+      username = "jarvis-agent",
+      groups   = ["system:masters"]
+    }
   ]
 }


### PR DESCRIPTION
## Fixes/Implements # (JIRA issue if applicable)  
https://cisco-eti.atlassian.net/browse/SRE-9075

### Description/Justification

The jarvis-agent IAM user needs access to the jarvis-sandbox cluster to perform read-write operations

### If the (atlantis) plan is destroying resources, reason for deletion  


### Additional details

- [x] `terraform fmt` was applied
- [x] All atlantis plans can be applied
- [ ] (For reviewers) I have verified the resource changes
