### PR TITLE
feat(prs): auto-approve when not in prod

### DIFF
--- a/aws_sscs-dev_us-east-2_fargate-test_eks.tf
+++ b/aws_sscs-dev_us-east-2_fargate-test_eks.tf
@@ -56,7 +56,7 @@ module "eks" {
   cluster_endpoint_public_access  = true
   enable_cluster_creator_admin_permissions = true
 
-  
+
 
   cluster_addons = {
     coredns = {
@@ -123,15 +123,6 @@ provider "kubernetes" {
   cluster_ca_certificate = base64decode(module.eks.cluster_certificate_authority_data)
   token                  = data.aws_eks_cluster_auth.cluster.token
 }
-
-# resource "null_resource" "wait_for_eks" {
-#   provisioner "local-exec" {
-#     command = "echo 'Module 1 finished. Waiting for 180 seconds...' && sleep 180"
-#     on_failure = continue
-#   }
-
-#   depends_on = [module.eks]
-# }
 
 module "eks-auth" {
   source  = "terraform-aws-modules/eks/aws//modules/aws-auth"

--- a/aws_sscs-dev_us-east-2_fargate-test_eks.tf
+++ b/aws_sscs-dev_us-east-2_fargate-test_eks.tf
@@ -21,17 +21,11 @@ terraform {
   }
 }
 
-variable "AWS_INFRA_REGION" {
-  description = "AWS Region"
-  default     = "us-east-2" #Set the region for the resources to be created.
-}
-
-
 # Infra AWS Provider
 provider "aws" {
   access_key  = data.vault_generic_secret.aws_infra_credential.data["AWS_ACCESS_KEY_ID"]
   secret_key  = data.vault_generic_secret.aws_infra_credential.data["AWS_SECRET_ACCESS_KEY"]
-  region      = var.AWS_INFRA_REGION
+  region      = "us-east-2"
   max_retries = 3
   default_tags {
     tags = {


### PR DESCRIPTION
Similar to https://github.com/cisco-eti/sre-cisco-groups-automation/blob/main/.github/workflows/pr-auto-approval.yml.
Approve PRs targeting `outshift-common-dev` and `outshift-common-staging`.
Will squash all those commits, testing for GHA can be tedious.