### PR TITLE
OPENSD-1369: create IRSA for CRUD access to chef-eval S3 bucket

### DIFF
--- a/aws_outshift-common-dev_iam_roles_chef_backend.tf
+++ b/aws_outshift-common-dev_iam_roles_chef_backend.tf
@@ -1,0 +1,9 @@
+terraform {
+  backend "s3" {
+    bucket         = "eticloud-tf-state-nonprod"
+    key            = "terraform-state/outshift-common-dev/iam/role/chef-eval-S3-admin.tfstate"
+    region         = "us-east-2"
+    dynamodb_table = "eticloud-tf-locks"
+    encrypt        = true
+  }
+}

--- a/aws_outshift-common-dev_iam_roles_chef_chef-eval-s3-admin-role.tf
+++ b/aws_outshift-common-dev_iam_roles_chef_chef-eval-s3-admin-role.tf
@@ -1,20 +1,20 @@
 resource "aws_iam_policy" "chef_eval_s3_admin_policy" {
   name        = "chef-eval-s3-admin-policy"
   description = "chef-eval S3 Admin Role IAM Policy"
-  policy      = jsonencode({
+  policy = jsonencode({
     Version = "2012-10-17",
     Statement = [
       {
         Effect = "Allow",
         Action = [
-          "s3:PutObject",      
-          "s3:GetObject",      
-          "s3:DeleteObject",   
-          "s3:ListBucket"      
+          "s3:PutObject",
+          "s3:GetObject",
+          "s3:DeleteObject",
+          "s3:ListBucket"
         ],
         Resource = [
-          "arn:aws:s3:::chef-eval",    
-          "arn:aws:s3:::chef-eval/*" 
+          "arn:aws:s3:::chef-eval",
+          "arn:aws:s3:::chef-eval/*"
         ]
       }
     ]

--- a/aws_outshift-common-dev_iam_roles_chef_chef-eval-s3-admin-role.tf
+++ b/aws_outshift-common-dev_iam_roles_chef_chef-eval-s3-admin-role.tf
@@ -1,0 +1,50 @@
+resource "aws_iam_policy" "chef_eval_s3_admin_policy" {
+  name        = "chef-eval-s3-admin-policy"
+  description = "chef-eval S3 Admin Role IAM Policy"
+  policy      = jsonencode({
+    Version = "2012-10-17",
+    Statement = [
+      {
+        Effect = "Allow",
+        Action = [
+          "s3:PutObject",      
+          "s3:GetObject",      
+          "s3:DeleteObject",   
+          "s3:ListBucket"      
+        ],
+        Resource = [
+          "arn:aws:s3:::chef-eval",    
+          "arn:aws:s3:::chef-eval/*" 
+        ]
+      }
+    ]
+  })
+}
+
+resource "aws_iam_role" "chef_eval_s3_admin_role" {
+  name = "chef-eval-s3-admin-role"
+  assume_role_policy = jsonencode({
+    "Version" : "2012-10-17"
+    "Statement" : [
+      {
+        "Effect" : "Allow",
+        "Principal" : {
+          "Federated" : "arn:aws:iam::471112537430:oidc-provider/oidc.eks.us-east-2.amazonaws.com/id/A9EDA6D83ABE1896B92C50B3BACC7C27"
+        },
+        "Action" : "sts:AssumeRoleWithWebIdentity",
+        "Condition" : {
+          "StringLike" : {
+            "oidc.eks.us-east-2.amazonaws.com/id/A9EDA6D83ABE1896B92C50B3BACC7C27:aud" : "sts.amazonaws.com",
+            "oidc.eks.us-east-2.amazonaws.com/id/A9EDA6D83ABE1896B92C50B3BACC7C27:sub" : "system:serviceaccount:chef-dev:*"
+          }
+        }
+      }
+    ]
+  })
+  force_detach_policies = true
+}
+
+resource "aws_iam_role_policy_attachment" "chef_eval_s3_admin_attachment" {
+  role       = aws_iam_role.chef_eval_s3_admin_role.name
+  policy_arn = aws_iam_policy.chef_eval_s3_admin_policy.arn
+}

--- a/aws_outshift-common-dev_iam_roles_chef_providers.tf
+++ b/aws_outshift-common-dev_iam_roles_chef_providers.tf
@@ -1,0 +1,30 @@
+provider "vault" {
+  address   = "https://keeper.cisco.com"
+  namespace = "eticloud"
+}
+
+
+data "vault_generic_secret" "aws_infra_credential" {
+  path     = "secret/infra/aws/outshift-common-dev/terraform_admin"
+}
+
+provider "aws" {
+  access_key  = data.vault_generic_secret.aws_infra_credential.data["AWS_ACCESS_KEY_ID"]
+  secret_key  = data.vault_generic_secret.aws_infra_credential.data["AWS_SECRET_ACCESS_KEY"]
+  region      = "us-east-2" # Must match the region where the EKS cluster and VPC are created.
+  max_retries = 3
+  default_tags {
+    # These tags are required for security compliance.
+    # For more information on Data Classification and Data Taxonomy, please talk to the SRE team.
+    tags = {
+      ResourceOwner      = "ETI SRE"
+      ApplicationName    = "outshift_ventures"
+      Component          = "chef"
+      ResourceOwner      = "outshift-chef-team"
+      CiscoMailAlias     = "outshift-chef-team@cisco.com"
+      DataClassification = "Cisco Confidential"
+      DataTaxonomy       = "Cisco Operations Data"
+      Environment        = "NonProd"
+    }
+  }
+}

--- a/aws_outshift-common-dev_iam_roles_chef_providers.tf
+++ b/aws_outshift-common-dev_iam_roles_chef_providers.tf
@@ -5,7 +5,7 @@ provider "vault" {
 
 
 data "vault_generic_secret" "aws_infra_credential" {
-  path     = "secret/infra/aws/outshift-common-dev/terraform_admin"
+  path = "secret/infra/aws/outshift-common-dev/terraform_admin"
 }
 
 provider "aws" {

--- a/aws_outshift-common-dev_iam_roles_chef_versions.tf
+++ b/aws_outshift-common-dev_iam_roles_chef_versions.tf
@@ -1,0 +1,9 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 4.0"
+    }
+  }
+  required_version = ">= 1.3.6"
+}


### PR DESCRIPTION
### Description/Justification
https://cisco-eti.atlassian.net/browse/OPENSD-1369


### Additional details

- [X] `terraform fmt` was applied
- [ ] All atlantis plans can be applied
- [ ] (For reviewers) I have verified the resource changes
