### PR TITLE
feat: Add team-based AWS login roles for access to the common-dev AWS account

### DIFF
--- a/aws_outshift-common-dev_iam_sso-roles_roles.tf
+++ b/aws_outshift-common-dev_iam_sso-roles_roles.tf
@@ -2,175 +2,175 @@ module "a3po_role" {
   source    = "./sso-roles-module"
   role_name = "a3po"
   tags = {
-      ApplicationName    = "outshift_ventures"
-      Component          = "a3po"
-      CiscoMailAlias     = "outshift-a3po@cisco.com"
-      ResourceOwner      = "a3po-admins"
-    }
+    ApplicationName = "outshift_ventures"
+    Component       = "a3po"
+    CiscoMailAlias  = "outshift-a3po@cisco.com"
+    ResourceOwner   = "a3po-admins"
+  }
 }
 
 module "action_engine_role" {
   source    = "./sso-roles-module"
   role_name = "action-engine"
   tags = {
-      ApplicationName    = "outshift_ventures"
-      Component          = "action-engine"
-      CiscoMailAlias     = "action-engine-team@cisco.com"
-      ResourceOwner      = "action-engine-team"
-    }
+    ApplicationName = "outshift_ventures"
+    Component       = "action-engine"
+    CiscoMailAlias  = "action-engine-team@cisco.com"
+    ResourceOwner   = "action-engine-team"
+  }
 }
 
 module "aether_role" {
   source    = "./sso-roles-module"
   role_name = "aether"
   tags = {
-      ApplicationName    = "outshift_ventures"
-      Component          = "aether"
-      CiscoMailAlias     = "outshift-aether@cisco.com"
-      ResourceOwner      = "aether-admins"
-    }
+    ApplicationName = "outshift_ventures"
+    Component       = "aether"
+    CiscoMailAlias  = "outshift-aether@cisco.com"
+    ResourceOwner   = "aether-admins"
+  }
 }
 
 module "alfred_role" {
   source    = "./sso-roles-module"
   role_name = "alfred"
   tags = {
-      ApplicationName    = "outshift_ventures"
-      Component          = "alfred"
-      CiscoMailAlias     = "outshift-alfred@cisco.com"
-      ResourceOwner      = "alfred-admins"
-    }
+    ApplicationName = "outshift_ventures"
+    Component       = "alfred"
+    CiscoMailAlias  = "outshift-alfred@cisco.com"
+    ResourceOwner   = "alfred-admins"
+  }
 }
 
 module "aqua_role" {
   source    = "./sso-roles-module"
   role_name = "aqua"
   tags = {
-      ApplicationName    = "outshift_ventures"
-      Component          = "aqua"
-      CiscoMailAlias     = "aqua-team@cisco.com"
-      ResourceOwner      = "outshift-aqua-dev"
-    }
+    ApplicationName = "outshift_ventures"
+    Component       = "aqua"
+    CiscoMailAlias  = "aqua-team@cisco.com"
+    ResourceOwner   = "outshift-aqua-dev"
+  }
 }
 
 module "argus_role" {
   source    = "./sso-roles-module"
   role_name = "a3po"
   tags = {
-      ApplicationName    = "outshift_ventures"
-      Component          = "argus"
-      CiscoMailAlias     = "outshift-argus-dev@cisco.com"
-      ResourceOwner      = "outshift-argus-dev"
-    }
+    ApplicationName = "outshift_ventures"
+    Component       = "argus"
+    CiscoMailAlias  = "outshift-argus-dev@cisco.com"
+    ResourceOwner   = "outshift-argus-dev"
+  }
 }
 
 module "cascade_role" {
   source    = "./sso-roles-module"
   role_name = "a3po"
   tags = {
-      ApplicationName    = "outshift_ventures"
-      Component          = "cascade"
-      CiscoMailAlias     = "chartsoo@cisco.com"
-      ResourceOwner      = "cil-splunk"
-    }
+    ApplicationName = "outshift_ventures"
+    Component       = "cascade"
+    CiscoMailAlias  = "chartsoo@cisco.com"
+    ResourceOwner   = "cil-splunk"
+  }
 }
 
 module "chef_role" {
   source    = "./sso-roles-module"
   role_name = "chef"
   tags = {
-      ApplicationName    = "outshift_ventures"
-      Component          = "chef"
-      CiscoMailAlias     = "outshift-chef-team@cisco.com"
-      ResourceOwner      = "outshift-chef-team"
-    }
+    ApplicationName = "outshift_ventures"
+    Component       = "chef"
+    CiscoMailAlias  = "outshift-chef-team@cisco.com"
+    ResourceOwner   = "outshift-chef-team"
+  }
 }
 
 module "ioa_identity_role" {
   source    = "./sso-roles-module"
   role_name = "ioa-identity"
   tags = {
-      ApplicationName    = "outshift_ventures"
-      Component          = "ioa_identity"
-      CiscoMailAlias     = "outshift-ioa-identity-team@cisco.com"
-      ResourceOwner      = "outshift-ioa-identity-team"
-    }
+    ApplicationName = "outshift_ventures"
+    Component       = "ioa_identity"
+    CiscoMailAlias  = "outshift-ioa-identity-team@cisco.com"
+    ResourceOwner   = "outshift-ioa-identity-team"
+  }
 }
 
 module "iridium_role" {
   source    = "./sso-roles-module"
   role_name = "iridium"
   tags = {
-      ApplicationName    = "outshift_ventures"
-      Component          = "iridium"
-      CiscoMailAlias     = "outshift-iridium@cisco.com"
-      ResourceOwner      = "iridium-admins"
-    }
+    ApplicationName = "outshift_ventures"
+    Component       = "iridium"
+    CiscoMailAlias  = "outshift-iridium@cisco.com"
+    ResourceOwner   = "iridium-admins"
+  }
 }
 
 module "marvin_role" {
   source    = "./sso-roles-module"
   role_name = "marvin"
   tags = {
-      ApplicationName    = "outshift_foundational_services"
-      Component          = "marvin"
-      CiscoMailAlias     = "marvin-outshift@cisco.com"
-      ResourceOwner      = "marvin-outshift"
-    }
+    ApplicationName = "outshift_foundational_services"
+    Component       = "marvin"
+    CiscoMailAlias  = "marvin-outshift@cisco.com"
+    ResourceOwner   = "marvin-outshift"
+  }
 }
 
 module "ostinato_role" {
   source    = "./sso-roles-module"
   role_name = "ostinato"
   tags = {
-      ApplicationName    = "outshift_foundational_services"
-      Component          = "ostinato"
-      CiscoMailAlias     = "ostinato-team-mailer@cisco.com"
-      Environment        = "NonProd"
-      ResourceOwner      = "ostinato-dev-team"
-    }
+    ApplicationName = "outshift_foundational_services"
+    Component       = "ostinato"
+    CiscoMailAlias  = "ostinato-team-mailer@cisco.com"
+    Environment     = "NonProd"
+    ResourceOwner   = "ostinato-dev-team"
+  }
 }
 
 module "eti_website_role" {
   source    = "./sso-roles-module"
   role_name = "eti-website"
   tags = {
-      ApplicationName    = "outshift_marketing"
-      Component          = "outshift_websites"
-      CiscoMailAlias     = "eti-websites@cisco.com"
-      ResourceOwner      = "eti-website-admins"
-    }
+    ApplicationName = "outshift_marketing"
+    Component       = "outshift_websites"
+    CiscoMailAlias  = "eti-websites@cisco.com"
+    ResourceOwner   = "eti-website-admins"
+  }
 }
 
 module "oval_role" {
   source    = "./sso-roles-module"
   role_name = "oval"
   tags = {
-      ApplicationName    = "outshift_ventures"
-      Component          = "oval"
-      CiscoMailAlias     = "outshift-oval@cisco.com"
-      ResourceOwner      = "oval-admins"
-    }
+    ApplicationName = "outshift_ventures"
+    Component       = "oval"
+    CiscoMailAlias  = "outshift-oval@cisco.com"
+    ResourceOwner   = "oval-admins"
+  }
 }
 
 module "phoenix_role" {
   source    = "./sso-roles-module"
   role_name = "phoenix"
   tags = {
-      ApplicationName    = "outshift_ventures"
-      Component          = "phoenix"
-      CiscoMailAlias     = "outshift-phoenix@cisco.com"
-      ResourceOwner      = "outshift-phoenix-admins"
-    }
+    ApplicationName = "outshift_ventures"
+    Component       = "phoenix"
+    CiscoMailAlias  = "outshift-phoenix@cisco.com"
+    ResourceOwner   = "outshift-phoenix-admins"
+  }
 }
 
 module "ragv2_role" {
   source    = "./sso-roles-module"
   role_name = "ragv2"
   tags = {
-      ApplicationName    = "outshift_ventures"
-      Component          = "ragv2"
-      CiscoMailAlias     = "ragv2@cisco.com"
-      ResourceOwner      = "ragv2-team"
-    }
+    ApplicationName = "outshift_ventures"
+    Component       = "ragv2"
+    CiscoMailAlias  = "ragv2@cisco.com"
+    ResourceOwner   = "ragv2-team"
+  }
 }

--- a/aws_outshift-common-dev_iam_sso-roles_roles.tf
+++ b/aws_outshift-common-dev_iam_sso-roles_roles.tf
@@ -1,0 +1,176 @@
+module "a3po_role" {
+  source    = "./sso-roles-module"
+  role_name = "a3po"
+  tags = {
+      ApplicationName    = "outshift_ventures"
+      Component          = "a3po"
+      CiscoMailAlias     = "outshift-a3po@cisco.com"
+      ResourceOwner      = "a3po-admins"
+    }
+}
+
+module "action_engine_role" {
+  source    = "./sso-roles-module"
+  role_name = "action-engine"
+  tags = {
+      ApplicationName    = "outshift_ventures"
+      Component          = "action-engine"
+      CiscoMailAlias     = "action-engine-team@cisco.com"
+      ResourceOwner      = "action-engine-team"
+    }
+}
+
+module "aether_role" {
+  source    = "./sso-roles-module"
+  role_name = "aether"
+  tags = {
+      ApplicationName    = "outshift_ventures"
+      Component          = "aether"
+      CiscoMailAlias     = "outshift-aether@cisco.com"
+      ResourceOwner      = "aether-admins"
+    }
+}
+
+module "alfred_role" {
+  source    = "./sso-roles-module"
+  role_name = "alfred"
+  tags = {
+      ApplicationName    = "outshift_ventures"
+      Component          = "alfred"
+      CiscoMailAlias     = "outshift-alfred@cisco.com"
+      ResourceOwner      = "alfred-admins"
+    }
+}
+
+module "aqua_role" {
+  source    = "./sso-roles-module"
+  role_name = "aqua"
+  tags = {
+      ApplicationName    = "outshift_ventures"
+      Component          = "aqua"
+      CiscoMailAlias     = "aqua-team@cisco.com"
+      ResourceOwner      = "outshift-aqua-dev"
+    }
+}
+
+module "argus_role" {
+  source    = "./sso-roles-module"
+  role_name = "a3po"
+  tags = {
+      ApplicationName    = "outshift_ventures"
+      Component          = "argus"
+      CiscoMailAlias     = "outshift-argus-dev@cisco.com"
+      ResourceOwner      = "outshift-argus-dev"
+    }
+}
+
+module "cascade_role" {
+  source    = "./sso-roles-module"
+  role_name = "a3po"
+  tags = {
+      ApplicationName    = "outshift_ventures"
+      Component          = "cascade"
+      CiscoMailAlias     = "chartsoo@cisco.com"
+      ResourceOwner      = "cil-splunk"
+    }
+}
+
+module "chef_role" {
+  source    = "./sso-roles-module"
+  role_name = "chef"
+  tags = {
+      ApplicationName    = "outshift_ventures"
+      Component          = "chef"
+      CiscoMailAlias     = "outshift-chef-team@cisco.com"
+      ResourceOwner      = "outshift-chef-team"
+    }
+}
+
+module "ioa_identity_role" {
+  source    = "./sso-roles-module"
+  role_name = "ioa-identity"
+  tags = {
+      ApplicationName    = "outshift_ventures"
+      Component          = "ioa_identity"
+      CiscoMailAlias     = "outshift-ioa-identity-team@cisco.com"
+      ResourceOwner      = "outshift-ioa-identity-team"
+    }
+}
+
+module "iridium_role" {
+  source    = "./sso-roles-module"
+  role_name = "iridium"
+  tags = {
+      ApplicationName    = "outshift_ventures"
+      Component          = "iridium"
+      CiscoMailAlias     = "outshift-iridium@cisco.com"
+      ResourceOwner      = "iridium-admins"
+    }
+}
+
+module "marvin_role" {
+  source    = "./sso-roles-module"
+  role_name = "marvin"
+  tags = {
+      ApplicationName    = "outshift_foundational_services"
+      Component          = "marvin"
+      CiscoMailAlias     = "marvin-outshift@cisco.com"
+      ResourceOwner      = "marvin-outshift"
+    }
+}
+
+module "ostinato_role" {
+  source    = "./sso-roles-module"
+  role_name = "ostinato"
+  tags = {
+      ApplicationName    = "outshift_foundational_services"
+      Component          = "ostinato"
+      CiscoMailAlias     = "ostinato-team-mailer@cisco.com"
+      Environment        = "NonProd"
+      ResourceOwner      = "ostinato-dev-team"
+    }
+}
+
+module "eti_website_role" {
+  source    = "./sso-roles-module"
+  role_name = "eti-website"
+  tags = {
+      ApplicationName    = "outshift_marketing"
+      Component          = "outshift_websites"
+      CiscoMailAlias     = "eti-websites@cisco.com"
+      ResourceOwner      = "eti-website-admins"
+    }
+}
+
+module "oval_role" {
+  source    = "./sso-roles-module"
+  role_name = "oval"
+  tags = {
+      ApplicationName    = "outshift_ventures"
+      Component          = "oval"
+      CiscoMailAlias     = "outshift-oval@cisco.com"
+      ResourceOwner      = "oval-admins"
+    }
+}
+
+module "phoenix_role" {
+  source    = "./sso-roles-module"
+  role_name = "phoenix"
+  tags = {
+      ApplicationName    = "outshift_ventures"
+      Component          = "phoenix"
+      CiscoMailAlias     = "outshift-phoenix@cisco.com"
+      ResourceOwner      = "outshift-phoenix-admins"
+    }
+}
+
+module "ragv2_role" {
+  source    = "./sso-roles-module"
+  role_name = "ragv2"
+  tags = {
+      ApplicationName    = "outshift_ventures"
+      Component          = "ragv2"
+      CiscoMailAlias     = "ragv2@cisco.com"
+      ResourceOwner      = "ragv2-team"
+    }
+}

--- a/aws_outshift-common-dev_iam_sso-roles_sso-roles-module_backend.tf
+++ b/aws_outshift-common-dev_iam_sso-roles_sso-roles-module_backend.tf
@@ -1,0 +1,9 @@
+terraform {
+  backend "s3" {
+    bucket         = "eticloud-tf-state-nonprod"
+    key            = "terraform-state/outshift-common-dev/iam/role/teams-sso-roles.tfstate"
+    region         = "us-east-2"
+    dynamodb_table = "eticloud-tf-locks"
+    encrypt        = true
+  }
+}

--- a/aws_outshift-common-dev_iam_sso-roles_sso-roles-module_data.tf
+++ b/aws_outshift-common-dev_iam_sso-roles_sso-roles-module_data.tf
@@ -1,0 +1,33 @@
+data "aws_caller_identity" "current" {}
+
+# IAM Policies
+data "aws_iam_policy_document" "assume_role_with_saml" {
+  statement {
+    effect = "Allow"
+
+    actions = ["sts:AssumeRoleWithSAML"]
+
+    principals {
+      type = "Federated"
+
+      identifiers = ["arn:aws:iam::${local.account_id}:saml-provider/cloudsso.cisco.com"]
+    }
+
+    condition {
+      test     = "StringEquals"
+      variable = "SAML:aud"
+      values   = ["https://signin.aws.amazon.com/saml"]
+    }
+  }
+
+  statement {
+    effect = "Allow"
+
+    actions = ["sts:AssumeRole"]
+    principals {
+      type = "AWS"
+
+      identifiers = ["arn:aws:iam::${local.account_id}:root"]
+    }
+  }
+}

--- a/aws_outshift-common-dev_iam_sso-roles_sso-roles-module_locals.tf
+++ b/aws_outshift-common-dev_iam_sso-roles_sso-roles-module_locals.tf
@@ -1,0 +1,4 @@
+locals {
+  account_id = data.aws_caller_identity.current.account_id
+  account_name = "outshift-common-dev"
+}

--- a/aws_outshift-common-dev_iam_sso-roles_sso-roles-module_locals.tf
+++ b/aws_outshift-common-dev_iam_sso-roles_sso-roles-module_locals.tf
@@ -1,4 +1,4 @@
 locals {
-  account_id = data.aws_caller_identity.current.account_id
+  account_id   = data.aws_caller_identity.current.account_id
   account_name = "outshift-common-dev"
 }

--- a/aws_outshift-common-dev_iam_sso-roles_sso-roles-module_main.tf
+++ b/aws_outshift-common-dev_iam_sso-roles_sso-roles-module_main.tf
@@ -9,5 +9,5 @@ resource "aws_iam_role" "this" {
 # Attach PowerUserAccess AWS Managed Policy 
 resource "aws_iam_role_policy_attachment" "power_user_access_policy_attachment" {
   role       = aws_iam_role.this.name
-  policy_arn = "arn:aws:iam::aws:policy/PowerUserAccess"
+  policy_arn = var.policy_arn
 }

--- a/aws_outshift-common-dev_iam_sso-roles_sso-roles-module_main.tf
+++ b/aws_outshift-common-dev_iam_sso-roles_sso-roles-module_main.tf
@@ -2,8 +2,8 @@
 resource "aws_iam_role" "this" {
   name                 = var.role_name
   max_session_duration = "3600"
-  assume_role_policy = data.aws_iam_policy_document.assume_role_with_saml.json
-  tags = var.tags
+  assume_role_policy   = data.aws_iam_policy_document.assume_role_with_saml.json
+  tags                 = var.tags
 }
 
 # Attach PowerUserAccess AWS Managed Policy 

--- a/aws_outshift-common-dev_iam_sso-roles_sso-roles-module_main.tf
+++ b/aws_outshift-common-dev_iam_sso-roles_sso-roles-module_main.tf
@@ -1,0 +1,13 @@
+# IAM role 
+resource "aws_iam_role" "this" {
+  name                 = var.role_name
+  max_session_duration = "3600"
+  assume_role_policy = data.aws_iam_policy_document.assume_role_with_saml.json
+  tags = var.tags
+}
+
+# Attach PowerUserAccess AWS Managed Policy 
+resource "aws_iam_role_policy_attachment" "power_user_access_policy_attachment" {
+  role       = aws_iam_role.this.name
+  policy_arn = "arn:aws:iam::aws:policy/PowerUserAccess"
+}

--- a/aws_outshift-common-dev_iam_sso-roles_sso-roles-module_provider.tf
+++ b/aws_outshift-common-dev_iam_sso-roles_sso-roles-module_provider.tf
@@ -1,0 +1,16 @@
+provider "vault" {
+  address   = "https://keeper.cisco.com" # DON'T CHANGE THIS VALUE
+  namespace = "eticloud"                 # DON'T CHANGE THIS VALUE
+}
+
+
+data "vault_generic_secret" "aws_infra_credential" {
+  path     = "secret/infra/aws/${local.account_name}/terraform_admin"
+}
+
+provider "aws" {
+  access_key  = data.vault_generic_secret.aws_infra_credential.data["AWS_ACCESS_KEY_ID"]     # DON'T CHANGE THIS VALUE
+  secret_key  = data.vault_generic_secret.aws_infra_credential.data["AWS_SECRET_ACCESS_KEY"] # DON'T CHANGE THIS VALUE
+  region      = "us-east-2" # Must match the region where the EKS cluster and VPC are created.
+  max_retries = 3
+}

--- a/aws_outshift-common-dev_iam_sso-roles_sso-roles-module_provider.tf
+++ b/aws_outshift-common-dev_iam_sso-roles_sso-roles-module_provider.tf
@@ -5,12 +5,12 @@ provider "vault" {
 
 
 data "vault_generic_secret" "aws_infra_credential" {
-  path     = "secret/infra/aws/${local.account_name}/terraform_admin"
+  path = "secret/infra/aws/${local.account_name}/terraform_admin"
 }
 
 provider "aws" {
   access_key  = data.vault_generic_secret.aws_infra_credential.data["AWS_ACCESS_KEY_ID"]     # DON'T CHANGE THIS VALUE
   secret_key  = data.vault_generic_secret.aws_infra_credential.data["AWS_SECRET_ACCESS_KEY"] # DON'T CHANGE THIS VALUE
-  region      = "us-east-2" # Must match the region where the EKS cluster and VPC are created.
+  region      = "us-east-2"                                                                  # Must match the region where the EKS cluster and VPC are created.
   max_retries = 3
 }

--- a/aws_outshift-common-dev_iam_sso-roles_sso-roles-module_variables.tf
+++ b/aws_outshift-common-dev_iam_sso-roles_sso-roles-module_variables.tf
@@ -1,6 +1,7 @@
 variable "role_name" {
   description = "Name of the IAM role"
   type        = string
+  default = "venture-role"
 }
 
 variable "tags" {

--- a/aws_outshift-common-dev_iam_sso-roles_sso-roles-module_variables.tf
+++ b/aws_outshift-common-dev_iam_sso-roles_sso-roles-module_variables.tf
@@ -7,4 +7,7 @@ variable "role_name" {
 variable "tags" {
   description = "Tags to apply to the IAM roles"
   type        = map(string)
+  default = {
+    ApplicationName = "outshift_ventures"
+  }
 }

--- a/aws_outshift-common-dev_iam_sso-roles_sso-roles-module_variables.tf
+++ b/aws_outshift-common-dev_iam_sso-roles_sso-roles-module_variables.tf
@@ -4,6 +4,11 @@ variable "role_name" {
   default = "venture-role"
 }
 
+variable "policy_arn" {
+  description = "ARN of the PowerUserAccess AWS managed policy to attach to the role"
+  type        = string
+  default = "arn:aws:iam::aws:policy/PowerUserAccess"
+}
 variable "tags" {
   description = "Tags to apply to the IAM roles"
   type        = map(string)

--- a/aws_outshift-common-dev_iam_sso-roles_sso-roles-module_variables.tf
+++ b/aws_outshift-common-dev_iam_sso-roles_sso-roles-module_variables.tf
@@ -1,0 +1,9 @@
+variable "role_name" {
+  description = "Name of the IAM role"
+  type        = string
+}
+
+variable "tags" {
+  description = "Tags to apply to the IAM roles"
+  type        = map(string)
+}

--- a/aws_outshift-common-dev_iam_sso-roles_sso-roles-module_versions.tf
+++ b/aws_outshift-common-dev_iam_sso-roles_sso-roles-module_versions.tf
@@ -1,0 +1,9 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+  required_version = ">= 1.5.5"
+}

--- a/aws_outshift-common-dev_iam_sso-roles_ventures-iam-roles_backend.tf
+++ b/aws_outshift-common-dev_iam_sso-roles_ventures-iam-roles_backend.tf
@@ -1,0 +1,9 @@
+terraform {
+  backend "s3" {
+    bucket         = "eticloud-tf-state-nonprod"
+    key            = "terraform-state/outshift-common-dev/iam/role/teams-sso-roles.tfstate"
+    region         = "us-east-2"
+    dynamodb_table = "eticloud-tf-locks"
+    encrypt        = true
+  }
+}

--- a/aws_outshift-common-dev_iam_sso-roles_ventures-iam-roles_provider.tf
+++ b/aws_outshift-common-dev_iam_sso-roles_ventures-iam-roles_provider.tf
@@ -1,0 +1,20 @@
+provider "vault" {
+  address   = "https://keeper.cisco.com" # DON'T CHANGE THIS VALUE
+  namespace = "eticloud"                 # DON'T CHANGE THIS VALUE
+}
+
+locals {
+  account_id   = data.aws_caller_identity.current.account_id
+  account_name = "outshift-common-dev"
+}
+
+data "vault_generic_secret" "aws_infra_credential" {
+  path = "secret/infra/aws/${local.account_name}/terraform_admin"
+}
+
+provider "aws" {
+  access_key  = data.vault_generic_secret.aws_infra_credential.data["AWS_ACCESS_KEY_ID"]     # DON'T CHANGE THIS VALUE
+  secret_key  = data.vault_generic_secret.aws_infra_credential.data["AWS_SECRET_ACCESS_KEY"] # DON'T CHANGE THIS VALUE
+  region      = "us-east-2"                                                                 
+  max_retries = 3
+}

--- a/aws_outshift-common-dev_iam_sso-roles_ventures-iam-roles_provider.tf
+++ b/aws_outshift-common-dev_iam_sso-roles_ventures-iam-roles_provider.tf
@@ -4,7 +4,6 @@ provider "vault" {
 }
 
 locals {
-  account_id   = data.aws_caller_identity.current.account_id
   account_name = "outshift-common-dev"
 }
 

--- a/aws_outshift-common-dev_iam_sso-roles_ventures-iam-roles_roles.tf
+++ b/aws_outshift-common-dev_iam_sso-roles_ventures-iam-roles_roles.tf
@@ -1,5 +1,5 @@
 module "a3po_role" {
-  source    = "../sso-roles-module"
+  source    = "../../../../../modules/sso-roles"
   role_name = "a3po"
   tags = {
     ApplicationName = "outshift_ventures"
@@ -10,7 +10,7 @@ module "a3po_role" {
 }
 
 module "action_engine_role" {
-  source    = "../sso-roles-module"
+  source    = "../../../../../modules/sso-roles"
   role_name = "action-engine"
   tags = {
     ApplicationName = "outshift_ventures"
@@ -21,7 +21,7 @@ module "action_engine_role" {
 }
 
 module "aether_role" {
-  source    = "../sso-roles-module"
+  source    = "../../../../../modules/sso-roles"
   role_name = "aether"
   tags = {
     ApplicationName = "outshift_ventures"
@@ -32,7 +32,7 @@ module "aether_role" {
 }
 
 module "alfred_role" {
-  source    = "../sso-roles-module"
+  source    = "../../../../../modules/sso-roles"
   role_name = "alfred"
   tags = {
     ApplicationName = "outshift_ventures"
@@ -43,7 +43,7 @@ module "alfred_role" {
 }
 
 module "aqua_role" {
-  source    = "../sso-roles-module"
+  source    = "../../../../../modules/sso-roles"
   role_name = "aqua"
   tags = {
     ApplicationName = "outshift_ventures"
@@ -54,8 +54,8 @@ module "aqua_role" {
 }
 
 module "argus_role" {
-  source    = "../sso-roles-module"
-  role_name = "a3po"
+  source    = "../../../../../modules/sso-roles"
+  role_name = "argus"
   tags = {
     ApplicationName = "outshift_ventures"
     Component       = "argus"
@@ -65,8 +65,8 @@ module "argus_role" {
 }
 
 module "cascade_role" {
-  source    = "../sso-roles-module"
-  role_name = "a3po"
+  source    = "../../../../../modules/sso-roles"
+  role_name = "cascade"
   tags = {
     ApplicationName = "outshift_ventures"
     Component       = "cascade"
@@ -76,7 +76,7 @@ module "cascade_role" {
 }
 
 module "chef_role" {
-  source    = "../sso-roles-module"
+  source    = "../../../../../modules/sso-roles"
   role_name = "chef"
   tags = {
     ApplicationName = "outshift_ventures"
@@ -87,7 +87,7 @@ module "chef_role" {
 }
 
 module "ioa_identity_role" {
-  source    = "../sso-roles-module"
+  source    = "../../../../../modules/sso-roles"
   role_name = "ioa-identity"
   tags = {
     ApplicationName = "outshift_ventures"
@@ -98,7 +98,7 @@ module "ioa_identity_role" {
 }
 
 module "iridium_role" {
-  source    = "../sso-roles-module"
+  source    = "../../../../../modules/sso-roles"
   role_name = "iridium"
   tags = {
     ApplicationName = "outshift_ventures"
@@ -109,7 +109,7 @@ module "iridium_role" {
 }
 
 module "marvin_role" {
-  source    = "../sso-roles-module"
+  source    = "../../../../../modules/sso-roles"
   role_name = "marvin"
   tags = {
     ApplicationName = "outshift_foundational_services"
@@ -120,7 +120,7 @@ module "marvin_role" {
 }
 
 module "ostinato_role" {
-  source    = "../sso-roles-module"
+  source    = "../../../../../modules/sso-roles"
   role_name = "ostinato"
   tags = {
     ApplicationName = "outshift_foundational_services"
@@ -132,7 +132,7 @@ module "ostinato_role" {
 }
 
 module "eti_website_role" {
-  source    = "../sso-roles-module"
+  source    = "../../../../../modules/sso-roles"
   role_name = "eti-website"
   tags = {
     ApplicationName = "outshift_marketing"
@@ -143,7 +143,7 @@ module "eti_website_role" {
 }
 
 module "oval_role" {
-  source    = "../sso-roles-module"
+  source    = "../../../../../modules/sso-roles"
   role_name = "oval"
   tags = {
     ApplicationName = "outshift_ventures"
@@ -154,7 +154,7 @@ module "oval_role" {
 }
 
 module "phoenix_role" {
-  source    = "../sso-roles-module"
+  source    = "../../../../../modules/sso-roles"
   role_name = "phoenix"
   tags = {
     ApplicationName = "outshift_ventures"
@@ -165,7 +165,7 @@ module "phoenix_role" {
 }
 
 module "ragv2_role" {
-  source    = "../sso-roles-module"
+  source    = "../../../../../modules/sso-roles"
   role_name = "ragv2"
   tags = {
     ApplicationName = "outshift_ventures"

--- a/aws_outshift-common-dev_iam_sso-roles_ventures-iam-roles_roles.tf
+++ b/aws_outshift-common-dev_iam_sso-roles_ventures-iam-roles_roles.tf
@@ -1,0 +1,176 @@
+module "a3po_role" {
+  source    = "../sso-roles-module"
+  role_name = "a3po"
+  tags = {
+    ApplicationName = "outshift_ventures"
+    Component       = "a3po"
+    CiscoMailAlias  = "outshift-a3po@cisco.com"
+    ResourceOwner   = "a3po-admins"
+  }
+}
+
+module "action_engine_role" {
+  source    = "../sso-roles-module"
+  role_name = "action-engine"
+  tags = {
+    ApplicationName = "outshift_ventures"
+    Component       = "action-engine"
+    CiscoMailAlias  = "action-engine-team@cisco.com"
+    ResourceOwner   = "action-engine-team"
+  }
+}
+
+module "aether_role" {
+  source    = "../sso-roles-module"
+  role_name = "aether"
+  tags = {
+    ApplicationName = "outshift_ventures"
+    Component       = "aether"
+    CiscoMailAlias  = "outshift-aether@cisco.com"
+    ResourceOwner   = "aether-admins"
+  }
+}
+
+module "alfred_role" {
+  source    = "../sso-roles-module"
+  role_name = "alfred"
+  tags = {
+    ApplicationName = "outshift_ventures"
+    Component       = "alfred"
+    CiscoMailAlias  = "outshift-alfred@cisco.com"
+    ResourceOwner   = "alfred-admins"
+  }
+}
+
+module "aqua_role" {
+  source    = "../sso-roles-module"
+  role_name = "aqua"
+  tags = {
+    ApplicationName = "outshift_ventures"
+    Component       = "aqua"
+    CiscoMailAlias  = "aqua-team@cisco.com"
+    ResourceOwner   = "outshift-aqua-dev"
+  }
+}
+
+module "argus_role" {
+  source    = "../sso-roles-module"
+  role_name = "a3po"
+  tags = {
+    ApplicationName = "outshift_ventures"
+    Component       = "argus"
+    CiscoMailAlias  = "outshift-argus-dev@cisco.com"
+    ResourceOwner   = "outshift-argus-dev"
+  }
+}
+
+module "cascade_role" {
+  source    = "../sso-roles-module"
+  role_name = "a3po"
+  tags = {
+    ApplicationName = "outshift_ventures"
+    Component       = "cascade"
+    CiscoMailAlias  = "chartsoo@cisco.com"
+    ResourceOwner   = "cil-splunk"
+  }
+}
+
+module "chef_role" {
+  source    = "../sso-roles-module"
+  role_name = "chef"
+  tags = {
+    ApplicationName = "outshift_ventures"
+    Component       = "chef"
+    CiscoMailAlias  = "outshift-chef-team@cisco.com"
+    ResourceOwner   = "outshift-chef-team"
+  }
+}
+
+module "ioa_identity_role" {
+  source    = "../sso-roles-module"
+  role_name = "ioa-identity"
+  tags = {
+    ApplicationName = "outshift_ventures"
+    Component       = "ioa_identity"
+    CiscoMailAlias  = "outshift-ioa-identity-team@cisco.com"
+    ResourceOwner   = "outshift-ioa-identity-team"
+  }
+}
+
+module "iridium_role" {
+  source    = "../sso-roles-module"
+  role_name = "iridium"
+  tags = {
+    ApplicationName = "outshift_ventures"
+    Component       = "iridium"
+    CiscoMailAlias  = "outshift-iridium@cisco.com"
+    ResourceOwner   = "iridium-admins"
+  }
+}
+
+module "marvin_role" {
+  source    = "../sso-roles-module"
+  role_name = "marvin"
+  tags = {
+    ApplicationName = "outshift_foundational_services"
+    Component       = "marvin"
+    CiscoMailAlias  = "marvin-outshift@cisco.com"
+    ResourceOwner   = "marvin-outshift"
+  }
+}
+
+module "ostinato_role" {
+  source    = "../sso-roles-module"
+  role_name = "ostinato"
+  tags = {
+    ApplicationName = "outshift_foundational_services"
+    Component       = "ostinato"
+    CiscoMailAlias  = "ostinato-team-mailer@cisco.com"
+    Environment     = "NonProd"
+    ResourceOwner   = "ostinato-dev-team"
+  }
+}
+
+module "eti_website_role" {
+  source    = "../sso-roles-module"
+  role_name = "eti-website"
+  tags = {
+    ApplicationName = "outshift_marketing"
+    Component       = "outshift_websites"
+    CiscoMailAlias  = "eti-websites@cisco.com"
+    ResourceOwner   = "eti-website-admins"
+  }
+}
+
+module "oval_role" {
+  source    = "../sso-roles-module"
+  role_name = "oval"
+  tags = {
+    ApplicationName = "outshift_ventures"
+    Component       = "oval"
+    CiscoMailAlias  = "outshift-oval@cisco.com"
+    ResourceOwner   = "oval-admins"
+  }
+}
+
+module "phoenix_role" {
+  source    = "../sso-roles-module"
+  role_name = "phoenix"
+  tags = {
+    ApplicationName = "outshift_ventures"
+    Component       = "phoenix"
+    CiscoMailAlias  = "outshift-phoenix@cisco.com"
+    ResourceOwner   = "outshift-phoenix-admins"
+  }
+}
+
+module "ragv2_role" {
+  source    = "../sso-roles-module"
+  role_name = "ragv2"
+  tags = {
+    ApplicationName = "outshift_ventures"
+    Component       = "ragv2"
+    CiscoMailAlias  = "ragv2@cisco.com"
+    ResourceOwner   = "ragv2-team"
+  }
+}

--- a/aws_outshift-common-dev_iam_sso-roles_versions.tf
+++ b/aws_outshift-common-dev_iam_sso-roles_versions.tf
@@ -2,8 +2,8 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 4.0"
+      version = "~> 5.0"
     }
   }
-  required_version = ">= 1.3.6"
+  required_version = ">= 1.5.5"
 }

--- a/aws_outshift-common-dev_us-east-2_eks_comn-dev-use2-1_eso-phoenix.tf
+++ b/aws_outshift-common-dev_us-east-2_eks_comn-dev-use2-1_eso-phoenix.tf
@@ -1,0 +1,43 @@
+locals {
+  policy_phoenix = <<-EOT
+  # K8s External Secrets Vault Policy
+
+  # Secret paths
+  path "secret/data/dev/*" {
+    capabilities = ["read", "list"]
+  }
+  path "secret/dev/*" {
+    capabilities = ["read", "list"]
+  }
+
+  # Common secrets
+  path "secret/data/common/*" {
+    capabilities = ["read", "list"]
+  }
+  path "secret/common/*" {
+    capabilities = ["read", "list"]
+  }
+  EOT
+}
+
+provider "vault" {
+  alias     = "phoenix"
+  address   = "https://keeper.cisco.com"
+  namespace = "eticloud/apps/phoenix"
+}
+
+# cluster resources for external-secrets
+module "eso_phoenix" {
+  depends_on = [ module.eks_all_in_one ]
+  cluster_ca        = base64decode(data.vault_generic_secret.cluster_certificate.data["b64certificate"])
+  cluster_endpoint  = data.vault_generic_secret.cluster_endpoint.data["cluster_endpoint"]
+  cluster_name      = local.name
+  environment       = local.environment
+  policy            = local.policy_phoenix
+  source            = "git::https://github.com/cisco-eti/sre-tf-module-eso-access.git?ref=2.0.7"
+  vault_namespace   = "eticloud/apps/phoenix"
+  
+  providers = {
+    vault      = vault.phoenix
+  }
+}

--- a/modules_sso-roles_data.tf
+++ b/modules_sso-roles_data.tf
@@ -1,0 +1,33 @@
+data "aws_caller_identity" "current" {}
+
+# IAM Policies
+data "aws_iam_policy_document" "assume_role_with_saml" {
+  statement {
+    effect = "Allow"
+
+    actions = ["sts:AssumeRoleWithSAML"]
+
+    principals {
+      type = "Federated"
+
+      identifiers = ["arn:aws:iam::${local.account_id}:saml-provider/cloudsso.cisco.com"]
+    }
+
+    condition {
+      test     = "StringEquals"
+      variable = "SAML:aud"
+      values   = ["https://signin.aws.amazon.com/saml"]
+    }
+  }
+
+  statement {
+    effect = "Allow"
+
+    actions = ["sts:AssumeRole"]
+    principals {
+      type = "AWS"
+
+      identifiers = ["arn:aws:iam::${local.account_id}:root"]
+    }
+  }
+}

--- a/modules_sso-roles_locals.tf
+++ b/modules_sso-roles_locals.tf
@@ -1,0 +1,3 @@
+locals {
+  account_id   = data.aws_caller_identity.current.account_id
+}

--- a/modules_sso-roles_main.tf
+++ b/modules_sso-roles_main.tf
@@ -1,0 +1,13 @@
+# IAM role 
+resource "aws_iam_role" "this" {
+  name                 = var.role_name
+  max_session_duration = "3600"
+  assume_role_policy   = data.aws_iam_policy_document.assume_role_with_saml.json
+  tags                 = var.tags
+}
+
+# Attach PowerUserAccess AWS Managed Policy 
+resource "aws_iam_role_policy_attachment" "power_user_access_policy_attachment" {
+  role       = aws_iam_role.this.name
+  policy_arn = var.policy_arn
+}

--- a/modules_sso-roles_variables.tf
+++ b/modules_sso-roles_variables.tf
@@ -1,0 +1,14 @@
+variable "role_name" {
+  description = "Name of the IAM role"
+  type        = string
+}
+
+variable "policy_arn" {
+  description = "ARN of the PowerUserAccess AWS managed policy to attach to the role"
+  type        = string
+  default = "arn:aws:iam::aws:policy/PowerUserAccess"
+}
+variable "tags" {
+  description = "Tags to apply to the IAM roles"
+  type        = map(string)
+}

--- a/modules_sso-roles_versions.tf
+++ b/modules_sso-roles_versions.tf
@@ -1,0 +1,9 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+  required_version = ">= 1.5.5"
+}


### PR DESCRIPTION
### Description/Justification
- creates a separate IAM role for each team from a local module
- Attaches the AWS Managed `PowerUserAccess` policy to each role to ensure that they have the same permissions as the DevOps role that the teams uses to login
- Each role permissions can be customized by modifying its policy in Terraform 

### Additional details

- [x] `terraform fmt` was applied
- [ ] All atlantis plans can be applied
- [ ] (For reviewers) I have verified the resource changes
