### PR TITLE
chore: add ESO to access secrets from a3po vault namespace in the comn-dev-use2-1 cluster

### DIFF
--- a/aws_outshift-common-dev_us-east-2_eks_comn-dev-use2-1_eso-a3po_eso.tf
+++ b/aws_outshift-common-dev_us-east-2_eks_comn-dev-use2-1_eso-a3po_eso.tf
@@ -40,7 +40,7 @@ data "aws_eks_cluster" "cluster" {
 data "vault_generic_secret" "cluster_certificate" {
   provider   = vault.eticloud
   path       = "secret/infra/eks/${local.name}/certificate"
-  depends_on = [module.eks_all_in_one]
+  
 }
 
 module "eso_eticloud_apps_a3po" {

--- a/aws_outshift-common-dev_us-east-2_eks_comn-dev-use2-1_eso-a3po_eso.tf
+++ b/aws_outshift-common-dev_us-east-2_eks_comn-dev-use2-1_eso-a3po_eso.tf
@@ -1,3 +1,8 @@
+/* 
+Created this ESO config file in its own directory to allow it to have its own tfstate 
+as a workaround to Atlantis apply failure as it kept trying to modify resources related to the comn-dev-use2-1 cluster tfstate
+*/
+
 terraform {
   backend "s3" {
     # This is the name of the backend S3 bucket.

--- a/aws_outshift-common-dev_us-east-2_eks_comn-dev-use2-1_eso-a3po_eso.tf
+++ b/aws_outshift-common-dev_us-east-2_eks_comn-dev-use2-1_eso-a3po_eso.tf
@@ -3,7 +3,7 @@ terraform {
     # This is the name of the backend S3 bucket.
     bucket = "eticloud-tf-state-nonprod"
     # This is the path to the Terraform state file in the backend S3 bucket.
-    key = "terraform-state/aws/eticloud/us-east-2/eks/comn-dev-use2-1.tfstate"
+    key = "terraform-state/aws/eticloud/us-east-2/eks/eso-a3po-comn-dev-use2-1.tfstate"
     # This is the region where the backend S3 bucket is located.
     region = "us-east-2" # DO NOT CHANGE.
   }

--- a/aws_outshift-common-dev_us-east-2_eks_comn-dev-use2-1_eso-a3po_eso.tf
+++ b/aws_outshift-common-dev_us-east-2_eks_comn-dev-use2-1_eso-a3po_eso.tf
@@ -1,0 +1,53 @@
+terraform {
+  backend "s3" {
+    # This is the name of the backend S3 bucket.
+    bucket = "eticloud-tf-state-nonprod"
+    # This is the path to the Terraform state file in the backend S3 bucket.
+    key = "terraform-state/aws/eticloud/us-east-2/eks/comn-dev-use2-1.tfstate"
+    # This is the region where the backend S3 bucket is located.
+    region = "us-east-2" # DO NOT CHANGE.
+  }
+}
+
+locals {
+  name             = "comn-dev-use2-1"
+  region           = "us-east-2"
+  aws_account_name = "outshift-common-dev"
+  account_id       = "471112537430"
+}
+
+provider "vault" {
+  alias     = "eticloud"
+  address   = "https://keeper.cisco.com"
+  namespace = "eticloud"
+}
+
+data "vault_generic_secret" "aws_infra_credential" {
+  provider = vault.eticloud
+  path     = "secret/infra/aws/${local.aws_account_name}/terraform_admin"
+}
+
+provider "aws" {
+  access_key = data.vault_generic_secret.aws_infra_credential.data["AWS_ACCESS_KEY_ID"]
+  secret_key = data.vault_generic_secret.aws_infra_credential.data["AWS_SECRET_ACCESS_KEY"]
+  region     = local.region
+}
+
+data "aws_eks_cluster" "cluster" {
+  name       = local.name
+}
+
+data "vault_generic_secret" "cluster_certificate" {
+  provider   = vault.eticloud
+  path       = "secret/infra/eks/${local.name}/certificate"
+  depends_on = [module.eks_all_in_one]
+}
+
+module "eso_eticloud_apps_a3po" {
+  source          = "git::https://github.com/cisco-eti/sre-tf-module-eso-access.git?ref=1.0.0"
+  cluster_name    = local.name
+  vault_namespace = "eticloud/apps/a3po"
+  kubernetes_host = data.aws_eks_cluster.cluster.endpoint
+  kubernetes_ca   = base64decode(data.vault_generic_secret.cluster_certificate.data["b64certificate"])
+  policies        = ["external-secrets-${local.name}"]
+}

--- a/aws_outshift-common-dev_us-east-2_eks_comn-dev-use2-1_eso.tf
+++ b/aws_outshift-common-dev_us-east-2_eks_comn-dev-use2-1_eso.tf
@@ -151,12 +151,3 @@ module "eso_eticloud_apps_aether" {
   kubernetes_ca   = base64decode(data.vault_generic_secret.cluster_certificate.data["b64certificate"])
   policies        = ["external-secrets-${local.name}"]
 }
-
-module "eso_eticloud_apps_a3po" {
-  source          = "git::https://github.com/cisco-eti/sre-tf-module-eso-access.git?ref=1.0.0"
-  cluster_name    = local.name
-  vault_namespace = "eticloud/apps/a3po"
-  kubernetes_host = data.aws_eks_cluster.cluster.endpoint
-  kubernetes_ca   = base64decode(data.vault_generic_secret.cluster_certificate.data["b64certificate"])
-  policies        = ["external-secrets-${local.name}"]
-}

--- a/aws_outshift-common-dev_us-east-2_eks_comn-dev-use2-1_eso.tf
+++ b/aws_outshift-common-dev_us-east-2_eks_comn-dev-use2-1_eso.tf
@@ -1,0 +1,162 @@
+provider "vault" {
+  alias     = "eticloud"
+  address   = "https://keeper.cisco.com"
+  namespace = "eticloud"
+}
+
+data "vault_generic_secret" "aws_infra_credential" {
+  provider = vault.eticloud
+  path     = "secret/infra/aws/${local.aws_account_name}/terraform_admin"
+}
+
+provider "aws" {
+  access_key = data.vault_generic_secret.aws_infra_credential.data["AWS_ACCESS_KEY_ID"]
+  secret_key = data.vault_generic_secret.aws_infra_credential.data["AWS_SECRET_ACCESS_KEY"]
+  region     = local.region
+}
+
+data "aws_eks_cluster" "cluster" {
+  depends_on = [module.eks_all_in_one]
+  name       = local.name
+}
+
+data "vault_generic_secret" "cluster_certificate" {
+  provider   = vault.eticloud
+  path       = "secret/infra/eks/${local.name}/certificate"
+  depends_on = [module.eks_all_in_one]
+}
+
+module "eso_eticloud" {
+  source          = "git::https://github.com/cisco-eti/sre-tf-module-eso-access.git?ref=1.0.0"
+  cluster_name    = local.name
+  vault_namespace = "eticloud"
+  kubernetes_host = data.aws_eks_cluster.cluster.endpoint
+  kubernetes_ca   = base64decode(data.vault_generic_secret.cluster_certificate.data["b64certificate"])
+  policies        = ["external-secrets-${local.name}"]
+}
+
+module "eso_eticloud_apps_appnet" {
+  source          = "git::https://github.com/cisco-eti/sre-tf-module-eso-access.git?ref=1.0.0"
+  cluster_name    = local.name
+  vault_namespace = "eticloud/apps/appnet"
+  kubernetes_host = data.aws_eks_cluster.cluster.endpoint
+  kubernetes_ca   = base64decode(data.vault_generic_secret.cluster_certificate.data["b64certificate"])
+  policies        = ["external-secrets-${local.name}"]
+}
+
+module "eso_eticloud_apps_research" {
+  source          = "git::https://github.com/cisco-eti/sre-tf-module-eso-access.git?ref=1.0.0"
+  cluster_name    = local.name
+  vault_namespace = "eticloud/apps/research"
+  kubernetes_host = data.aws_eks_cluster.cluster.endpoint
+  kubernetes_ca   = base64decode(data.vault_generic_secret.cluster_certificate.data["b64certificate"])
+  policies        = ["external-secrets-${local.name}"]
+}
+
+module "eso_eticloud_apps_sre" {
+  source          = "git::https://github.com/cisco-eti/sre-tf-module-eso-access.git?ref=1.0.0"
+  cluster_name    = local.name
+  vault_namespace = "eticloud/apps/sre"
+  kubernetes_host = data.aws_eks_cluster.cluster.endpoint
+  kubernetes_ca   = base64decode(data.vault_generic_secret.cluster_certificate.data["b64certificate"])
+  policies        = ["external-secrets-${local.name}"]
+}
+
+module "eso_eticloud_apps_websites" {
+  source          = "git::https://github.com/cisco-eti/sre-tf-module-eso-access.git?ref=1.0.0"
+  cluster_name    = local.name
+  vault_namespace = "eticloud/apps/websites"
+  kubernetes_host = data.aws_eks_cluster.cluster.endpoint
+  kubernetes_ca   = base64decode(data.vault_generic_secret.cluster_certificate.data["b64certificate"])
+  policies        = ["external-secrets-${local.name}"]
+}
+
+module "eso_eticloud_apps_identity" {
+  source          = "git::https://github.com/cisco-eti/sre-tf-module-eso-access.git?ref=1.0.0"
+  cluster_name    = local.name
+  vault_namespace = "eticloud/apps/eti-identity"
+  kubernetes_host = data.aws_eks_cluster.cluster.endpoint
+  kubernetes_ca   = base64decode(data.vault_generic_secret.cluster_certificate.data["b64certificate"])
+  policies        = ["external-secrets-${local.name}"]
+}
+
+module "eso_eticloud_apps_banzai" {
+  source          = "git::https://github.com/cisco-eti/sre-tf-module-eso-access.git?ref=1.0.0"
+  cluster_name    = local.name
+  vault_namespace = "eticloud/apps/banzai"
+  kubernetes_host = data.aws_eks_cluster.cluster.endpoint
+  kubernetes_ca   = base64decode(data.vault_generic_secret.cluster_certificate.data["b64certificate"])
+  policies        = ["external-secrets-${local.name}"]
+}
+
+module "eso_eticloud_apps_demo_labs" {
+  source          = "git::https://github.com/cisco-eti/sre-tf-module-eso-access.git?ref=1.0.0"
+  cluster_name    = local.name
+  vault_namespace = "eticloud/apps/demo-labs"
+  kubernetes_host = data.aws_eks_cluster.cluster.endpoint
+  kubernetes_ca   = base64decode(data.vault_generic_secret.cluster_certificate.data["b64certificate"])
+  policies        = ["external-secrets-${local.name}"]
+}
+
+module "eso_eticloud_apps_genie" {
+  source          = "git::https://github.com/cisco-eti/sre-tf-module-eso-access.git?ref=1.0.0"
+  cluster_name    = local.name
+  vault_namespace = "eticloud/apps/genie"
+  kubernetes_host = data.aws_eks_cluster.cluster.endpoint
+  kubernetes_ca   = base64decode(data.vault_generic_secret.cluster_certificate.data["b64certificate"])
+  policies        = ["external-secrets-${local.name}"]
+}
+
+module "eso_eticloud_apps_cil" {
+  source          = "git::https://github.com/cisco-eti/sre-tf-module-eso-access.git?ref=1.0.0"
+  cluster_name    = local.name
+  vault_namespace = "eticloud/apps/cil"
+  kubernetes_host = data.aws_eks_cluster.cluster.endpoint
+  kubernetes_ca   = base64decode(data.vault_generic_secret.cluster_certificate.data["b64certificate"])
+  policies        = ["external-secrets-${local.name}"]
+}
+
+module "eso_eticloud_apps_ppu" {
+  source          = "git::https://github.com/cisco-eti/sre-tf-module-eso-access.git?ref=1.0.0"
+  cluster_name    = local.name
+  vault_namespace = "eticloud/apps/ppu"
+  kubernetes_host = data.aws_eks_cluster.cluster.endpoint
+  kubernetes_ca   = base64decode(data.vault_generic_secret.cluster_certificate.data["b64certificate"])
+  policies        = ["external-secrets-${local.name}"]
+}
+
+module "eso_eticloud_apps_rosey" {
+  source          = "git::https://github.com/cisco-eti/sre-tf-module-eso-access.git?ref=1.0.0"
+  cluster_name    = local.name
+  vault_namespace = "eticloud/apps/rosey"
+  kubernetes_host = data.aws_eks_cluster.cluster.endpoint
+  kubernetes_ca   = base64decode(data.vault_generic_secret.cluster_certificate.data["b64certificate"])
+  policies        = ["external-secrets-${local.name}"]
+}
+
+module "eso_eticloud_apps_puccini" {
+  source          = "git::https://github.com/cisco-eti/sre-tf-module-eso-access.git?ref=1.0.0"
+  cluster_name    = local.name
+  vault_namespace = "eticloud/apps/puccini"
+  kubernetes_host = data.aws_eks_cluster.cluster.endpoint
+  kubernetes_ca   = base64decode(data.vault_generic_secret.cluster_certificate.data["b64certificate"])
+  policies        = ["external-secrets-${local.name}"]
+}
+
+module "eso_eticloud_apps_aether" {
+  source          = "git::https://github.com/cisco-eti/sre-tf-module-eso-access.git?ref=1.0.0"
+  cluster_name    = local.name
+  vault_namespace = "eticloud/apps/aether"
+  kubernetes_host = data.aws_eks_cluster.cluster.endpoint
+  kubernetes_ca   = base64decode(data.vault_generic_secret.cluster_certificate.data["b64certificate"])
+  policies        = ["external-secrets-${local.name}"]
+}
+
+module "eso_eticloud_apps_a3po" {
+  source          = "git::https://github.com/cisco-eti/sre-tf-module-eso-access.git?ref=1.0.0"
+  cluster_name    = local.name
+  vault_namespace = "eticloud/apps/a3po"
+  kubernetes_host = data.aws_eks_cluster.cluster.endpoint
+  kubernetes_ca   = base64decode(data.vault_generic_secret.cluster_certificate.data["b64certificate"])
+  policies        = ["external-secrets-${local.name}"]
+}


### PR DESCRIPTION
## Fixes/Implements # (JIRA issue if applicable)  
https://cisco-eti.atlassian.net/browse/OPENSD-1130

### Additional details

- [x] `terraform fmt` was applied
- [ ] All atlantis plans can be applied
- [ ] (For reviewers) I have verified the resource changes
