### PR TITLE
fix(vault-login): Allow users from Ventures to log in from the UI in outshift-users

### DIFF
--- a/keeper_namespaces_eticloud_outshift-users_actionengine.tf
+++ b/keeper_namespaces_eticloud_outshift-users_actionengine.tf
@@ -20,10 +20,10 @@ resource "vault_jwt_auth_backend_role" "actionengine" {
     given_name  = "given_name",
     sub         = "sub"
   }
-  groups_claim = "memberof"
-  oidc_scopes  = ["profile", "email", "openid"]
-  user_claim   = "sub"
-  token_policies = [vault_policy.actionengine.name]
+  groups_claim   = "memberof"
+  oidc_scopes    = ["profile", "email", "openid"]
+  user_claim     = "sub"
+  token_policies = [vault_policy.actionengine.name, vault_policy.default.name]
 }
 resource "vault_policy" "actionengine" {
   provider = vault.venture

--- a/keeper_namespaces_eticloud_outshift-users_autosync.tf
+++ b/keeper_namespaces_eticloud_outshift-users_autosync.tf
@@ -41,61 +41,61 @@ locals {
 }
 
 data "vault_generic_secret" "autosync_llms_mistral" {
-  path = "autosync/llms/mistral"
+  path     = "autosync/llms/mistral"
   provider = vault.venture
 }
 
 data "vault_generic_secret" "autosync_llms_aws_bedrock" {
-  path = "autosync/llms/aws/bedrock"
+  path     = "autosync/llms/aws/bedrock"
   provider = vault.venture
 }
 
 # Data retrieval for GPT4 Key
 data "vault_generic_secret" "autosync_llms_azure_openai_gpt4" {
-  path = "autosync/llms/azure/openai/gpt4"
+  path     = "autosync/llms/azure/openai/gpt4"
   provider = vault.venture
 }
 
 # Data retrieval for GPT4o Key
 data "vault_generic_secret" "autosync_llms_azure_openai_gpt4o" {
-  path = "autosync/llms/azure/openai/gpt4o"
+  path     = "autosync/llms/azure/openai/gpt4o"
   provider = vault.venture
 }
 
 # Data retrieval for GPT4o-mini Key
 data "vault_generic_secret" "autosync_llms_azure_openai_gpt4o-mini" {
-  path = "autosync/llms/azure/openai/gpt4o-mini"
+  path     = "autosync/llms/azure/openai/gpt4o-mini"
   provider = vault.venture
 }
 
 # Data retrieval for text-embedding-3-small Key
 data "vault_generic_secret" "autosync_llms_azure_openai_text_embedding_3_small" {
-  path = "autosync/llms/azure/openai/text-embedding-3-small"
+  path     = "autosync/llms/azure/openai/text-embedding-3-small"
   provider = vault.venture
 }
 
 # Data retrieval for text-embedding-3-large Key
 data "vault_generic_secret" "autosync_llms_azure_openai_text_embedding_3_large" {
-  path = "autosync/llms/azure/openai/text-embedding-3-large"
+  path     = "autosync/llms/azure/openai/text-embedding-3-large"
   provider = vault.venture
 }
 
 # Data retrieval for Cisco Sharepoint Key
 data "vault_generic_secret" "autosync_datasources_sharepoint_outshiftgenai" {
-  path = "autosync/datasources/sharepoint/OutshiftGenAI"
+  path     = "autosync/datasources/sharepoint/OutshiftGenAI"
   provider = vault.venture
 }
 
 # Data retrieval for Outshift Private Sharepoint Client ID/Secret
 
 data "vault_generic_secret" "autosync_datasources_sharepoint_ciscoeticloud_api_motific_rag_user" {
-  path = "autosync/datasources/sharepoint/ciscoeticloud/api_users/motific-rag-user"
+  path     = "autosync/datasources/sharepoint/ciscoeticloud/api_users/motific-rag-user"
   provider = vault.venture
 }
 
 # Data retrieval for Outshift Private Sharepoint Key
 data "vault_generic_secret" "autosync_datasources_sharepoint_ciscoeticloud_human_motific_rag_user1" {
-  path = "autosync/datasources/sharepoint/ciscoeticloud/human_users/motific_rag_user1"
+  path     = "autosync/datasources/sharepoint/ciscoeticloud/human_users/motific_rag_user1"
   provider = vault.venture
 }
 
@@ -103,80 +103,80 @@ data "vault_generic_secret" "autosync_datasources_sharepoint_ciscoeticloud_human
 
 # Sync llms/mistral secrets to respective namespaces
 resource "vault_generic_secret" "llms_mistral" {
-  for_each = toset(local.mistral_kv_paths)
-  provider = vault.venture
+  for_each  = toset(local.mistral_kv_paths)
+  provider  = vault.venture
   data_json = data.vault_generic_secret.autosync_llms_mistral.data_json
-  path = "${each.value}/llms/mistral"
+  path      = "${each.value}/llms/mistral"
 }
 
 # Sync llms/aws/bedrock secrets to respective namespaces
 resource "vault_generic_secret" "llms_aws_bedrock" {
-  for_each = toset(local.aws_bedrock_kv_paths)
-  provider = vault.venture
+  for_each  = toset(local.aws_bedrock_kv_paths)
+  provider  = vault.venture
   data_json = data.vault_generic_secret.autosync_llms_aws_bedrock.data_json
-  path = "${each.value}/llms/aws/bedrock"
+  path      = "${each.value}/llms/aws/bedrock"
 }
 
 # Sync llms/azure/openai/gpt4 secrets to respective namespaces
 resource "vault_generic_secret" "llms_azure_openai_gpt4" {
-  for_each = toset(local.gpt4_kv_paths)
-  provider = vault.venture
+  for_each  = toset(local.gpt4_kv_paths)
+  provider  = vault.venture
   data_json = data.vault_generic_secret.autosync_llms_azure_openai_gpt4.data_json
-  path = "${each.value}/llms/azure/openai/gpt4"
+  path      = "${each.value}/llms/azure/openai/gpt4"
 }
 
 # Sync llms/azure/openai/gpt4o secrets to respective namespaces
 resource "vault_generic_secret" "llms_azure_openai_gpt4o" {
-  for_each = toset(local.gpt4o_kv_paths)
-  provider = vault.venture
+  for_each  = toset(local.gpt4o_kv_paths)
+  provider  = vault.venture
   data_json = data.vault_generic_secret.autosync_llms_azure_openai_gpt4o.data_json
-  path = "${each.value}/llms/azure/openai/gpt4o"
+  path      = "${each.value}/llms/azure/openai/gpt4o"
 }
 
 # Sync llms/azure/openai/gpt4o-mini secrets to respective namespaces
 resource "vault_generic_secret" "llms_azure_openai_gpt4o-mini" {
-  for_each = toset(local.gpt4o-mini_kv_paths)
-  provider = vault.venture
+  for_each  = toset(local.gpt4o-mini_kv_paths)
+  provider  = vault.venture
   data_json = data.vault_generic_secret.autosync_llms_azure_openai_gpt4o-mini.data_json
-  path = "${each.value}/llms/azure/openai/gpt4o-mini"
+  path      = "${each.value}/llms/azure/openai/gpt4o-mini"
 }
 
 # Sync llms/azure/openai/text-embedding-3-small secrets to respective namespaces
 resource "vault_generic_secret" "llms_azure_openai_text_embedding_3_small" {
-  for_each = toset(local.text_embedding_3_small_kv_paths)
-  provider = vault.venture
+  for_each  = toset(local.text_embedding_3_small_kv_paths)
+  provider  = vault.venture
   data_json = data.vault_generic_secret.autosync_llms_azure_openai_text_embedding_3_small.data_json
-  path = "${each.value}/llms/azure/openai/text-embedding-3-small"
+  path      = "${each.value}/llms/azure/openai/text-embedding-3-small"
 }
 
 # Sync llms/azure/openai/text-embedding-3-large secrets to respective namespaces
 resource "vault_generic_secret" "llms_azure_openai_text_embedding_3_large" {
-  for_each = toset(local.text_embedding_3_large_kv_paths)
-  provider = vault.venture
+  for_each  = toset(local.text_embedding_3_large_kv_paths)
+  provider  = vault.venture
   data_json = data.vault_generic_secret.autosync_llms_azure_openai_text_embedding_3_large.data_json
-  path = "${each.value}/llms/azure/openai/text-embedding-3-large"
+  path      = "${each.value}/llms/azure/openai/text-embedding-3-large"
 }
 
 # Sync Cisco Sharepoint secrets to respective namespaces
 resource "vault_generic_secret" "datasources_sharepoint_outshiftgenai" {
-  for_each = toset(local.datasources_sharepoint_outshiftgenai_kv_paths)
-  provider = vault.venture
+  for_each  = toset(local.datasources_sharepoint_outshiftgenai_kv_paths)
+  provider  = vault.venture
   data_json = data.vault_generic_secret.autosync_datasources_sharepoint_outshiftgenai.data_json
-  path = "${each.value}/datasources/sharepoint/OutshiftGenAI"
+  path      = "${each.value}/datasources/sharepoint/OutshiftGenAI"
 }
 
 # Sync Outshift Private Sharepoint Azure Service Principle secrets to respective namespaces
 resource "vault_generic_secret" "datasources_sharepoint_ciscoeticloud_api_motific_rag_user" {
-  for_each = toset(local.datasources_sharepoint_ciscoeticloud_api_motific_rag_user_kv_paths)
-  provider = vault.venture
+  for_each  = toset(local.datasources_sharepoint_ciscoeticloud_api_motific_rag_user_kv_paths)
+  provider  = vault.venture
   data_json = data.vault_generic_secret.autosync_datasources_sharepoint_ciscoeticloud_api_motific_rag_user.data_json
-  path = "${each.value}/datasources/sharepoint/ciscoeticloud/api_users/motific-rag-user"
+  path      = "${each.value}/datasources/sharepoint/ciscoeticloud/api_users/motific-rag-user"
 }
 
 # Sync Outshift Private Sharepoint Azure Human User secrets to respective namespaces
 resource "vault_generic_secret" "datasources_sharepoint_ciscoeticloud_human_motific_rag_user1" {
-  for_each = toset(local.datasources_sharepoint_ciscoeticloud_human_motific_rag_user1_kv_paths)
-  provider = vault.venture
+  for_each  = toset(local.datasources_sharepoint_ciscoeticloud_human_motific_rag_user1_kv_paths)
+  provider  = vault.venture
   data_json = data.vault_generic_secret.autosync_datasources_sharepoint_ciscoeticloud_human_motific_rag_user1.data_json
-  path = "${each.value}/datasources/sharepoint/ciscoeticloud/human_users/motific_rag_user1"
+  path      = "${each.value}/datasources/sharepoint/ciscoeticloud/human_users/motific_rag_user1"
 }

--- a/keeper_namespaces_eticloud_outshift-users_dmonkey.tf
+++ b/keeper_namespaces_eticloud_outshift-users_dmonkey.tf
@@ -20,10 +20,10 @@ resource "vault_jwt_auth_backend_role" "dmonkey" {
     given_name  = "given_name",
     sub         = "sub"
   }
-  groups_claim = "memberof"
-  oidc_scopes  = ["profile", "email", "openid"]
-  user_claim   = "sub"
-  token_policies = [vault_policy.dmonkey.name]
+  groups_claim   = "memberof"
+  oidc_scopes    = ["profile", "email", "openid"]
+  user_claim     = "sub"
+  token_policies = [vault_policy.dmonkey.name, vault_policy.default.name]
 }
 resource "vault_policy" "dmonkey" {
   provider = vault.venture

--- a/keeper_namespaces_eticloud_outshift-users_engineering_rd.tf
+++ b/keeper_namespaces_eticloud_outshift-users_engineering_rd.tf
@@ -20,10 +20,10 @@ resource "vault_jwt_auth_backend_role" "engineering_rd" {
     given_name  = "given_name",
     sub         = "sub"
   }
-  groups_claim = "memberof"
-  oidc_scopes  = ["profile", "email", "openid"]
-  user_claim   = "sub"
-  token_policies = [vault_policy.engineering_rd.name]
+  groups_claim   = "memberof"
+  oidc_scopes    = ["profile", "email", "openid"]
+  user_claim     = "sub"
+  token_policies = [vault_policy.engineering_rd.name, vault_policy.default.name]
 }
 
 resource "vault_policy" "engineering_rd" {

--- a/keeper_namespaces_eticloud_outshift-users_main.tf
+++ b/keeper_namespaces_eticloud_outshift-users_main.tf
@@ -147,6 +147,5 @@ path "auth/token/revoke-self" {
 path "sys/capabilities-self" {
     capabilities = ["update"]
 }
-}
 EOT
 }

--- a/keeper_namespaces_eticloud_outshift-users_main.tf
+++ b/keeper_namespaces_eticloud_outshift-users_main.tf
@@ -126,3 +126,27 @@ resource "vault_jwt_auth_backend" "oidc" {
   oidc_discovery_url = "https://sso-dbbfec7f.sso.duosecurity.com/oidc/${var.oidc_client_id}"
   default_role       = "sandbox-developer"
 }
+
+resource "vault_policy" "default" {
+  provider = vault.venture
+  name     = "default"
+  policy   = <<EOT
+# Allow tokens to look up their own properties
+path "auth/token/lookup-self" {
+    capabilities = ["read"]
+}
+# Allow tokens to renew themselves
+path "auth/token/renew-self" {
+    capabilities = ["update"]
+}
+# Allow tokens to revoke themselves
+path "auth/token/revoke-self" {
+    capabilities = ["update"]
+}
+# Allow a token to look up its own capabilities on a path
+path "sys/capabilities-self" {
+    capabilities = ["update"]
+}
+}
+EOT
+}

--- a/keeper_namespaces_eticloud_outshift-users_ostinato.tf
+++ b/keeper_namespaces_eticloud_outshift-users_ostinato.tf
@@ -20,10 +20,10 @@ resource "vault_jwt_auth_backend_role" "ostinato" {
     given_name  = "given_name",
     sub         = "sub"
   }
-  groups_claim = "memberof"
-  oidc_scopes  = ["profile", "email", "openid"]
-  user_claim   = "sub"
-  token_policies = [vault_policy.ostinato.name]
+  groups_claim   = "memberof"
+  oidc_scopes    = ["profile", "email", "openid"]
+  user_claim     = "sub"
+  token_policies = [vault_policy.ostinato.name, vault_policy.default.name]
 }
 resource "vault_policy" "ostinato" {
   provider = vault.venture

--- a/keeper_namespaces_eticloud_outshift-users_phoenix.tf
+++ b/keeper_namespaces_eticloud_outshift-users_phoenix.tf
@@ -20,10 +20,10 @@ resource "vault_jwt_auth_backend_role" "phoenix" {
     given_name  = "given_name",
     sub         = "sub"
   }
-  groups_claim = "memberof"
-  oidc_scopes  = ["profile", "email", "openid"]
-  user_claim   = "sub"
-  token_policies = [vault_policy.phoenix.name]
+  groups_claim   = "memberof"
+  oidc_scopes    = ["profile", "email", "openid"]
+  user_claim     = "sub"
+  token_policies = [vault_policy.phoenix.name, vault_policy.default.name]
 }
 
 resource "vault_policy" "phoenix" {

--- a/keeper_namespaces_eticloud_outshift-users_prcoach.tf
+++ b/keeper_namespaces_eticloud_outshift-users_prcoach.tf
@@ -20,10 +20,10 @@ resource "vault_jwt_auth_backend_role" "prcoach" {
     given_name  = "given_name",
     sub         = "sub"
   }
-  groups_claim = "memberof"
-  oidc_scopes  = ["profile", "email", "openid"]
-  user_claim   = "sub"
-  token_policies = [vault_policy.prcoach.name]
+  groups_claim   = "memberof"
+  oidc_scopes    = ["profile", "email", "openid"]
+  user_claim     = "sub"
+  token_policies = [vault_policy.prcoach.name] # TODO: vault_policy.default.name was added in Keeper UI, import it
 }
 
 resource "vault_policy" "prcoach" {

--- a/keeper_namespaces_eticloud_outshift-users_prcoach.tf
+++ b/keeper_namespaces_eticloud_outshift-users_prcoach.tf
@@ -23,7 +23,7 @@ resource "vault_jwt_auth_backend_role" "prcoach" {
   groups_claim   = "memberof"
   oidc_scopes    = ["profile", "email", "openid"]
   user_claim     = "sub"
-  token_policies = [vault_policy.prcoach.name] # TODO: vault_policy.default.name was added in Keeper UI, import it
+  token_policies = [vault_policy.prcoach.name, vault_policy.default.name]
 }
 
 resource "vault_policy" "prcoach" {

--- a/keeper_namespaces_eticloud_outshift-users_puccini.tf
+++ b/keeper_namespaces_eticloud_outshift-users_puccini.tf
@@ -20,10 +20,10 @@ resource "vault_jwt_auth_backend_role" "puccini" {
     given_name  = "given_name",
     sub         = "sub"
   }
-  groups_claim = "memberof"
-  oidc_scopes  = ["profile", "email", "openid"]
-  user_claim   = "sub"
-  token_policies = [vault_policy.puccini.name]
+  groups_claim   = "memberof"
+  oidc_scopes    = ["profile", "email", "openid"]
+  user_claim     = "sub"
+  token_policies = [vault_policy.puccini.name, vault_policy.default.name]
 }
 
 resource "vault_policy" "puccini" {

--- a/keeper_namespaces_eticloud_outshift-users_ragv2.tf
+++ b/keeper_namespaces_eticloud_outshift-users_ragv2.tf
@@ -20,10 +20,10 @@ resource "vault_jwt_auth_backend_role" "ragv2" {
     given_name  = "given_name",
     sub         = "sub"
   }
-  groups_claim = "memberof"
-  oidc_scopes  = ["profile", "email", "openid"]
-  user_claim   = "sub"
-  token_policies = [vault_policy.ragv2.name]
+  groups_claim   = "memberof"
+  oidc_scopes    = ["profile", "email", "openid"]
+  user_claim     = "sub"
+  token_policies = [vault_policy.ragv2.name, vault_policy.default.name]
 }
 
 resource "vault_policy" "ragv2" {

--- a/keeper_namespaces_eticloud_outshift-users_sandbox-developer.tf
+++ b/keeper_namespaces_eticloud_outshift-users_sandbox-developer.tf
@@ -20,10 +20,10 @@ resource "vault_jwt_auth_backend_role" "sandbox-developer" {
     given_name  = "given_name",
     sub         = "sub"
   }
-  groups_claim = "memberof"
-  oidc_scopes  = ["profile", "email", "openid"]
-  user_claim   = "sub"
-  token_policies = [vault_policy.sandbox-developer.name]
+  groups_claim   = "memberof"
+  oidc_scopes    = ["profile", "email", "openid"]
+  user_claim     = "sub"
+  token_policies = [vault_policy.sandbox-developer.name, vault_policy.default.name]
 }
 resource "vault_policy" "sandbox-developer" {
   provider = vault.venture

--- a/keeper_namespaces_eticloud_outshift-users_secrets-engines_aws_aws-eticloud_iam.tf
+++ b/keeper_namespaces_eticloud_outshift-users_secrets-engines_aws_aws-eticloud_iam.tf
@@ -4,8 +4,8 @@ resource "aws_iam_user" "vault-secret-engine-dev-sandbox" {
 }
 
 resource "aws_iam_user_policy" "vault-secret-engine-dev-sandbox-policy" {
-  name   = "vault-secret-engine-dev-sandbox-policy"
-  user   = aws_iam_user.vault-secret-engine-dev-sandbox.name
+  name = "vault-secret-engine-dev-sandbox-policy"
+  user = aws_iam_user.vault-secret-engine-dev-sandbox.name
 
   policy = <<EOF
 {

--- a/keeper_namespaces_eticloud_outshift-users_secrets-engines_aws_aws-eticloud_main.tf
+++ b/keeper_namespaces_eticloud_outshift-users_secrets-engines_aws_aws-eticloud_main.tf
@@ -3,8 +3,8 @@ resource "vault_aws_secret_backend" "dev-sandbox-aws-eticloud" {
   path        = "dev-sandbox-aws-eticloud"
   description = "AWS Secrets Engine for Dev Sandbox access"
 
-  access_key  = aws_iam_access_key.vault-secret-engine-dev-sandbox.id
-  secret_key  = aws_iam_access_key.vault-secret-engine-dev-sandbox.secret
+  access_key = aws_iam_access_key.vault-secret-engine-dev-sandbox.id
+  secret_key = aws_iam_access_key.vault-secret-engine-dev-sandbox.secret
 }
 
 resource "vault_aws_secret_backend_role" "dev-sandbox-vault-role" {

--- a/keeper_namespaces_eticloud_outshift-users_secrets-engines_aws_aws-eticloud_provider.tf
+++ b/keeper_namespaces_eticloud_outshift-users_secrets-engines_aws_aws-eticloud_provider.tf
@@ -9,7 +9,7 @@ provider "vault" {
 }
 
 data "vault_generic_secret" "aws_infra_credential" {
-  path      = "secret/infra/aws/eticloud/terraform_admin"
+  path = "secret/infra/aws/eticloud/terraform_admin"
 }
 
 # Infra AWS Provider

--- a/keeper_namespaces_eticloud_outshift-users_smith.tf
+++ b/keeper_namespaces_eticloud_outshift-users_smith.tf
@@ -20,10 +20,10 @@ resource "vault_jwt_auth_backend_role" "smith" {
     given_name  = "given_name",
     sub         = "sub"
   }
-  groups_claim = "memberof"
-  oidc_scopes  = ["profile", "email", "openid"]
-  user_claim   = "sub"
-  token_policies = [vault_policy.smith.name]
+  groups_claim   = "memberof"
+  oidc_scopes    = ["profile", "email", "openid"]
+  user_claim     = "sub"
+  token_policies = [vault_policy.smith.name, vault_policy.default.name]
 }
 
 resource "vault_policy" "smith" {


### PR DESCRIPTION
## Fixes/Implements # (JIRA issue if applicable)  

https://cisco-eti.atlassian.net/browse/OPENSD-1067

We were seeing `403`s on `GET v1/auth/token/lookup-self` thus being unable to log in with the Keeper / Vault UI

and `fmt`.

### If the (atlantis) plan is destroying resources, reason for deletion  

N/A

### Additional details

- [x] `terraform fmt` was applied
- [x] All atlantis plans can be applied
- [ ] (For reviewers) I have verified the resource changes
