### PR TITLE
fix(iam): clean up unused resources, unneeded

### DIFF
--- a/aws_eti-ci_us-east-1_ec2_gha-self-hosted-runners_self-hosted-runner-1_ec2.tf
+++ b/aws_eti-ci_us-east-1_ec2_gha-self-hosted-runners_self-hosted-runner-1_ec2.tf
@@ -8,7 +8,6 @@ module "ec2-instance" {
     data.aws_security_group.cloud_agent_ssh_from_cisco.id,
   data.aws_security_group.cloud_agent_host_monitoring_from_cisco.id]
   subnet_id            = data.aws_subnet.public.id
-  iam_instance_profile = aws_iam_instance_profile.ec2_ssm.name
   key_name             = "eti-jenkins"
   monitoring           = true
   ebs_optimized        = true

--- a/aws_eti-ci_us-east-1_ec2_gha-self-hosted-runners_self-hosted-runner-1_ec2.tf
+++ b/aws_eti-ci_us-east-1_ec2_gha-self-hosted-runners_self-hosted-runner-1_ec2.tf
@@ -34,37 +34,3 @@ module "ec2-instance" {
     hostname_type                        = "ip-name"
   }
 }
-
-resource "aws_iam_role" "ec2_ssm" {
-  name = "ec2_ssm_role"
-
-  assume_role_policy = jsonencode({
-    Version = "2012-10-17",
-    Statement = [{
-      Action = "sts:AssumeRole",
-      Effect = "Allow",
-      Principal = {
-        Service = "ec2.amazonaws.com"
-      },
-    }],
-  })
-}
-
-resource "aws_iam_role_policy" "ec2_ssm_policy" {
-  name = "ec2_ssm_policy"
-  role = aws_iam_role.ec2_ssm.name
-
-  policy = jsonencode({
-    Version = "2012-10-17",
-    Statement = [{
-      Effect   = "Allow",
-      Action   = ["ssm:GetParameter"],
-      Resource = "arn:aws:ssm:us-east-1:${data.aws_caller_identity.current.account_id}:parameter/outshift-platform-gha-token"
-    }]
-  })
-}
-
-resource "aws_iam_instance_profile" "ec2_ssm" {
-  name = "ec2_ssm_instance_profile"
-  role = aws_iam_role.ec2_ssm.name
-}

--- a/aws_eti-ci_us-east-1_ec2_gha-self-hosted-runners_self-hosted-runner-2_ec2.tf
+++ b/aws_eti-ci_us-east-1_ec2_gha-self-hosted-runners_self-hosted-runner-2_ec2.tf
@@ -8,7 +8,6 @@ module "ec2-instance" {
     data.aws_security_group.cloud_agent_ssh_from_cisco.id,
   data.aws_security_group.cloud_agent_host_monitoring_from_cisco.id]
   subnet_id            = data.aws_subnet.public.id
-  iam_instance_profile = aws_iam_instance_profile.ec2_ssm.name
   key_name             = "eti-jenkins"
   monitoring           = true
   ebs_optimized        = true

--- a/aws_eti-ci_us-east-1_ec2_gha-self-hosted-runners_self-hosted-runner-2_ec2.tf
+++ b/aws_eti-ci_us-east-1_ec2_gha-self-hosted-runners_self-hosted-runner-2_ec2.tf
@@ -34,37 +34,3 @@ module "ec2-instance" {
     hostname_type                        = "ip-name"
   }
 }
-
-resource "aws_iam_role" "ec2_ssm" {
-  name = "ec2_ssm_role_2"
-
-  assume_role_policy = jsonencode({
-    Version = "2012-10-17",
-    Statement = [{
-      Action = "sts:AssumeRole",
-      Effect = "Allow",
-      Principal = {
-        Service = "ec2.amazonaws.com"
-      },
-    }],
-  })
-}
-
-resource "aws_iam_role_policy" "ec2_ssm_policy" {
-  name = "ec2_ssm_policy_2"
-  role = aws_iam_role.ec2_ssm.name
-
-  policy = jsonencode({
-    Version = "2012-10-17",
-    Statement = [{
-      Effect   = "Allow",
-      Action   = ["ssm:GetParameter"],
-      Resource = "arn:aws:ssm:us-east-1:${data.aws_caller_identity.current.account_id}:parameter/outshift-platform-gha-token"
-    }]
-  })
-}
-
-resource "aws_iam_instance_profile" "ec2_ssm" {
-  name = "ec2_ssm_instance_profile_2"
-  role = aws_iam_role.ec2_ssm.name
-}


### PR DESCRIPTION
## Fixes/Implements # (JIRA issue if applicable)  

Using AWS SSM won't be needed, using an IAM role with a trust policy using OIDC without a long lived credential is preferred.

### Description/Justification

(Why is this change needed? Which team might need it? etc...)  


### If the (atlantis) plan is destroying resources, reason for deletion  


### Additional details

- [x] `terraform fmt` was applied
- [ ] All atlantis plans can be applied
- [ ] (For reviewers) I have verified the resource changes
