### PR TITLE
chore: add FinOps tags to bastion and nodegroup on common-staging cluster & reduce nodegroup nodes to 1

### DIFF
--- a/aws_eticloud_us-east-2_vpc_agntcy_main.tf
+++ b/aws_eticloud_us-east-2_vpc_agntcy_main.tf
@@ -1,0 +1,37 @@
+# This file was created by Outshift Platform Self-Service automation.
+
+terraform {
+  backend "s3" {
+    # We separate the different levels of development into different buckets.
+    # The buckets are eticloud-tf-state-sandbox, eticloud-tf-state-nonprod, eticloud-tf-state-prod.
+    # The environment should match the CSBEnvironment below.
+    bucket = "eticloud-tf-state-prod"
+    # Note the path here. It should match the pattern terraform_state/<service>/<region>/<name>.tfstate
+    key = "terraform-state/eticloud/us-east-2/vpc/agntcy.tfstate"
+    # Do not change without talking to the SRE team. This is the region where the terraform backend bucket is located.
+    region = "us-east-2"
+  }
+}
+
+locals {
+  name             = "agntcy"
+  region           = "us-east-2"
+  aws_account_name = "eticloud"
+}
+
+module "vpc" {
+  source           = "git::https://github.com/cisco-eti/sre-tf-module-vpc-allinone.git?ref=latest"
+  name             = local.name             # VPC name
+  region           = local.region           # AWS provider region
+  aws_account_name = local.aws_account_name # AWS account name
+  cidr             = "10.0.0.0/16"      # VPC CIDR
+
+  # Tags
+  application_name    = "outshift_ventures"
+  component           = "phoenix"
+  cisco_mail_alias    = "eti-sre-admins@cisco.com"
+  data_classification = "Cisco Restricted"
+  data_taxonomy       = "Cisco Operations Data"
+  environment         = "Prod"
+  resource_owner      = "outshift-phoenix-admins"
+}

--- a/aws_outshift-common-staging_us-east-2_eks_comn-staging-use2-1_main.tf
+++ b/aws_outshift-common-staging_us-east-2_eks_comn-staging-use2-1_main.tf
@@ -29,9 +29,9 @@ module "eks_all_in_one" {
 
   # EKS Managed Private Node Group
   instance_types = ["m6a.2xlarge"] # EKS instance types
-  min_size       = 3               # EKS node group min size
-  max_size       = 3               # EKS node group max size
-  desired_size   = 3               # EKS node group desired size
+  min_size       = 2               # EKS node group min size
+  max_size       = 2               # EKS node group max size
+  desired_size   = 2               # EKS node group desired size
 
   # Karpenter
   create_karpenter_irsa = true #  Create Karpenter IRSA

--- a/aws_outshift-common-staging_us-east-2_eks_comn-staging-use2-1_main.tf
+++ b/aws_outshift-common-staging_us-east-2_eks_comn-staging-use2-1_main.tf
@@ -29,9 +29,9 @@ module "eks_all_in_one" {
 
   # EKS Managed Private Node Group
   instance_types = ["m6a.2xlarge"] # EKS instance types
-  min_size       = 2               # EKS node group min size
-  max_size       = 2               # EKS node group max size
-  desired_size   = 2               # EKS node group desired size
+  min_size       = 1               # EKS node group min size
+  max_size       = 1               # EKS node group max size
+  desired_size   = 1               # EKS node group desired size
 
   # Karpenter
   create_karpenter_irsa = true #  Create Karpenter IRSA

--- a/aws_outshift-common-staging_us-east-2_eks_comn-staging-use2-1_main.tf
+++ b/aws_outshift-common-staging_us-east-2_eks_comn-staging-use2-1_main.tf
@@ -18,6 +18,7 @@ locals {
 module "eks_all_in_one" {
   source = "git::https://github.com/cisco-eti/sre-tf-module-eks-allinone.git?ref=latest"
 
+
   name               = local.name             # EKS cluster name
   region             = local.region           # AWS provider region
   aws_account_name   = local.aws_account_name # AWS account name


### PR DESCRIPTION
## Fixes/Implements # (JIRA issue if applicable)  
https://cisco-eti.atlassian.net/browse/SRE-9258

### Description/Justification

(Why is this change needed? Which team might need it? etc...)  


### If the (atlantis) plan is destroying resources, reason for deletion  


### Additional details

- [ ] `terraform fmt` was applied
- [ ] All atlantis plans can be applied
- [ ] (For reviewers) I have verified the resource changes
