### PR TITLE
[eso] fix: create dedicated policy for dragonfly

### DIFF
--- a/aws_dragonfly-prod_eu-central-1_eks_dragonfly-prod-euc1-1_eso.tf
+++ b/aws_dragonfly-prod_eu-central-1_eks_dragonfly-prod-euc1-1_eso.tf
@@ -35,5 +35,5 @@ module "eso_eticloud" {
   vault_namespace = "eticloud"
   kubernetes_host = data.aws_eks_cluster.cluster.endpoint
   kubernetes_ca   = base64decode(data.vault_generic_secret.cluster_certificate.data["b64certificate"])
-  policies        = ["external-secrets-prod"]
+  policies        = ["external-secrets-prod-dragonfly"]
 }


### PR DESCRIPTION
instead of using the previous shared `prod` one.
https://platform-docs.eticloud.io/services/kubernetes/baseapps/external-secrets/configure-external-secrets/
