### PR TITLE
chore: remove marvin s3 requests-failover-marvin-dev-use2-1

### DIFF
--- a/aws_outshift-common-dev_us-east-2_s3_requests-failover-marvin-dev-use2-1_main.tf
+++ b/aws_outshift-common-dev_us-east-2_s3_requests-failover-marvin-dev-use2-1_main.tf
@@ -23,7 +23,6 @@ terraform {
 
   }
 }
-
 variable "AWS_INFRA_REGION" {
   description = "AWS Region"
   default     = "us-east-2" #Set the region for the resources to be created.


### PR DESCRIPTION
## Fixes/Implements # (JIRA issue if applicable)  


### Description/Justification

(Why is this change needed? Which team might need it? etc...)  


### If the (atlantis) plan is destroying resources, reason for deletion  


### Additional details

- [ ] `terraform fmt` was applied
- [ ] All atlantis plans can be applied
- [ ] (For reviewers) I have verified the resource changes
