### PR TITLE
OPENSD-1232: destroy eti-research-12 ec2 instance

### DIFF
--- a/aws_cisco-research_us-east-2_ec2_cisco-research-12_ec2.tf
+++ b/aws_cisco-research_us-east-2_ec2_cisco-research-12_ec2.tf
@@ -43,4 +43,4 @@ module "ec2" {
   tag_data_taxonomy               = "Cisco Operations Data"
   tag_environment                 = "Sandbox"
   tag_resource_owner              = "ETI SRE"
-}
+}  

--- a/aws_cisco-research_us-east-2_ec2_cisco-research-12_ec2.tf
+++ b/aws_cisco-research_us-east-2_ec2_cisco-research-12_ec2.tf
@@ -26,7 +26,7 @@ provider "aws" {
 }
 
 module "ec2" {
-  source                          = "git::https://wwwin-github.cisco.com/eti/sre-tf-module-aws-ec2?ref=1.1.8"
+  source                          = "git::https://github.com/cisco-eti/sre-tf-module-aws-ec2?ref=1.1.8"
   ec2_name                        = "cisco-research-12" # The name of the instance(s) to be created. Will be appended with a number.
   ec2_associate_public_ip_address = false              # Whether the instance(s) will have a public IP address. If true, the instances will be created in public subnets and additional security groups will be required.
   ec2_instance_count              = 1                  # The number of instances to create.


### PR DESCRIPTION
## Fixes/Implements # (JIRA issue if applicable)  
https://cisco-eti.atlassian.net/browse/OPENSD-1232

### If the (atlantis) plan is destroying resources, reason for deletion  
Resource not used anymore, hence the owner's request to decommission it

### Additional details

- [ ] `terraform fmt` was applied
- [ ] All atlantis plans can be applied
- [ ] (For reviewers) I have verified the resource changes
