### PR TITLE
feat(github-org): add cisco-platform

### DIFF
--- a/github.com_cisco-platform_gh_actions_org_secrets.tf
+++ b/github.com_cisco-platform_gh_actions_org_secrets.tf
@@ -1,0 +1,74 @@
+data "vault_generic_secret" "gha_ci_secrets" {
+  provider = vault.eticloud
+  path     = "ci/gha/gh-actions"
+}
+
+data "vault_generic_secret" "GHCR_TOKEN" {
+  provider = vault.eticloud
+  path     = "ci/gha/GHCR_TOKEN"
+}
+
+data "vault_generic_secret" "gha_approle" {
+  provider = vault.eticloud
+  path     = "ci/gha/approle"
+}
+
+data "github_actions_organization_public_key" "gha_org_public_key" {
+}
+
+data "sodium_encrypted_item" "GHCR_TOKEN" {
+  public_key_base64 = data.github_actions_organization_public_key.gha_org_public_key.key
+  content_base64    = base64encode(data.vault_generic_secret.GHCR_TOKEN.data["PAT"])
+}
+
+data "sodium_encrypted_item" "GHCR_USERNAME" {
+  public_key_base64 = data.github_actions_organization_public_key.gha_org_public_key.key
+  content_base64    = base64encode(data.vault_generic_secret.GHCR_TOKEN.data["GHEC_USERNAME"])
+}
+
+data "sodium_encrypted_item" "VAULT_APPROLE_ROLE_ID" {
+  public_key_base64 = data.github_actions_organization_public_key.gha_org_public_key.key
+  content_base64    = base64encode(data.vault_generic_secret.gha_approle.data["VAULT_APPROLE_ROLE_ID"])
+}
+
+data "sodium_encrypted_item" "VAULT_APPROLE_SECRET_ID" {
+  public_key_base64 = data.github_actions_organization_public_key.gha_org_public_key.key
+  content_base64    = base64encode(data.vault_generic_secret.gha_approle.data["VAULT_APPROLE_SECRET_ID"])
+}
+
+data "sodium_encrypted_item" "WEBEX_PLATFORM_NOTIFICATION_ROOM_ID" {
+  public_key_base64 = data.github_actions_organization_public_key.gha_org_public_key.key
+  content_base64    = base64encode(data.vault_generic_secret.gha_ci_secrets.data["WEBEX_PLATFORM_NOTIFICATION_ROOM_ID"])
+}
+
+data "sodium_encrypted_item" "WEBEX_TOKEN" {
+  public_key_base64 = data.github_actions_organization_public_key.gha_org_public_key.key
+  content_base64    = base64encode(data.vault_generic_secret.gha_ci_secrets.data["WEBEX_TOKEN"])
+}
+
+data "sodium_encrypted_item" "DEVHUB_TOKEN" {
+  public_key_base64 = data.github_actions_organization_public_key.gha_org_public_key.key
+  content_base64    = base64encode(data.vault_generic_secret.gha_ci_secrets.data["DEVHUB_TOKEN"])
+}
+
+locals {
+  github_secrets = {
+    "GHCR_TOKEN"                          = data.sodium_encrypted_item.GHCR_TOKEN.encrypted_value_base64
+    "GHCR_USERNAME"                       = data.sodium_encrypted_item.GHCR_USERNAME.encrypted_value_base64
+    "VAULT_APPROLE_ROLE_ID"               = data.sodium_encrypted_item.VAULT_APPROLE_ROLE_ID.encrypted_value_base64
+    "VAULT_APPROLE_SECRET_ID"             = data.sodium_encrypted_item.VAULT_APPROLE_SECRET_ID.encrypted_value_base64
+    "WEBEX_PLATFORM_NOTIFICATION_ROOM_ID" = data.sodium_encrypted_item.WEBEX_PLATFORM_NOTIFICATION_ROOM_ID.encrypted_value_base64
+    "WEBEX_TOKEN"                         = data.sodium_encrypted_item.WEBEX_TOKEN.encrypted_value_base64
+    "DEVHUB_TOKEN"                        = data.sodium_encrypted_item.DEVHUB_TOKEN.encrypted_value_base64
+  }
+}
+resource "github_actions_organization_secret" "dynamic" {
+  for_each        = local.github_secrets
+  secret_name     = each.key
+  visibility      = "private"
+  encrypted_value = each.value
+
+  lifecycle {
+    ignore_changes = [encrypted_value]
+  }
+}

--- a/github.com_cisco-platform_gh_actions_org_variables.tf
+++ b/github.com_cisco-platform_gh_actions_org_variables.tf
@@ -1,0 +1,24 @@
+locals {
+  github_variables = {
+    "DEFAULT_RUNNER_GROUP"           = "SRE-Large-Runners"
+    "ECR_PUBLIC_REGISTRY_ALIAS"      = "ciscoeti"
+    "GHCR_REGISTRY"                  = "ghcr.io/cisco-eti"
+    "LATEST_SRE_BUILD_IMAGE"         = "ghcr.io/cisco-eti/sre-pipeline-docker:2024.05.30-e409a0c-90"
+    "SONAR_PROPERTIES_FILE"          = "build/sonar-project.properties"
+    "SONAR_SCANNER_CLI_DOCKER_IMAGE" = "ghcr.io/cisco-eti/sonar-scanner-cli:latest"
+    "SRE_BUILD_IMAGE"                = "ghcr.io/cisco-eti/sre-pipeline-docker:2024.05.30-e409a0c-91"
+    "UBUNTU_RUNNER"                  = "ubuntu-latest"
+    "KEEPER_URL"                     = "https://keeper.cisco.com"
+    "VAULT_ADDR"                     = "https://keeper.cisco.com"
+    "VAULT_NAMESPACE"                = "eticloud"
+    "VAULT_SECRET_PATH"              = "ci/data/gha/gh-actions"
+  }
+}
+
+resource "github_actions_organization_variable" "dynamic" {
+  for_each = local.github_variables
+
+  variable_name = each.key
+  visibility    = "private"
+  value         = each.value
+}

--- a/github.com_cisco-platform_gh_actions_org_variables.tf
+++ b/github.com_cisco-platform_gh_actions_org_variables.tf
@@ -1,12 +1,8 @@
 locals {
   github_variables = {
     "DEFAULT_RUNNER_GROUP"           = "SRE-Large-Runners"
-    "ECR_PUBLIC_REGISTRY_ALIAS"      = "ciscoeti"
-    "GHCR_REGISTRY"                  = "ghcr.io/cisco-eti"
-    "LATEST_SRE_BUILD_IMAGE"         = "ghcr.io/cisco-eti/sre-pipeline-docker:2024.05.30-e409a0c-90"
-    "SONAR_PROPERTIES_FILE"          = "build/sonar-project.properties"
-    "SONAR_SCANNER_CLI_DOCKER_IMAGE" = "ghcr.io/cisco-eti/sonar-scanner-cli:latest"
-    "SRE_BUILD_IMAGE"                = "ghcr.io/cisco-eti/sre-pipeline-docker:2024.05.30-e409a0c-91"
+    "ECR_PUBLIC_REGISTRY_ALIAS"      = "ciscoplatform"
+    "GHCR_REGISTRY"                  = "ghcr.io/cisco-platform"
     "UBUNTU_RUNNER"                  = "ubuntu-latest"
     "KEEPER_URL"                     = "https://keeper.cisco.com"
     "VAULT_ADDR"                     = "https://keeper.cisco.com"

--- a/github.com_cisco-platform_gh_actions_runner_group.tf
+++ b/github.com_cisco-platform_gh_actions_runner_group.tf
@@ -1,0 +1,4 @@
+resource "github_actions_runner_group" "SRE-Large-Runners" {
+  name       = "SRE-Large-Runners"
+  visibility = "all"
+}

--- a/github.com_cisco-platform_provider.tf
+++ b/github.com_cisco-platform_provider.tf
@@ -1,7 +1,7 @@
 terraform {
   backend "s3" {
     bucket = "eticloud-tf-state-prod"
-    key    = "terraform-state/github.com/cisco-eti/backend.tfstate"
+    key    = "terraform-state/github.com/cisco-platform/backend.tfstate"
     region = "us-east-2"
   }
   required_providers {

--- a/github.com_cisco-platform_provider.tf
+++ b/github.com_cisco-platform_provider.tf
@@ -35,5 +35,5 @@ data "vault_generic_secret" "generic_user_gh_token" {
 # Configure the GitHub Provider
 provider "github" {
   token = data.vault_generic_secret.generic_user_gh_token.data["TERRAFORM_ADMIN_GHEC_PAT"]
-  owner = "cisco-platform" # CHANGE_ME: The owner of the repository
+  owner = "cisco-platform"
 }

--- a/github.com_cisco-platform_provider.tf
+++ b/github.com_cisco-platform_provider.tf
@@ -1,0 +1,39 @@
+terraform {
+  backend "s3" {
+    bucket = "eticloud-tf-state-prod"
+    key    = "terraform-state/github.com/cisco-eti/backend.tfstate"
+    region = "us-east-2"
+  }
+  required_providers {
+    sodium = {
+      source  = "killmeplz/sodium"
+      version = "~> 0.0.3"
+    }
+    github = {
+      source  = "integrations/github"
+      version = "~> 6.0"
+    }
+  }
+}
+provider "vault" {
+  alias     = "eticloud_teamsecrets"
+  address   = "https://keeper.cisco.com"
+  namespace = "eticloud/teamsecrets"
+}
+
+provider "vault" {
+  alias     = "eticloud"
+  address   = "https://keeper.cisco.com"
+  namespace = "eticloud"
+}
+
+data "vault_generic_secret" "generic_user_gh_token" {
+  provider = vault.eticloud_teamsecrets
+  path     = "secret/generic_users/eti-sre-cicd.gen"
+}
+
+# Configure the GitHub Provider
+provider "github" {
+  token = data.vault_generic_secret.generic_user_gh_token.data["TERRAFORM_ADMIN_GHEC_PAT"]
+  owner = "cisco-platform" # CHANGE_ME: The owner of the repository
+}


### PR DESCRIPTION
## Fixes/Implements # (JIRA issue if applicable)  

Since we have a new org https://github.com/cisco-platform, does it make sense to add the GitHub secret management here? 

### Description/Justification

(Why is this change needed? Which team might need it? etc...)  

This was done for https://github.com/outshift-platform


### If the (atlantis) plan is destroying resources, reason for deletion  


### Additional details

- [x] `terraform fmt` was applied
- [ ] All atlantis plans can be applied
- [ ] (For reviewers) I have verified the resource changes
