### PR TITLE
chore: adding ostinato RDS + roles

### DIFF
--- a/aws_outshift-common-dev_iam_roles_ostinato_ostinato-rag-roles.tf
+++ b/aws_outshift-common-dev_iam_roles_ostinato_ostinato-rag-roles.tf
@@ -1,0 +1,118 @@
+provider "vault" {
+  alias     = "eticloud"
+  address   = "https://keeper.cisco.com"
+  namespace = "eticloud"
+}
+
+data "vault_generic_secret" "aws_infra_credential" {
+  provider = vault.eticloud
+  path     = "secret/infra/aws/outshift-common-dev/terraform_admin"
+}
+
+provider "aws" {
+  access_key = data.vault_generic_secret.aws_infra_credential.data["AWS_ACCESS_KEY_ID"]
+  secret_key = data.vault_generic_secret.aws_infra_credential.data["AWS_SECRET_ACCESS_KEY"]
+  region     = "us-east-2"
+}
+
+resource "aws_iam_policy" "aws_ostinato_dev_rag_services_policy" {
+  name        = "ostinato-dev-rag-services-policy"
+  description = "AWS rag services role IAM Policy"
+  policy = jsonencode({
+    Version = "2012-10-17",
+    Statement = [
+      {
+        Sid    = "VisualEditor0",
+        Effect = "Allow",
+        Action = [
+          "secretsmanager:GetSecretValue",
+          "s3:*",
+          "kms:*",
+          "sagemaker:ListEndpoints"
+        ],
+        Resource = "*"
+      },
+      {
+        Sid    = "VisualEditor1",
+        Effect = "Allow",
+        Action = [
+          "sagemaker:InvokeEndpoint",
+          "sts:AssumeRoleWithWebIdentity"
+        ],
+        Resource = [
+          "arn:aws:iam::471112537430:role/ostinato-dev-rag-services-role",
+          "arn:aws:sagemaker:*:471112537430:endpoint/*"
+        ]
+      }
+    ]
+  })
+}
+
+resource "aws_iam_role" "aws_ostinato_dev_rag_services_role" {
+  name = "ostinato-dev-rag-services-role"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17",
+    Statement = [
+      {
+        Effect = "Allow",
+        Principal = {
+          Federated = "arn:aws:iam::471112537430:oidc-provider/oidc.eks.us-east-2.amazonaws.com/id/A9EDA6D83ABE1896B92C50B3BACC7C27"
+        },
+        Action = "sts:AssumeRoleWithWebIdentity",
+        Condition = {
+          StringEquals = {
+            "oidc.eks.us-east-2.amazonaws.com/id/A9EDA6D83ABE1896B92C50B3BACC7C27:aud" : "sts.amazonaws.com",
+            "oidc.eks.us-east-2.amazonaws.com/id/A9EDA6D83ABE1896B92C50B3BACC7C27:sub" : "system:serviceaccount:ostinato-system:rag-acquisition-sa"
+          }
+        }
+      },
+      {
+        Effect = "Allow",
+        Principal = {
+          Federated = "arn:aws:iam::471112537430:oidc-provider/oidc.eks.us-east-2.amazonaws.com/id/A9EDA6D83ABE1896B92C50B3BACC7C27"
+        },
+        Action = "sts:AssumeRoleWithWebIdentity",
+        Condition = {
+          StringEquals = {
+            "oidc.eks.us-east-2.amazonaws.com/id/A9EDA6D83ABE1896B92C50B3BACC7C27:aud" : "sts.amazonaws.com",
+            "oidc.eks.us-east-2.amazonaws.com/id/A9EDA6D83ABE1896B92C50B3BACC7C27:sub" : "system:serviceaccount:ostinato-system:rag-inference-sa"
+          }
+        }
+      },
+      {
+        Effect = "Allow",
+        Principal = {
+          Federated = "arn:aws:iam::471112537430:oidc-provider/oidc.eks.us-east-2.amazonaws.com/id/A9EDA6D83ABE1896B92C50B3BACC7C27"
+        },
+        Action = "sts:AssumeRoleWithWebIdentity",
+        Condition = {
+          StringEquals = {
+            "oidc.eks.us-east-2.amazonaws.com/id/A9EDA6D83ABE1896B92C50B3BACC7C27:aud" : "sts.amazonaws.com",
+            "oidc.eks.us-east-2.amazonaws.com/id/A9EDA6D83ABE1896B92C50B3BACC7C27:sub" : "system:serviceaccount:ostinato-system:rag-ingestion-manager-sa"
+          }
+        }
+      },
+      {
+        Action    = "sts:AssumeRoleWithWebIdentity"
+        Condition = {
+            StringEquals = {
+                "oidc.eks.us-east-2.amazonaws.com/id/A9EDA6D83ABE1896B92C50B3BACC7C27:aud" = "sts.amazonaws.com"
+                "oidc.eks.us-east-2.amazonaws.com/id/A9EDA6D83ABE1896B92C50B3BACC7C27:sub" = "system:serviceaccount:ostinato-system:rag-doc-processor-sa"
+              }
+          }
+        Effect    = "Allow"
+        Principal = {
+            Federated = "arn:aws:iam::471112537430:oidc-provider/oidc.eks.us-east-2.amazonaws.com/id/A9EDA6D83ABE1896B92C50B3BACC7C27"
+          }
+      }
+    ]
+  })
+
+  force_detach_policies = false
+}
+
+resource "aws_iam_role_policy_attachment" "aws_ostinato_rag_services_policy_attachment" {
+  role       = aws_iam_role.aws_ostinato_dev_rag_services_role.name
+  policy_arn = aws_iam_policy.aws_ostinato_dev_rag_services_policy.arn
+}

--- a/aws_outshift-common-dev_us-east-2_rds_rds-ostinato-dev-1-knowledgebase_backend.tf
+++ b/aws_outshift-common-dev_us-east-2_rds_rds-ostinato-dev-1-knowledgebase_backend.tf
@@ -1,0 +1,7 @@
+terraform {
+  backend "s3" {
+    bucket = "eticloud-tf-state-nonprod" 
+    key    = "terraform-state/aurora-postgres/us-east-2/ostinato-dev-1-knowledgebase.tfstate"
+    region = "us-east-2"
+  }
+}

--- a/aws_outshift-common-dev_us-east-2_rds_rds-ostinato-dev-1-knowledgebase_locals.tf
+++ b/aws_outshift-common-dev_us-east-2_rds_rds-ostinato-dev-1-knowledgebase_locals.tf
@@ -1,0 +1,7 @@
+
+locals {
+  vpc_name = "common-dev-use2-vpc-data"
+  cluster_vpc_name = "comn-dev-use2-1"
+  aws_account_name = "outshift-common-dev"
+  rds_name  = "ostinato-dev-1-knowledgebase"
+}

--- a/aws_outshift-common-dev_us-east-2_rds_rds-ostinato-dev-1-knowledgebase_main.tf
+++ b/aws_outshift-common-dev_us-east-2_rds_rds-ostinato-dev-1-knowledgebase_main.tf
@@ -1,0 +1,22 @@
+data "vault_generic_secret" "aws_infra_credential" {
+  path     = "secret/infra/aws/${local.aws_account_name}/terraform_admin"
+  provider = vault.eticloud
+}
+
+data "aws_vpc" "cluster_vpc" {
+  filter {
+    name   = "tag:Name"
+    values = [local.cluster_vpc_name]
+  }
+}
+
+module "rds" {
+  source            = "git::https://github.com/cisco-eti/sre-tf-module-aws-aurora-postgres?ref=1.1.0"
+  vpc_name          = local.vpc_name
+  database_name     = "ostinato_knowledgebase"
+  db_instance_type  = "db.r5.xlarge"
+  cluster_name      = local.rds_name
+  secret_path       = "secret/eticcprod/infra/aurora-pg/us-east-2/vowel-genai-dev/vowel-dev-1-knowledgebase"
+  db_allowed_cidrs  = [data.aws_vpc.cluster_vpc.cidr_block]
+  db_engine_version = "15"
+}

--- a/aws_outshift-common-dev_us-east-2_rds_rds-ostinato-dev-1-knowledgebase_providers.tf
+++ b/aws_outshift-common-dev_us-east-2_rds_rds-ostinato-dev-1-knowledgebase_providers.tf
@@ -1,0 +1,23 @@
+provider "vault" {
+  alias     = "eticloud"
+  address   = "https://keeper.cisco.com"
+  namespace = "eticloud"
+}
+
+provider "aws" {
+  access_key  = data.vault_generic_secret.aws_infra_credential.data["AWS_ACCESS_KEY_ID"]
+  secret_key  = data.vault_generic_secret.aws_infra_credential.data["AWS_SECRET_ACCESS_KEY"]
+  region      = "us-east-2"
+  max_retries = 3
+  default_tags {
+    tags = {
+      ApplicationName    = "outshift_foundational_services"
+      Component          = "ostinato"
+      CiscoMailAlias     = "ostinato-team-mailer@cisco.com"
+      DataClassification = "Cisco Confidential"
+      DataTaxonomy       = "Cisco Operations Data"
+      EnvironmentName    = "NonProd"
+      ResourceOwner      = "ostinato-dev-team"
+    }
+  }
+}

--- a/aws_outshift-common-dev_us-east-2_rds_rds-ostinato-dev-1-temporal_backend.tf
+++ b/aws_outshift-common-dev_us-east-2_rds_rds-ostinato-dev-1-temporal_backend.tf
@@ -1,0 +1,7 @@
+terraform {
+  backend "s3" {
+    bucket = "eticloud-tf-state-nonprod" 
+    key    = "terraform-state/aurora-postgres/us-east-2/ostinato-dev-1-temporal.tfstate"
+    region = "us-east-2"
+  }
+}

--- a/aws_outshift-common-dev_us-east-2_rds_rds-ostinato-dev-1-temporal_locals.tf
+++ b/aws_outshift-common-dev_us-east-2_rds_rds-ostinato-dev-1-temporal_locals.tf
@@ -1,0 +1,7 @@
+
+locals {
+  vpc_name = "common-dev-use2-vpc-data"
+  cluster_vpc_name = "comn-dev-use2-1"
+  aws_account_name = "outshift-common-dev"
+  rds_name  = "ostinato-dev-1-temporal"
+}

--- a/aws_outshift-common-dev_us-east-2_rds_rds-ostinato-dev-1-temporal_main.tf
+++ b/aws_outshift-common-dev_us-east-2_rds_rds-ostinato-dev-1-temporal_main.tf
@@ -1,0 +1,22 @@
+data "vault_generic_secret" "aws_infra_credential" {
+  path     = "secret/infra/aws/${local.aws_account_name}/terraform_admin"
+  provider = vault.eticloud
+}
+
+data "aws_vpc" "cluster_vpc" {
+  filter {
+    name   = "tag:Name"
+    values = [local.cluster_vpc_name]
+  }
+}
+
+module "rds" {
+  source            = "git::https://github.com/cisco-eti/sre-tf-module-aws-aurora-postgres?ref=1.1.0"
+  vpc_name          = local.vpc_name
+  database_name     = "ostinato_temporal"
+  db_instance_type  = "db.r5.xlarge"
+  cluster_name      = local.rds_name
+  secret_path       = "secret/eticcprod/infra/aurora-pg/us-east-2/vowel-genai-dev/vowel-dev-1-knowledgebase"
+  db_allowed_cidrs  = [data.aws_vpc.cluster_vpc.cidr_block]
+  db_engine_version = "15"
+}

--- a/aws_outshift-common-dev_us-east-2_rds_rds-ostinato-dev-1-temporal_providers.tf
+++ b/aws_outshift-common-dev_us-east-2_rds_rds-ostinato-dev-1-temporal_providers.tf
@@ -1,0 +1,23 @@
+provider "vault" {
+  alias     = "eticloud"
+  address   = "https://keeper.cisco.com"
+  namespace = "eticloud"
+}
+
+provider "aws" {
+  access_key  = data.vault_generic_secret.aws_infra_credential.data["AWS_ACCESS_KEY_ID"]
+  secret_key  = data.vault_generic_secret.aws_infra_credential.data["AWS_SECRET_ACCESS_KEY"]
+  region      = "us-east-2"
+  max_retries = 3
+  default_tags {
+    tags = {
+      ApplicationName    = "outshift_foundational_services"
+      Component          = "ostinato"
+      CiscoMailAlias     = "ostinato-team-mailer@cisco.com"
+      DataClassification = "Cisco Confidential"
+      DataTaxonomy       = "Cisco Operations Data"
+      EnvironmentName    = "NonProd"
+      ResourceOwner      = "ostinato-dev-team"
+    }
+  }
+}


### PR DESCRIPTION
## Fixes/Implements # (JIRA issue if applicable)  

https://cisco-eti.atlassian.net/browse/SRE-9216

### Description/Justification

Creating ostinato RDS as part of vowel -> ostinato migration. Will be removing RDS instances from vowel-dev-1 account

Migrating the following: https://github.com/cisco-eti/platform-terraform-infra/tree/main/aws/vowel-genai-dev/us-east-2/rds

### If the (atlantis) plan is destroying resources, reason for deletion  

### Additional details

- [x] `terraform fmt` was applied
- [ ] All atlantis plans can be applied
- [ ] (For reviewers) I have verified the resource changes
